### PR TITLE
CORE-2212: Migrate cordapp-configuration Gradle plugin.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,4 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-import io.gitlab.arturbosch.detekt.DetektPlugin
 import static org.gradle.api.JavaVersion.*
 
 buildscript {
@@ -11,6 +10,7 @@ buildscript {
 
 
 plugins {
+    id 'net.corda.cordapp.cordapp-configuration'
     id 'org.jetbrains.kotlin.jvm' apply false
     id 'org.jetbrains.kotlin.plugin.allopen' apply false
     id 'org.jetbrains.kotlin.plugin.noarg' apply false
@@ -83,7 +83,7 @@ subprojects {
     group 'net.corda'
 
     pluginManager.withPlugin('org.jetbrains.kotlin.jvm') {
-        apply plugin: DetektPlugin
+        apply plugin: 'io.gitlab.arturbosch.detekt'
         apply plugin: 'jacoco'
         apply plugin: 'org.jetbrains.dokka'
 

--- a/cordapp-configuration-publish/build.gradle
+++ b/cordapp-configuration-publish/build.gradle
@@ -1,0 +1,121 @@
+import static org.gradle.api.attributes.Category.CATEGORY_ATTRIBUTE
+import static org.gradle.api.attributes.Category.DOCUMENTATION
+import static org.gradle.api.attributes.DocsType.DOCS_TYPE_ATTRIBUTE
+
+plugins {
+    id 'com.jfrog.artifactory'
+    id 'maven-publish'
+    id 'base'
+}
+
+description 'Publishes the cordapp-configuration Gradle plugin.'
+
+ext {
+    pluginGroup = 'net.corda.cordapp'
+    pluginName = 'cordapp-configuration'
+    pluginId = 'net.corda.cordapp.cordapp-configuration'
+}
+
+configurations {
+    gradlePlugin {
+        canBeConsumed = false
+        transitive = false
+    }
+
+    pluginSources {
+        canBeConsumed = false
+        transitive = false
+
+        attributes {
+            attribute(CATEGORY_ATTRIBUTE, objects.named(Category, DOCUMENTATION))
+            attribute(DOCS_TYPE_ATTRIBUTE, objects.named(DocsType, 'sources'))
+        }
+    }
+
+    pluginJavadoc {
+        canBeConsumed = false
+        transitive = false
+
+        attributes {
+            attribute(CATEGORY_ATTRIBUTE, objects.named(Category, DOCUMENTATION))
+            attribute(DOCS_TYPE_ATTRIBUTE, objects.named(DocsType, 'javadoc'))
+        }
+    }
+}
+
+dependencies {
+    gradlePlugin group: pluginGroup, name: pluginName
+    pluginSources group: pluginGroup, name: pluginName
+    pluginJavadoc group: pluginGroup, name: pluginName
+}
+
+tasks.withType(Jar).configureEach {
+    throw new StopExecutionException('This project should not create a jar.')
+}
+
+tasks.register('install') {
+    dependsOn 'publishToMavenLocal'
+}
+
+def cordappConfigProject = gradle.includedBuild('cordapp-configuration')
+
+publishing {
+    publications {
+        cordappConfiguration(MavenPublication) {
+            groupId pluginGroup
+            artifactId pluginName
+
+            artifact provider { configurations.gradlePlugin.singleFile }
+            artifact(
+                source: provider { configurations.pluginSources.singleFile },
+                builtBy: cordappConfigProject.task(':sourcesJar'),
+                classifier: 'sources'
+            )
+            artifact(
+                source: provider { configurations.pluginJavadoc.singleFile },
+                builtBy: cordappConfigProject.task(':javadocJar'),
+                classifier: 'javadoc'
+            )
+
+            pom {
+                name = 'Cordapp CPK Configuration'
+                description = 'Configuration properties for cordapp-cpk Gradle plugin.'
+
+                licenses {
+                    license {
+                        name = licenseName
+                        url = licenseUrl
+                        distribution = 'repo'
+                    }
+                }
+
+                developers {
+                    developer {
+                        id = 'R3'
+                        name = 'R3'
+                        email = 'dev@corda.net'
+                    }
+                }
+            }
+        }
+
+        pluginMarker(MavenPublication) {
+            groupId pluginId
+            artifactId "${pluginId}.gradle.plugin"
+
+            pom {
+                packaging 'pom'
+                withXml {
+                    def dependency = asNode().appendNode('dependencies').appendNode('dependency')
+                    dependency.appendNode('groupId', pluginGroup)
+                    dependency.appendNode('artifactId', pluginName)
+                    dependency.appendNode('version', project.version)
+                }
+            }
+        }
+    }
+}
+
+artifactoryPublish {
+    publications('cordappConfiguration', 'pluginMarker')
+}

--- a/cordapp-configuration/build.gradle
+++ b/cordapp-configuration/build.gradle
@@ -1,0 +1,52 @@
+import static org.gradle.api.JavaVersion.VERSION_1_8
+
+plugins {
+    id 'java-gradle-plugin'
+    id 'java-library'
+}
+
+description 'Configuration properties for cordapp-cpk Gradle plugin.'
+
+group = 'net.corda.cordapp'
+
+gradlePlugin {
+    plugins {
+        cordappConfiguration {
+            id = 'net.corda.cordapp.cordapp-configuration'
+            implementationClass = 'net.corda.cordapp.ConfigurationPlugin'
+        }
+    }
+    automatedPublishing = false
+}
+
+java {
+    // Allowing this plugin to run successfully
+    // on Java 8 means that Corda can fail the
+    // build later with a graceful error message.
+    sourceCompatibility = VERSION_1_8
+    targetCompatibility = VERSION_1_8
+
+    withJavadocJar()
+    withSourcesJar()
+}
+
+dependencies {
+    testImplementation "org.junit.jupiter:junit-jupiter-api:$junitVersion"
+    testImplementation "org.junit.jupiter:junit-jupiter-params:$junitVersion"
+    testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junitVersion"
+}
+
+tasks.named('jar', Jar) {
+    manifest {
+        attributes('Sealed': true)
+    }
+}
+
+tasks.withType(Test).configureEach {
+    useJUnitPlatform()
+}
+
+tasks.withType(ValidatePlugins).configureEach {
+    // Ask Gradle to tell us how to annotate tasks correctly.
+    enableStricterValidation = true
+}

--- a/cordapp-configuration/gradle.properties
+++ b/cordapp-configuration/gradle.properties
@@ -1,0 +1,5 @@
+org.gradle.java.installations.auto-download=false
+org.gradle.jvmargs=-XX:+UseG1GC -Xmx1g
+org.gradle.caching=false
+
+junitVersion=5.7.2

--- a/cordapp-configuration/settings.gradle
+++ b/cordapp-configuration/settings.gradle
@@ -1,0 +1,5 @@
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+    }
+}

--- a/cordapp-configuration/src/main/java/net/corda/cordapp/ConfigurationPlugin.java
+++ b/cordapp-configuration/src/main/java/net/corda/cordapp/ConfigurationPlugin.java
@@ -1,0 +1,86 @@
+package net.corda.cordapp;
+
+import org.gradle.api.GradleException;
+import org.gradle.api.InvalidUserCodeException;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.tasks.StopExecutionException;
+
+import javax.annotation.Nonnull;
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.List;
+import java.util.Properties;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.unmodifiableList;
+
+@SuppressWarnings("unused")
+public final class ConfigurationPlugin implements Plugin<Project> {
+    private static final String MINIMUM_PLUGIN_VERSION_PROPERTY = "Minimum-Corda-Plugins-Version";
+    private static final String PLUGIN_VERSION = "META-INF/pluginVersion.properties";
+    private static final String CONFIGURATION = "cordapp-configuration.properties";
+
+    // These are the IDs of the Corda Gradle plugins that CorDapp developers need.
+    private static final List<String> CORDAPP_PLUGIN_IDS = unmodifiableList(asList(
+        "net.corda.plugins.cordapp-cpk",
+        "net.corda.plugins.cordapp-cpb",
+        "net.corda.plugins.quasar-utils"
+    ));
+
+    private static final Version MINIMUM_PLUGIN_VERSION;
+    static {
+        URL configuration = ConfigurationPlugin.class.getResource(CONFIGURATION);
+        if (configuration == null) {
+            throw new InvalidUserCodeException(CONFIGURATION + " is missing.");
+        }
+        Properties properties = loadProperties(configuration);
+        MINIMUM_PLUGIN_VERSION = Version.parse(properties.getProperty(MINIMUM_PLUGIN_VERSION_PROPERTY));
+    }
+
+    @Override
+    public void apply(@Nonnull Project project) {
+        if (!project.equals(project.getRootProject())) {
+            throw new GradleException("cordapp-configuration plugin incorrectly applied to '"
+                + project.getPath() + "' project. It should only be applied to the root project.");
+        }
+
+        project.allprojects(this::validatePlugins);
+    }
+
+    private void validatePlugins(@Nonnull Project project) {
+        CORDAPP_PLUGIN_IDS.forEach(id ->
+            project.getPlugins().withId(id, plugin -> {
+                final Version version = getVersionFrom(id, plugin);
+                if (version.getBaseVersion().compareTo(MINIMUM_PLUGIN_VERSION) < 0) {
+                    throw new StopExecutionException("Plugin " + id + " version " + version
+                            + " is below minimum version " + MINIMUM_PLUGIN_VERSION);
+                }
+            })
+        );
+    }
+
+    @Nonnull
+    private static Version getVersionFrom(String id, @Nonnull Plugin<?> plugin) {
+        final URL versionResource = plugin.getClass().getClassLoader().getResource(PLUGIN_VERSION);
+        if (versionResource == null) {
+            throw new StopExecutionException("Plugin " + id + " has no " + PLUGIN_VERSION);
+        }
+
+        final Properties properties = loadProperties(versionResource);
+        return Version.parse(properties.getProperty("version"));
+    }
+
+    @Nonnull
+    private static Properties loadProperties(@Nonnull URL resource) {
+        Properties properties = new Properties();
+        try (InputStream input = new BufferedInputStream(resource.openStream())) {
+            properties.load(input);
+        } catch (IOException e) {
+            throw new InvalidUserCodeException(e.getMessage(), e);
+        }
+        return properties;
+    }
+}

--- a/cordapp-configuration/src/main/java/net/corda/cordapp/Version.java
+++ b/cordapp-configuration/src/main/java/net/corda/cordapp/Version.java
@@ -1,0 +1,110 @@
+package net.corda.cordapp;
+
+import org.gradle.api.tasks.StopExecutionException;
+
+import javax.annotation.Nonnull;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+final class Version implements Comparable<Version> {
+    private static final Pattern VERSION_PATTERN = Pattern.compile("((\\d++)(\\.\\d++)+)(-.+)?");
+
+    private final int major;
+    private final int minor;
+    private final int revision;
+    private final String tag;
+
+    private Version(int major, int minor, int revision, String tag) {
+        this.major = major;
+        this.minor = minor;
+        this.revision = revision;
+        this.tag = tag;
+    }
+
+    @Nonnull
+    Version getBaseVersion() {
+        return new Version(major, minor, revision, "");
+    }
+
+    @Override
+    public int compareTo(@Nonnull Version version) {
+        int result = major - version.major;
+        if (result == 0) {
+            result = minor - version.minor;
+            if (result == 0) {
+                result = revision - version.revision;
+                if (result == 0) {
+                    result = tag.compareTo(version.tag);
+                }
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (object == this) {
+            return true;
+        } else if (object == null || object.getClass() != Version.class) {
+            return false;
+        }
+        Version other = (Version) object;
+        return major == other.major
+                && minor == other.minor
+                && revision == other.revision
+                && tag.equals(other.tag);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(major, minor, revision, tag);
+    }
+
+    @Override
+    @Nonnull
+    public String toString() {
+        StringBuilder builder = new StringBuilder()
+            .append(major).append('.').append(minor).append('.').append(revision);
+        if (!tag.isEmpty()) {
+            builder.append('-').append(tag);
+        }
+        return builder.toString();
+    }
+
+    @Nonnull
+    static Version parse(String version) {
+        final Matcher matcher = VERSION_PATTERN.matcher(version);
+        if (!matcher.matches()) {
+            throw new StopExecutionException("Unsupported version format '" + version + '\'');
+        }
+
+        final String dottedVersion = matcher.group(1);
+        final String majorVersion = matcher.group(2);
+        final String revision = matcher.group(3);
+        final String minorVersion = dottedVersion.substring(majorVersion.length(), dottedVersion.length() - revision.length());
+        if (minorVersion.lastIndexOf('.') > 0) {
+            // The '.' should either be the first character, or be missing entirely.
+            throw new StopExecutionException("Unsupported version format '" + version + '\'');
+        }
+        return new Version(
+            Integer.parseInt(majorVersion),
+            parseComponent(minorVersion),
+            parseComponent(revision),
+            parseTag(matcher.group(4))
+        );
+    }
+
+    private static int parseComponent(String component) {
+        return isNullOrEmpty(component) ? 0 : Integer.parseInt(component.substring(1));
+    }
+
+    @Nonnull
+    private static String parseTag(String str) {
+        return isNullOrEmpty(str) ? "" : str.substring(1).toUpperCase();
+    }
+
+    private static boolean isNullOrEmpty(String s) {
+        return s == null || s.isEmpty();
+    }
+}

--- a/cordapp-configuration/src/main/resources/net/corda/cordapp/cordapp-configuration.properties
+++ b/cordapp-configuration/src/main/resources/net/corda/cordapp/cordapp-configuration.properties
@@ -1,0 +1,22 @@
+Corda-Contract-Classes=IMPLEMENTS;net.corda.v5.ledger.contracts.Contract
+Corda-Flow-Classes=IMPLEMENTS;net.corda.v5.application.flows.Flow
+Corda-MappedSchema-Classes=EXTENDS;net.corda.v5.persistence.MappedSchema
+Corda-SerializationWhitelist-Classes=IMPLEMENTS;net.corda.v5.serialization.SerializationWhitelist
+Corda-SerializationCustomSerializer-Classes=IMPLEMENTS;net.corda.v5.serialization.SerializationCustomSerializer
+Corda-Service-Classes=IMPLEMENTS;net.corda.v5.application.services.CordaService
+Corda-CheckpointCustomSerializer-Classes=IMPLEMENTS;net.corda.v5.serialization.CheckpointCustomSerializer
+Corda-NotaryService-Classes=EXTENDS;net.corda.v5.ledger.notary.NotaryService
+Corda-StateAndRefPostProcessor-Classes=IMPLEMENTS;net.corda.v5.ledger.services.vault.StateAndRefPostProcessor
+Corda-CustomQueryPostProcessor-Classes=IMPLEMENTS;net.corda.v5.application.services.persistence.CustomQueryPostProcessor
+
+# Corda should adjust this version over time, as required.
+Minimum-Corda-Plugins-Version=6.0.0
+
+# CorDapps must always import these packages so that Corda can
+# still create lazy JPA proxies within the OSGi framework.
+Required-Packages=org.hibernate.annotations,\
+    org.hibernate.proxy,\
+    javassist.util.proxy
+
+# The OSGi "consumer policy" for Corda's API packages.
+Import-Policy-Packages=net.corda.v5.*

--- a/cordapp-configuration/src/test/java/net/corda/cordapp/VersionTest.java
+++ b/cordapp-configuration/src/test/java/net/corda/cordapp/VersionTest.java
@@ -1,0 +1,99 @@
+package net.corda.cordapp;
+
+import org.gradle.api.tasks.StopExecutionException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+
+import java.util.stream.Stream;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Timeout(value = 30, unit = SECONDS)
+class VersionTest {
+    static class LessThanProvider implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+            return Stream.of(
+                Arguments.of("6.0", "6.0.1"),
+                Arguments.of("6.0.0", "6.0.1"),
+                Arguments.of("6.0.0", "6.1"),
+                Arguments.of("6.0.0", "6.1-snapshot"),
+                Arguments.of("6.0.0", "6.1.0"),
+                Arguments.of("6.0.0", "6.1.1"),
+                Arguments.of("6.0.0", "6.1.2"),
+                Arguments.of("6.0.0", "6.1.2-SNAPSHOT")
+            );
+        }
+    }
+
+    @ParameterizedTest(name = "{displayName} -> {0} < {1}")
+    @DisplayName("Less Than")
+    @ArgumentsSource(LessThanProvider.class)
+    void testLessThan(String lesser, String greater) {
+        assertTrue(Version.parse(lesser).compareTo(Version.parse(greater)) < 0);
+    }
+
+    static class EqualsProvider implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+            return Stream.of(
+                Arguments.of("6.0", "6.0.0"),
+                Arguments.of("6.0-SNAPSHOT", "6.0.0-SNAPSHOT"),
+                Arguments.of("6.0.0-snapshot", "6.0.0-SNAPSHOT")
+            );
+        }
+    }
+
+    @ParameterizedTest(name = "{displayName} -> {0} = {1}")
+    @DisplayName("Equals")
+    @ArgumentsSource(EqualsProvider.class)
+    void testEquals(String first, String second) {
+        assertEquals(Version.parse(first), Version.parse(second));
+    }
+
+    static class BaseVersionProvider implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+            return Stream.of(
+                Arguments.of("6.0", "6.0.0"),
+                Arguments.of("6.0.0", "6.0.0"),
+                Arguments.of("6.0-SNAPSHOT", "6.0.0"),
+                Arguments.of("6.1.2-SNAPSHOT", "6.1.2"),
+                Arguments.of("6.1.2-DevPreview-RC01", "6.1.2")
+            );
+        }
+    }
+
+    @ParameterizedTest(name = "{displayName} -> {0} has base {1}")
+    @DisplayName("Base Version")
+    @ArgumentsSource(BaseVersionProvider.class)
+    void testBaseVersion(String version, String baseVersion) {
+        assertEquals(baseVersion, Version.parse(version).getBaseVersion().toString());
+    }
+
+    static class BadProvider implements ArgumentsProvider {
+        @Override
+        public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+            return Stream.of(
+                Arguments.of("6"),
+                Arguments.of("6.0-"),
+                Arguments.of("6.0.0.0")
+            );
+        }
+    }
+
+    @ParameterizedTest(name = "{displayName} -> {0}")
+    @DisplayName("BadVersion")
+    @ArgumentsSource(BadProvider.class)
+    void testBadVersion(String bad) {
+        assertThrows(StopExecutionException.class, () -> Version.parse(bad));
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -86,9 +86,11 @@ dependencyResolutionManagement {
 
 rootProject.name = "corda-api"
 
+includeBuild 'cordapp-configuration'
 include 'application'
 include 'base'
 include 'corda-platform'
+include 'cordapp-configuration-publish'
 include 'crypto'
 include 'data:avro-schema'
 include 'data:topic-schema'


### PR DESCRIPTION
Migrate the `cordapp-configuration` Gradle plugin from the `corda5` repository.

Continue to include this plugin as a composite Gradle build to ensure that it is kept distinct from the other projects. Applying this plugin to the root project instructs Gradle to build it, and also serves as a functional test.