### PR TITLE
CORE-2360: Add Kotlin, OSGi, SLF4J and Java Persistence to Corda API.

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -7,8 +7,7 @@ plugins {
 description 'Corda Application'
 
 dependencies {
-    api "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlinVersion"
-    api "net.corda.kotlin:kotlin-stdlib-jdk8-osgi:$kotlinVersion"
+    api 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
 
     api platform(project(':corda-api'))
     api project(":base")
@@ -19,8 +18,8 @@ dependencies {
     implementation "org.bouncycastle:bcprov-jdk15on:$bouncycastleVersion"
     implementation "org.bouncycastle:bcpkix-jdk15on:$bouncycastleVersion"
 
-    compileOnly "org.osgi:osgi.core:$osgiVersion"
-    compileOnly "org.osgi:osgi.annotation:$osgiVersion"
+    compileOnly 'org.osgi:osgi.core'
+    compileOnly 'org.osgi:osgi.annotation'
 
     testImplementation "org.assertj:assertj-core:$assertjVersion"
 }

--- a/base/build.gradle
+++ b/base/build.gradle
@@ -8,12 +8,11 @@ description 'Corda Base'
 
 dependencies {
     implementation platform(project(':corda-api'))
-    implementation "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlinVersion"
-    implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi:$kotlinVersion"
+    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
     // Concluded this is the one acceptable dependency in addition to kotlin.
-    implementation "org.slf4j:slf4j-api:$slf4jVersion"
+    implementation 'org.slf4j:slf4j-api'
 
-    compileOnly "org.osgi:osgi.annotation:$osgiVersion"
+    compileOnly 'org.osgi:osgi.annotation'
 
     testImplementation "org.assertj:assertj-core:$assertjVersion"
 }

--- a/cipher-suite/build.gradle
+++ b/cipher-suite/build.gradle
@@ -7,11 +7,10 @@ plugins {
 description 'Corda Cipher Suite'
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlinVersion"
-    implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi:$kotlinVersion"
-    implementation "org.slf4j:slf4j-api:$slf4jVersion"
+    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.slf4j:slf4j-api'
 
-    compileOnly "org.osgi:osgi.annotation:$osgiVersion"
+    compileOnly 'org.osgi:osgi.annotation'
 
     implementation "org.bouncycastle:bcprov-jdk15on:$bouncycastleVersion"
     implementation "org.bouncycastle:bcpkix-jdk15on:$bouncycastleVersion"

--- a/corda-api/build.gradle
+++ b/corda-api/build.gradle
@@ -14,6 +14,13 @@ dependencies {
         api project(':data:topic-schema')
         api project(':persistence')
         api project(':serialization')
+
+        api "javax.persistence:javax.persistence-api:$javaxPersistenceApiVersion"
+        api "net.corda.kotlin:kotlin-stdlib-jdk8-osgi:$kotlinVersion"
+        api "net.corda.kotlin:kotlin-stdlib-jdk7-osgi:$kotlinVersion"
+        api "org.osgi:osgi.annotation:$osgiVersion"
+        api "org.osgi:osgi.core:$osgiVersion"
+        api "org.slf4j:slf4j-api:$slf4jVersion"
     }
 }
 

--- a/crypto/build.gradle
+++ b/crypto/build.gradle
@@ -7,11 +7,10 @@ plugins {
 description 'Corda Crypto'
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlinVersion"
-    implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi:$kotlinVersion"
-    implementation "org.slf4j:slf4j-api:$slf4jVersion"
+    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.slf4j:slf4j-api'
 
-    compileOnly "org.osgi:osgi.annotation:$osgiVersion"
+    compileOnly 'org.osgi:osgi.annotation'
 
     implementation "org.bouncycastle:bcprov-jdk15on:$bouncycastleVersion"
     implementation "org.bouncycastle:bcpkix-jdk15on:$bouncycastleVersion"

--- a/data/avro-schema/build.gradle
+++ b/data/avro-schema/build.gradle
@@ -13,10 +13,10 @@ dependencies {
     api "org.apache.avro:avro:$avroVersion"
     implementation platform(project(':corda-api'))
     implementation project(":base")
-    implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi:$kotlinVersion"
+    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
 
-    compileOnly "org.osgi:osgi.annotation:$osgiVersion"
-    compileOnly "org.osgi:osgi.core:$osgiVersion"
+    compileOnly 'org.osgi:osgi.annotation'
+    compileOnly 'org.osgi:osgi.core'
 }
 
 description 'Data Model Definitions'

--- a/data/topic-schema/build.gradle
+++ b/data/topic-schema/build.gradle
@@ -6,6 +6,6 @@ plugins {
 description 'Definition of Topics'
 
 dependencies {
-    implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi:$kotlinVersion"
+    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
     implementation platform(project(':corda-api'))
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -33,7 +33,7 @@ guavaVersion = 30.1.1-jre
 
 
 # Logging
-slf4jVersion = 1.7.30
+slf4jVersion = 1.7.32
 log4jVersion = 2.13.3
 
 # Main implementation dependencies
@@ -50,10 +50,10 @@ hibernateVersion = 5.4.32.Final
 
 # Testing
 assertjVersion = 3.12.2
-junitVersion = 5.7.1
+junitVersion = 5.7.2
 mockitoVersion = 2.28.2
 mockitoKotlinVersion = 1.6.0
 
 # OSGi
 bndVersion = 5.3.0
-osgiVersion = 7.0.0
+osgiVersion = 8.0.0

--- a/persistence/build.gradle
+++ b/persistence/build.gradle
@@ -7,11 +7,10 @@ plugins {
 description 'Corda Persistence'
 
 dependencies {
-    compileOnly "org.osgi:osgi.annotation:$osgiVersion"
+    compileOnly 'org.osgi:osgi.annotation'
 
-    api "javax.persistence:javax.persistence-api:$javaxPersistenceApiVersion"
-    implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi:$kotlinVersion"
-    implementation "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlinVersion"
+    api 'javax.persistence:javax.persistence-api'
+    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
 
     implementation platform(project(':corda-api'))
     implementation project(":base")

--- a/serialization/build.gradle
+++ b/serialization/build.gradle
@@ -10,10 +10,9 @@ dependencies {
     api platform(project(':corda-api'))
     api project(":base")
 
-    implementation "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlinVersion"
-    implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi:$kotlinVersion"
+    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
 
-    compileOnly "org.osgi:osgi.annotation:$osgiVersion"
+    compileOnly 'org.osgi:osgi.annotation'
 
     testImplementation "org.junit.jupiter:junit-jupiter-api:$junitVersion"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junitVersion"


### PR DESCRIPTION
Kotlin, OSGi, SLF4J and Java Persistence are key API dependencies of Corda's API, so add these to the `corda-api` platform too.

Note that:
- The Kotlin Gradle plugin is incompatible with Gradle platforms, as it will apply its own version to any unversioned Kotlin dependency that it recognises. I have therefore only included Corda's own Kotlin OSGi bundles into the platform.
-  `corda-runtime-os` uses Felix 7, which implements `org.osgi.framework` 1.10. This framework is correctly described by OSGi 8.0.0.
- SLF4J 1.7.32 is a minor bug-fix update for 1.7.30, as described [here](http://www.slf4j.org/news.html).