### PR TITLE
CORE-2360: Add OSGi component annotations to corda-api platform.

### DIFF
--- a/corda-api/build.gradle
+++ b/corda-api/build.gradle
@@ -20,6 +20,7 @@ dependencies {
         api "net.corda.kotlin:kotlin-stdlib-jdk7-osgi:$kotlinVersion"
         api "org.osgi:osgi.annotation:$osgiVersion"
         api "org.osgi:osgi.core:$osgiVersion"
+        api "org.osgi:org.osgi.service.component.annotations:$osgiScrAnnotationVersion"
         api "org.slf4j:slf4j-api:$slf4jVersion"
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -57,3 +57,4 @@ mockitoKotlinVersion = 1.6.0
 # OSGi
 bndVersion = 5.3.0
 osgiVersion = 8.0.0
+osgiScrAnnotationVersion = 1.4.0


### PR DESCRIPTION
Also include the OSGi component annotations in the `corda-api` platform, because leaving it out makes using the platform feel clunky.