### PR TITLE
NOTICK: Remove JUnit4 Gradle tasks.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -135,62 +135,6 @@ subprojects {
             )
         }
 
-        // This block should be remove when the junit 4 tests are removed
-        sourceSets {
-            junit4Test {
-                kotlin {
-                    srcDirs += file("$projectDir/src/junit4Test/kotlin")
-                }
-                java {
-                    srcDirs += file("$projectDir/src/junit4Test/java")
-                }
-                resources {
-                    srcDirs += file("$projectDir/src/junit4Test/resources")
-                }
-                compileClasspath += main.output + test.output
-                runtimeClasspath += main.output + test.output
-            }
-        }
-
-        dependencies {
-            // TODO: remove vintage engine when existing tests labelled "junit4Test" and we don't have a dependency on 4 anymore
-            junit4TestRuntimeOnly "org.junit.vintage:junit-vintage-engine:$junitVersion"
-        }
-
-        kotlin {
-            target {
-                java
-                compilations.junit4Test {
-                    associateWith compilations.main
-                    associateWith compilations.test
-
-                    configurations {
-                        junit4TestApi.extendsFrom testApi
-                        junit4TestImplementation.extendsFrom testImplementation
-                        junit4TestRuntimeOnly.extendsFrom testRuntimeOnly
-
-                        [ junit4TestCompileClasspath, junit4TestRuntimeClasspath ].forEach { cfg ->
-                            configureKotlinForOSGi(cfg)
-                        }
-                    }
-                }
-            }
-        }
-
-        tasks.register('junit4Test', Test) {
-            description = 'Runs junit4 tests'
-            group = 'verification'
-
-            testClassesDirs = project.sourceSets['junit4Test'].output.classesDirs
-            classpath = project.sourceSets['junit4Test'].runtimeClasspath
-            shouldRunAfter tasks.named('test')
-        }
-
-        tasks.named('test') {
-            dependsOn tasks.named('junit4Test')
-        }
-
-
         configurations {
             all {
                 resolutionStrategy {

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 2
+cordaApiRevision = 3
 
 # Main
 kotlinVersion = 1.4.21
@@ -49,7 +49,6 @@ hibernateVersion = 5.4.32.Final
 
 # Testing
 assertjVersion = 3.12.2
-legacyJunitVersion = 4.13
 junitVersion = 5.7.1
 mockitoVersion = 2.28.2
 mockitoKotlinVersion = 1.6.0


### PR DESCRIPTION
Remove JUnit 4 support now that the tests have been migrated to JUnit 5.