### PR TITLE
NOTICK: Prevent cordapp-cpk and common-library plugins being applied together.

### DIFF
--- a/buildSrc/src/main/groovy/corda-api.common-library.gradle
+++ b/buildSrc/src/main/groovy/corda-api.common-library.gradle
@@ -5,6 +5,10 @@ plugins {
     id 'biz.aQute.bnd.builder'
 }
 
+pluginManager.withPlugin('net.corda.plugins.cordapp-cpk') {
+    throw new StopExecutionException('corda-api.common-library plugin is incompatible with building CPKs and CPBs')
+}
+
 configurations {
     testArtifacts {
         canBeResolved = false


### PR DESCRIPTION
Both the `cordapp-cpk` and `common-library` plugins will reconfigure the `jar` task, but for different reasons and in different ways. Prevent them both being applied to the same project.