### PR TITLE
CORE-1926: Convert the key from bytes to string

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/AuthenticatedMessageAndKey.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/AuthenticatedMessageAndKey.avsc
@@ -9,7 +9,7 @@
     },
     {
       "name": "key",
-      "type": "bytes"
+      "type": "string"
     }
   ]
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 5
+cordaApiRevision = 6
 
 # Main
 kotlinVersion = 1.4.21


### PR DESCRIPTION
Converting the key from `bytes` to `string` to make the Link Manager code a bit cleaner, since we know keys in the `p2p.out` topic are only going to be strings.

For context, the code that integrates with this change can be found [here](https://github.com/corda/corda-runtime-os/tree/CORE-1926-loopback-mechanism).