### PR TITLE
INFRA-1541 - change versioning strategy according to design pr #355

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,8 @@
-@Library('corda-shared-build-pipeline-steps@corda5') _
+@Library('corda-shared-build-pipeline-steps@5.0') _
 
 cordaPipeline(
     runIntegrationTests: false,
-    nexusAppId: 'net.corda-api-5.0'
+    nexusAppId: 'net.corda-api-5.0',
+    // TODO: add flow worker dependency once change is made there.
+    // dependentJobsNames: ['/Corda5/flow-worker-version-compatibility/release%2FENT%2F5.0']
     )

--- a/build.gradle
+++ b/build.gradle
@@ -99,11 +99,12 @@ if (JavaVersion.current() != javaVersion) {
 }
 logger.quiet("SDK version: {}", JavaVersion.current())
 logger.quiet("JAVA HOME {}", System.getProperty("java.home"))
+def cordaVersion = "$cordaProductVersion.$cordaApiRevision"
 if (System.getenv("RELEASE_VERSION")?.trim()) {
     version = System.getenv("RELEASE_VERSION")
 } else {
-    def versionSuffix = System.getenv('VERSION_SUFFIX') ?: "0-SNAPSHOT"
-    version = "$cordaVersion-$versionSuffix"
+    def versionSuffix = System.getenv('VERSION_SUFFIX') ?: "-SNAPSHOT"
+    version = "$cordaVersion$versionSuffix"
 }
 
 logger.quiet("Corda release version: {}", version)

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,8 +2,14 @@
 # because some versions here need to be matched by app authors in
 # their own projects. So don't get fancy with syntax!
 
+# Versioning
+cordaProductVersion = 5.0.0
+# NOTE: update this each time this module contains a breaking change
+## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
+##   a per module property in which case module versions can change independently.
+cordaApiRevision = 0
+
 # Main
-cordaVersion = 5.0.0
 kotlinVersion = 1.4.21
 
 # License


### PR DESCRIPTION
This will change the version format according to https://github.com/corda/platform-eng-design/pull/355

Once this is merged in, a change will need to be made to the flow worker repo to use dynamic versioning, and then the build dependency can be completed.
