### PR TITLE
CORE-2135: Create a Gradle platform describing Corda API.

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'com.r3.internal.gradle.plugins.r3Publish'
+    id 'org.jetbrains.kotlin.jvm'
     id 'biz.aQute.bnd.builder'
 }
 
@@ -9,6 +10,7 @@ dependencies {
     api "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlinVersion"
     api "net.corda.kotlin:kotlin-stdlib-jdk8-osgi:$kotlinVersion"
 
+    api platform(project(':corda-platform'))
     api project(":base")
     api project(":serialization")
 

--- a/base/build.gradle
+++ b/base/build.gradle
@@ -1,11 +1,13 @@
 plugins {
     id 'com.r3.internal.gradle.plugins.r3Publish'
+    id 'org.jetbrains.kotlin.jvm'
     id 'biz.aQute.bnd.builder'
 }
 
 description 'Corda Base'
 
 dependencies {
+    implementation platform(project(':corda-platform'))
     implementation "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlinVersion"
     implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi:$kotlinVersion"
     // Concluded this is the one acceptable dependency in addition to kotlin.

--- a/build.gradle
+++ b/build.gradle
@@ -51,41 +51,6 @@ void configureKotlinForOSGi(Configuration configuration) {
 }
 
 def releaseType = System.getenv('RELEASE_TYPE') ?: "SNAPSHOT"
-
-allprojects {
-    repositories {
-        def cordaUseCache = System.getenv("CORDA_USE_CACHE")
-        if (cordaUseCache != null) {
-            maven {
-                url = "$artifactoryContextUrl/$cordaUseCache"
-                name = "R3 Maven remote repositories"
-                authentication {
-                    basic(BasicAuthentication)
-                }
-                credentials {
-                    username = System.getenv('CORDA_ARTIFACTORY_USERNAME')
-                    password = System.getenv('CORDA_ARTIFACTORY_PASSWORD')
-                }
-            }
-        } else {
-            mavenLocal()
-            mavenCentral()
-
-            maven {
-                url = "$artifactoryContextUrl/corda-dependencies"
-            }
-
-            maven {
-                url = "https://repo.gradle.org/gradle/libs-releases-local/"
-            }
-
-            maven {
-                url = "$artifactoryContextUrl/${System.getenv('CORDA_CONSUME_REPOSITORY_KEY') ?: 'corda-os-maven'}"
-            }
-        }
-    }
-}
-
 def javaVersion = VERSION_11
 
 logger.quiet("********************** CORDA BUILD **********************")
@@ -117,219 +82,219 @@ subprojects {
     version rootProject.version
     group 'net.corda'
 
-    apply plugin: 'kotlin'
-    apply plugin: DetektPlugin
-    apply plugin: 'jacoco'
-    apply plugin: 'org.jetbrains.dokka'
+    pluginManager.withPlugin('org.jetbrains.kotlin.jvm') {
+        apply plugin: DetektPlugin
+        apply plugin: 'jacoco'
+        apply plugin: 'org.jetbrains.dokka'
 
-    // NOTE: question whether it is "ok" to force dependencies on all modules like this
-    //  thinking is that for the test dependencies it's ok as it'll keep things consistent.
-    //  we can add exclusions, or review this if necessary.
-    dependencies {
-        // Test libraries -> keep consistent across modules
-        testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlinVersion"
-        testImplementation "org.mockito:mockito-core:$mockitoVersion"
-        testImplementation("com.nhaarman:mockito-kotlin:$mockitoKotlinVersion") {
-            // Excluding mockito-core and adding it implicitly above. This is done to allow the use of the latest version of mockito.
-            exclude group: 'mockito-core'
+        // NOTE: question whether it is "ok" to force dependencies on all modules like this
+        //  thinking is that for the test dependencies it's ok as it'll keep things consistent.
+        //  we can add exclusions, or review this if necessary.
+        dependencies {
+            // Test libraries -> keep consistent across modules
+            testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlinVersion"
+            testImplementation "org.mockito:mockito-core:$mockitoVersion"
+            testImplementation("com.nhaarman:mockito-kotlin:$mockitoKotlinVersion") {
+                // Excluding mockito-core and adding it implicitly above. This is done to allow the use of the latest version of mockito.
+                exclude group: 'mockito-core'
+            }
+
+            testImplementation "org.junit.jupiter:junit-jupiter:$junitVersion"
+
+            // Test runtime libraries -> also keep consistent
+            testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junitVersion"
+
+            detektPlugins "io.gitlab.arturbosch.detekt:detekt-formatting:$detektPluginVersion"
         }
 
-        testImplementation "org.junit.jupiter:junit-jupiter:$junitVersion"
+        java {
+            sourceCompatibility = javaVersion
+            targetCompatibility = javaVersion
+        }
 
-        // Test runtime libraries -> also keep consistent
-        testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junitVersion"
-
-        detektPlugins "io.gitlab.arturbosch.detekt:detekt-formatting:$detektPluginVersion"
-    }
-
-    java {
-        sourceCompatibility = javaVersion
-        targetCompatibility = javaVersion
-    }
-
-    // Making all persistence entity open and with an empty constructor to allow Hibernate to work.
-    apply plugin: 'kotlin-allopen'
-    allOpen {
-        annotations(
+        // Making all persistence entity open and with an empty constructor to allow Hibernate to work.
+        apply plugin: 'kotlin-allopen'
+        allOpen {
+            annotations(
                 "javax.persistence.Entity",
                 "javax.persistence.Embeddable",
                 "javax.persistence.MappedSuperclass"
-        )
-    }
-    apply plugin: 'kotlin-noarg'
-    noArg {
-        annotations(
+            )
+        }
+        apply plugin: 'kotlin-noarg'
+        noArg {
+            annotations(
                 "javax.persistence.Entity",
                 "javax.persistence.Embeddable",
                 "javax.persistence.MappedSuperclass"
-        )
-    }
-
-    // This block should be remove when the junit 4 tests are removed
-    sourceSets {
-        junit4Test {
-            kotlin {
-                srcDirs += file("$projectDir/src/junit4Test/kotlin")
-            }
-            java {
-                srcDirs += file("$projectDir/src/junit4Test/java")
-            }
-            resources {
-                srcDirs += file("$projectDir/src/junit4Test/resources")
-            }
-            compileClasspath += main.output + test.output
-            runtimeClasspath += main.output + test.output
+            )
         }
-    }
 
-    dependencies {
-        // TODO: remove vintage engine when existing tests labelled "junit4Test" and we don't have a dependency on 4 anymore
-        junit4TestRuntimeOnly "org.junit.vintage:junit-vintage-engine:$junitVersion"
-    }
+        // This block should be remove when the junit 4 tests are removed
+        sourceSets {
+            junit4Test {
+                kotlin {
+                    srcDirs += file("$projectDir/src/junit4Test/kotlin")
+                }
+                java {
+                    srcDirs += file("$projectDir/src/junit4Test/java")
+                }
+                resources {
+                    srcDirs += file("$projectDir/src/junit4Test/resources")
+                }
+                compileClasspath += main.output + test.output
+                runtimeClasspath += main.output + test.output
+            }
+        }
 
-    kotlin {
-        target {
-            java
-            compilations.junit4Test {
-                associateWith compilations.main
-                associateWith compilations.test
+        dependencies {
+            // TODO: remove vintage engine when existing tests labelled "junit4Test" and we don't have a dependency on 4 anymore
+            junit4TestRuntimeOnly "org.junit.vintage:junit-vintage-engine:$junitVersion"
+        }
 
-                configurations {
-                    junit4TestApi.extendsFrom testApi
-                    junit4TestImplementation.extendsFrom testImplementation
-                    junit4TestRuntimeOnly.extendsFrom testRuntimeOnly
+        kotlin {
+            target {
+                java
+                compilations.junit4Test {
+                    associateWith compilations.main
+                    associateWith compilations.test
 
-                    [ junit4TestCompileClasspath, junit4TestRuntimeClasspath ].forEach { cfg ->
-                        configureKotlinForOSGi(cfg)
+                    configurations {
+                        junit4TestApi.extendsFrom testApi
+                        junit4TestImplementation.extendsFrom testImplementation
+                        junit4TestRuntimeOnly.extendsFrom testRuntimeOnly
+
+                        [ junit4TestCompileClasspath, junit4TestRuntimeClasspath ].forEach { cfg ->
+                            configureKotlinForOSGi(cfg)
+                        }
                     }
                 }
             }
         }
-    }
 
-    tasks.register('junit4Test', Test) {
-        description = 'Runs junit4 tests'
-        group = 'verification'
+        tasks.register('junit4Test', Test) {
+            description = 'Runs junit4 tests'
+            group = 'verification'
 
-        testClassesDirs = project.sourceSets['junit4Test'].output.classesDirs
-        classpath = project.sourceSets['junit4Test'].runtimeClasspath
-        shouldRunAfter tasks.named('test')
-    }
+            testClassesDirs = project.sourceSets['junit4Test'].output.classesDirs
+            classpath = project.sourceSets['junit4Test'].runtimeClasspath
+            shouldRunAfter tasks.named('test')
+        }
 
-    tasks.named('test') {
-        dependsOn tasks.named('junit4Test')
-    }
+        tasks.named('test') {
+            dependsOn tasks.named('junit4Test')
+        }
 
 
-    configurations {
-        all {
-            resolutionStrategy {
-                dependencySubstitution {
-                    // Replace any Logback SLF4J back-end with Log4J2.
-                    substitute module('ch.qos.logback:logback-classic') using module("org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion")
+        configurations {
+            all {
+                resolutionStrategy {
+                    dependencySubstitution {
+                        // Replace any Logback SLF4J back-end with Log4J2.
+                        substitute module('ch.qos.logback:logback-classic') using module("org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion")
+                    }
+                }
+            }
+
+            [ compileClasspath, testCompileClasspath, runtimeClasspath, testRuntimeClasspath ].forEach { cfg ->
+                configureKotlinForOSGi(cfg)
+            }
+        }
+
+        tasks.withType(KotlinCompile).configureEach {
+            kotlinOptions {
+                allWarningsAsErrors = true
+                languageVersion = '1.4'
+                apiVersion = '1.4'
+                verbose = true
+                jvmTarget = javaVersion
+                freeCompilerArgs += [
+                    "-Xjvm-default=all",
+                    // Prevent Kotlin from warning about kotlin.* classes inside the OSGi bundle.
+                    "-Xskip-runtime-version-check",
+                    "-java-parameters"
+                ]
+            }
+        }
+
+        tasks.withType(JavaCompile).configureEach {
+            def compilerArgs = options.compilerArgs
+            compilerArgs << '-parameters'
+
+            options.encoding = 'UTF-8'
+        }
+
+        // TODO: does this really need to apply to all modules or can this be moved to the modules that need it only?
+        tasks.named('compileTestJava', JavaCompile) {
+            def compilerArgs = options.compilerArgs
+            compilerArgs << '--add-exports'
+            compilerArgs << 'java.base/sun.security.x509=ALL-UNNAMED'
+            compilerArgs << '--add-exports'
+            compilerArgs << 'java.base/sun.security.util=ALL-UNNAMED'
+        }
+
+        // TODO: as above, this may not apply to all modules, so maybe should be moved out
+        tasks.withType(Jar).matching { it.name != 'cpk' }.configureEach {
+            manifest {
+                attributes("Corda-Release-Version": archiveVersion.get())
+                attributes("Corda-Revision": revision)
+                attributes("Automatic-Module-Name": "net.corda.${project.name.replace('-', '.')}")
+                // NOTE: this needs to be reverted to a URL with the version once the URL structure has been defined.
+//                attributes("Corda-Docs-Link": "https://docs.corda.net/docs/corda-os/$cordaVersion")
+                attributes("Corda-Docs-Link": "https://docs.r3.com/")
+            }
+        }
+
+        // Added to support junit5 tests
+        tasks.withType(Test).configureEach {
+            useJUnitPlatform()
+        }
+
+        tasks.register('compileAll') { task ->
+            description = "Compiles all the Kotlin and Java classes, including all of the test classes."
+            group = "verification"
+
+            task.dependsOn tasks.withType(AbstractCompile)
+        }
+
+        detekt {
+            baseline = file("$projectDir/detekt-baseline.xml")
+            config.setFrom(files("$rootProjectDir/detekt-config.yml"))
+            parallel = true
+            reports {
+                xml {
+                    enabled = true
+                    destination = file("$projectDir/build/detekt-report.xml")
+                }
+                html {
+                    enabled = false
+                }
+                txt {
+                    enabled = false
                 }
             }
         }
 
-        [ compileClasspath, testCompileClasspath, runtimeClasspath, testRuntimeClasspath ].forEach { cfg ->
-            configureKotlinForOSGi(cfg)
-        }
-    }
+        tasks.named('jacocoTestReport') {
+            def jacocoExecutionDataFiles = fileTree(buildDir).include("/jacoco/*.exec")
+            executionData.setFrom(jacocoExecutionDataFiles)
 
-    tasks.withType(KotlinCompile).configureEach {
-        kotlinOptions {
-            allWarningsAsErrors = true
-            languageVersion = '1.4'
-            apiVersion = '1.4'
-            verbose = true
-            jvmTarget = javaVersion
-            freeCompilerArgs += [
-                "-Xjvm-default=all",
-                // Prevent Kotlin from warning about kotlin.* classes inside the OSGi bundle.
-                "-Xskip-runtime-version-check",
-                "-java-parameters"
-            ]
-        }
-    }
+            dependsOn tasks.named('test') // tests are required to run before generating the report
 
-    tasks.withType(JavaCompile).configureEach {
-        def compilerArgs = options.compilerArgs
-        compilerArgs << '-parameters'
-
-        options.encoding = 'UTF-8'
-    }
-
-    // TODO: does this really need to apply to all modules or can this be moved to the modules that need it only?
-    tasks.named('compileTestJava', JavaCompile) {
-        def compilerArgs = options.compilerArgs
-        compilerArgs << '--add-exports'
-        compilerArgs << 'java.base/sun.security.x509=ALL-UNNAMED'
-        compilerArgs << '--add-exports'
-        compilerArgs << 'java.base/sun.security.util=ALL-UNNAMED'
-    }
-
-    // TODO: as above, this may not apply to all modules, so maybe should be moved out
-    tasks.withType(Jar).matching { it.name != 'cpk' }.configureEach {
-        manifest {
-            attributes("Corda-Release-Version": archiveVersion.get())
-            attributes("Corda-Revision": revision)
-            attributes("Automatic-Module-Name": "net.corda.${project.name.replace('-', '.')}")
-            // NOTE: this needs to be reverted to a URL with the version once the URL structure has been defined.
-//            attributes("Corda-Docs-Link": "https://docs.corda.net/docs/corda-os/$cordaVersion")
-            attributes("Corda-Docs-Link": "https://docs.r3.com/")
-        }
-    }
-
-    // Added to support junit5 tests
-    tasks.withType(Test).configureEach {
-        useJUnitPlatform()
-    }
-
-    tasks.register('compileAll') { task ->
-        description = "Compiles all the Kotlin and Java classes, including all of the test classes."
-        group = "verification"
-
-        task.dependsOn tasks.withType(AbstractCompile)
-    }
-
-    detekt {
-        baseline = file("$projectDir/detekt-baseline.xml")
-        config.setFrom(files("$rootProjectDir/detekt-config.yml"))
-        parallel = true
-        reports {
-            xml {
-                enabled = true
-                destination = file("$projectDir/build/detekt-report.xml")
-            }
-            html {
-                enabled = false
-            }
-            txt {
-                enabled = false
+            reports {
+                xml.enabled true
+                html.enabled true
             }
         }
-    }
 
-    tasks.named('jacocoTestReport') {
-        def jacocoExecutionDataFiles = fileTree(buildDir).include("/jacoco/*.exec")
-        executionData.setFrom(jacocoExecutionDataFiles)
+        tasks.register('javadocJar', Jar) {
+            description = 'Create JavaDoc Jar from dokka docs'
+            group = 'documentation'
 
-        dependsOn tasks.named('test') // tests are required to run before generating the report
-
-        reports {
-            xml.enabled true
-            html.enabled true
+            dependsOn(dokkaHtml)
+            archiveBaseName = jar.archiveBaseName
+            archiveClassifier.set("javadoc")
+            from(dokkaHtml.outputDirectory)
         }
     }
-
-    tasks.register('javadocJar', Jar) {
-        description = 'Create JavaDoc Jar from dokka docs'
-        group = 'documentation'
-
-        dependsOn(dokkaHtml)
-        archiveBaseName = jar.archiveBaseName
-        archiveClassifier.set("javadoc")
-        from(dokkaHtml.outputDirectory)
-    }
-
 }

--- a/corda-platform/build.gradle
+++ b/corda-platform/build.gradle
@@ -1,0 +1,48 @@
+plugins {
+    id 'java-platform'
+    id 'maven-publish'
+    id 'com.jfrog.artifactory'
+}
+
+dependencies {
+    constraints {
+        api project(':application')
+        api project(':base')
+        api project(':crypto')
+        api project(':data:avro-schema')
+        api project(':data:topic-schema')
+        api project(':serialization')
+    }
+}
+
+publishing {
+    publications {
+        platformConfiguration(MavenPublication) {
+            from components.javaPlatform
+
+            pom {
+                name = 'Corda API Platform'
+
+                licenses {
+                    license {
+                        name = licenseName
+                        url = licenseUrl
+                        distribution = 'repo'
+                    }
+                }
+
+                developers {
+                    developer {
+                        id = 'R3'
+                        name = 'R3'
+                        email = 'dev@corda.net'
+                    }
+                }
+            }
+        }
+    }
+}
+
+artifactoryPublish {
+    publications('platformConfiguration')
+}

--- a/crypto/build.gradle
+++ b/crypto/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'com.r3.internal.gradle.plugins.r3Publish'
+    id 'org.jetbrains.kotlin.jvm'
     id 'biz.aQute.bnd.builder'
 }
 
@@ -16,6 +17,7 @@ dependencies {
     implementation "org.bouncycastle:bcpkix-jdk15on:$bouncycastleVersion"
     implementation "net.i2p.crypto:eddsa:$eddsaVersion"
 
+    api platform(project(':corda-platform'))
     api project(':base')
 
     testImplementation "org.assertj:assertj-core:$assertjVersion"

--- a/data/avro-schema/build.gradle
+++ b/data/avro-schema/build.gradle
@@ -3,6 +3,7 @@ import groovy.io.FileType
 import groovy.text.SimpleTemplateEngine
 
 plugins {
+    id 'org.jetbrains.kotlin.jvm'
     id 'com.r3.internal.gradle.plugins.r3Publish'
     id "com.github.davidmc24.gradle.plugin.avro-base"
     id 'biz.aQute.bnd.builder'
@@ -10,6 +11,7 @@ plugins {
 
 dependencies {
     api "org.apache.avro:avro:$avroVersion"
+    implementation platform(project(':corda-platform'))
     implementation project(":base")
 
     compileOnly "org.osgi:osgi.annotation:$osgiVersion"
@@ -120,7 +122,6 @@ tasks.named('processResources', ProcessResources) {
  * all the classes from this bundle.
  */
 tasks.named('jar', Jar) {
-    archiveBaseName = project.name
     bnd """
 Bundle-Name: \${project.description}
 Bundle-SymbolicName: \${project.group}.\${project.name}

--- a/data/topic-schema/build.gradle
+++ b/data/topic-schema/build.gradle
@@ -1,5 +1,10 @@
 plugins {
+    id 'org.jetbrains.kotlin.jvm'
     id 'com.r3.internal.gradle.plugins.r3Publish'
 }
 
 description 'Definition of Topics'
+
+dependencies {
+    implementation platform(project(':corda-platform'))
+}

--- a/serialization/build.gradle
+++ b/serialization/build.gradle
@@ -1,11 +1,13 @@
 plugins {
     id 'com.r3.internal.gradle.plugins.r3Publish'
+    id 'org.jetbrains.kotlin.jvm'
     id 'biz.aQute.bnd.builder'
 }
 
 description 'Corda Serialization'
 
 dependencies {
+    api platform(project(':corda-platform'))
     api project(":base")
 
     implementation "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlinVersion"

--- a/settings.gradle
+++ b/settings.gradle
@@ -15,12 +15,6 @@ pluginManagement {
             }
         } else {
             maven {
-                url "$artifactoryContextUrl/corda-dev"
-                content {
-                    includeGroupByRegex 'net\\.corda\\.plugins(\\..*)?'
-                }
-            }
-            maven {
                 url "$artifactoryContextUrl/corda-releases"
                 content {
                     includeGroupByRegex 'net\\.corda\\.plugins(\\..*)?'
@@ -32,8 +26,8 @@ pluginManagement {
         maven {
             url "$artifactoryContextUrl/engineering-tools-maven"
             credentials {
-                username = System.getenv('CORDA_ARTIFACTORY_USERNAME') ?: cordaArtifactoryUsername
-                password = System.getenv('CORDA_ARTIFACTORY_PASSWORD') ?: cordaArtifactoryPassword
+                username = settings.ext.find('cordaArtifactoryUsername') ?: System.getenv('CORDA_ARTIFACTORY_USERNAME')
+                password = settings.ext.find('cordaArtifactoryPassword') ?: System.getenv('CORDA_ARTIFACTORY_PASSWORD')
             }
             content {
                 includeGroupByRegex 'com\\.r3\\.internal(\\..*)?'
@@ -56,10 +50,45 @@ pluginManagement {
     }
 }
 
+dependencyResolutionManagement {
+    repositories {
+        def cordaUseCache = System.getenv("CORDA_USE_CACHE")
+        if (cordaUseCache != null) {
+            maven {
+                url = "$artifactoryContextUrl/$cordaUseCache"
+                name = "R3 Maven remote repositories"
+                authentication {
+                    basic(BasicAuthentication)
+                }
+                credentials {
+                    username = System.getenv('CORDA_ARTIFACTORY_USERNAME')
+                    password = System.getenv('CORDA_ARTIFACTORY_PASSWORD')
+                }
+            }
+        } else {
+            mavenLocal()
+            mavenCentral()
+
+            maven {
+                url = "$artifactoryContextUrl/corda-dependencies"
+            }
+
+            maven {
+                url = "$artifactoryContextUrl/${System.getenv('CORDA_CONSUME_REPOSITORY_KEY') ?: 'corda-os-maven'}"
+                credentials {
+                    username = settings.ext.find('cordaArtifactoryUsername') ?: System.getenv('CORDA_ARTIFACTORY_USERNAME')
+                    password = settings.ext.find('cordaArtifactoryPassword') ?: System.getenv('CORDA_ARTIFACTORY_PASSWORD')
+                }
+            }
+        }
+    }
+}
+
 rootProject.name = "corda-api"
 
 include 'application'
 include 'base'
+include 'corda-platform'
 include 'crypto'
 include 'data:avro-schema'
 include 'data:topic-schema'


### PR DESCRIPTION
A Gradle platform is effectively a Maven BOM or `<dependencyManagement/>` element. A Gradle project can use the platform to avoid declaring explicit versions of any of the platform's contents:
```gradle
dependencies {
    cordaProvided platform("net.corda:corda-platform:$corda_release_version")
    cordaProvided 'net.corda:corda-application'
    cordaProvided 'net.corda:corda-crypto'
    cordaProvided 'net.corda:corda-ledger'
}
```
The platform dependency merely needs to be present in the Gradle configuration being resolved - either directly, on in a super-configuration.