### PR TITLE
NOTICK: Configure Kotlin plugin not to add dependency on non-OSGi standard library.

### DIFF
--- a/data/avro-schema/build.gradle
+++ b/data/avro-schema/build.gradle
@@ -13,6 +13,7 @@ dependencies {
     api "org.apache.avro:avro:$avroVersion"
     implementation platform(project(':corda-api'))
     implementation project(":base")
+    implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi:$kotlinVersion"
 
     compileOnly "org.osgi:osgi.annotation:$osgiVersion"
     compileOnly "org.osgi:osgi.core:$osgiVersion"

--- a/data/topic-schema/build.gradle
+++ b/data/topic-schema/build.gradle
@@ -6,5 +6,6 @@ plugins {
 description 'Definition of Topics'
 
 dependencies {
+    implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi:$kotlinVersion"
     implementation platform(project(':corda-api'))
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,6 +11,7 @@ cordaApiRevision = 3
 
 # Main
 kotlinVersion = 1.4.21
+kotlin.stdlib.default.dependency = false
 
 # License
 ## TODO: Change to correct name and URL


### PR DESCRIPTION
The Gradle plugin for Kotlin 1.4+ will silently add a dependency on `kotlin-stdlib` if it doesn't detect an existing one. Unfortunately, the plugin does not recognise `kotlin-osgi-bundle` as an alternative standard library, and so we must configure the plugin _not_ to add this extra and unwanted dependency by default.