### PR TITLE
NOTICK: Simplify dependency on corda-flows CPK.

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -1,14 +1,17 @@
 plugins {
     id 'groovy-gradle-plugin'
 }
+
+repositories {
+    gradlePluginPortal()
+}
+
 // We can't get the values directly from `gradle.properties` from here for some gradle-y reason.
 // So we'll load it into our own object to grab what we need.
 def constants = new Properties()
 file("$rootDir/../gradle.properties").withInputStream { InputStream input -> constants.load(input) }
 def bndVersion = constants.getProperty('bndVersion')
-repositories {
-    gradlePluginPortal()
-}
+
 dependencies {
     implementation "biz.aQute.bnd:biz.aQute.bnd.gradle:$bndVersion"
 }

--- a/packaging/build.gradle
+++ b/packaging/build.gradle
@@ -19,6 +19,7 @@ allprojects {
 configurations {
     flowsCPK {
         canBeConsumed = false
+        transitive = false
     }
     workflowCPK {
         canBeConsumed = false
@@ -52,13 +53,13 @@ dependencies {
     // TODO:  This should be re-visited when more of the cordapp APIs are imported into this repo.
     workflow project('test:workflow-cpk')
     workflowLibs project(path: 'test:workflow-cpk', configuration: 'libFolderDependencies')
-    flowsCPK(group: 'net.corda', name: 'corda-flows', version: "$cordaDevPreviewVersion", classifier: 'cordapp', ext: 'cpk')
+    flowsCPK "net.corda:corda-flows:$cordaDevPreviewVersion:cordapp@cpk"
     workflowCPK project(path: 'test:workflow-cpk', configuration: 'cordaCPK')
 }
 
 def certificateProvider = provider {
     CertificateFactory cf = CertificateFactory.getInstance('X.509')
-    def cert = rootProject.file('packaging/config/dev/corda_dev_cpk.cer').withInputStream {
+    def cert = file('config/dev/corda_dev_cpk.cer').withInputStream {
         cf.generateCertificate(it)
     }
     cert.publicKey.encoded.sha256()
@@ -68,13 +69,11 @@ tasks.named('test', Test) {
     inputs.files(configurations.flowsCPK, configurations.workflowCPK)
 
     doFirst {
-        // Make sure we pick out only the corda-flows cpk
-        def cordaFlows = configurations.flowsCPK.filter { it.toString().contains("corda-flows")}.singleFile.toURI()
         systemProperties([
             'java.io.tmpdir' : buildDir.absolutePath,
             'net.corda.dev.cert' : certificateProvider.get(),
             'net.corda.packaging.test.workflow.libs' : configurations.workflowLibs.collect { it.toURI() }.join(' '),
-            'net.corda.flows.cpk' : cordaFlows,
+            'net.corda.flows.cpk' : configurations.flowsCPK.singleFile.toURI(),
             'net.corda.packaging.test.workflow.cpk' : configurations.workflowCPK.singleFile.toURI(),
             'net.corda.packaging.test.contract.bundle.symbolic.name': contractSymbolicName,
             'net.corda.packaging.test.contract.bundle.version' : MavenVersion.parseMavenString(version.toString()).OSGiVersion.toString(),


### PR DESCRIPTION
The best way to remove transitive dependencies is not to request them in the first place.
The certificate file also belongs to the `packaging` project and so we don't need to resolve its location from the root.