### PR TITLE
NOTICK: Resolve Gradle warning when generating KDoc for Avro classes.

### DIFF
--- a/data/avro-schema/build.gradle
+++ b/data/avro-schema/build.gradle
@@ -107,6 +107,10 @@ tasks.named("compileKotlin") {
     dependsOn generateOSGiPackageInfo
 }
 
+tasks.named('dokkaHtml') {
+    inputs.files generateAvro, generateOSGiPackageInfo
+}
+
 def generatedResources = files(generatedClassesDir) {
     builtBy generateOSGiPackageInfo
 }


### PR DESCRIPTION
Tell Dokka which tasks are generating some of its Avro inputs. This resolves a Gradle "deprecated behaviour" warning.