### PR TITLE
CORE-2242-Schema Changes Needed To Add Diffie Hellman Key Exchange To Linkmanager

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/crypto/InitiatorHelloMessage.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/crypto/InitiatorHelloMessage.avsc
@@ -17,6 +17,10 @@
         "type": "array",
         "items": "net.corda.p2p.crypto.ProtocolMode"
       }
+    },
+    {
+      "name": "source",
+      "type": "net.corda.p2p.crypto.internal.InitiatorHandshakeIdentity"
     }
   ]
 }

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/crypto/internal/InitiatorHandshakeIdentity.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/crypto/internal/InitiatorHandshakeIdentity.avsc
@@ -1,0 +1,15 @@
+{
+  "type": "record",
+  "name": "InitiatorHandshakeIdentity",
+  "namespace": "net.corda.p2p.crypto.internal",
+  "fields": [
+    {
+      "name": "initiatorPublicKeyHash",
+      "type": "bytes"
+    },
+    {
+      "name": "groupId",
+      "type": "string"
+    }
+  ]
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 4
+cordaApiRevision = 5
 
 # Main
 kotlinVersion = 1.4.21


### PR DESCRIPTION
Added the public key hash and the group identifier to initiatorHelloMessage. This is needed for doing all the Diffie-Hellman steps in the LinkManager (so we know where to send the responderHelloMessage).