### PR TITLE
CORE-2041 added AVRO over-the-wire crypto services models

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/WirePublicKey.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/WirePublicKey.avsc
@@ -2,10 +2,12 @@
   "type": "record",
   "name": "WirePublicKey",
   "namespace": "net.corda.data.crypto.wire",
+  "doc": "Internal over-the-wire public key serialised as byte array for crypto services.",
   "fields": [
     {
       "name": "key",
-      "type": "bytes"
+      "type": "bytes",
+      "doc": "Encoded public key"
     }
   ]
 }

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/WirePublicKeys.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/WirePublicKeys.avsc
@@ -2,13 +2,15 @@
   "type": "record",
   "name": "WirePublicKeys",
   "namespace": "net.corda.data.crypto.wire",
+  "doc": "Internal over-the-wire collection of public keys serialised as byte arrays for crypto services",
   "fields": [
     {
       "name": "keys",
       "type": {
         "type": "array",
         "items": "bytes"
-      }
+      },
+      "doc": "Collection of encoded public key"
     }
   ]
 }

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/WireSignature.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/WireSignature.avsc
@@ -2,10 +2,12 @@
   "type": "record",
   "name": "WireSignature",
   "namespace": "net.corda.data.crypto.wire",
+  "doc": "Internal over-the-wire digital signature for crypto services",
   "fields": [
     {
       "name": "bytes",
-      "type": "bytes"
+      "type": "bytes",
+      "doc": "Byte array of the signature, exactly as returned by crypto signing operations"
     }
   ]
 }

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/WireSignatureSchemes.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/WireSignatureSchemes.avsc
@@ -2,13 +2,15 @@
   "type": "record",
   "name": "WireSignatureSchemes",
   "namespace": "net.corda.data.crypto.wire",
+  "doc": "Internal over-the-wire collection of signature scheme code names for crypto services",
   "fields": [
     {
       "name": "codes",
       "type": {
         "type": "array",
         "items": "string"
-      }
+      },
+      "doc": "Collection of [SignatureScheme].codeName(s)"
     }
   ]
 }

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/WireSignatureSpec.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/WireSignatureSpec.avsc
@@ -2,17 +2,20 @@
   "type": "record",
   "name": "WireSignatureSpec",
   "namespace": "net.corda.data.crypto.wire",
+  "doc": "Internal over-the-wire signature spec for crypto services",
   "fields": [
     {
       "name": "signatureName",
-      "type": "string"
+      "type": "string",
+      "doc": "A signature-scheme name as required to create [Signature] objects (e.g. \"SHA256withECDSA\")"
     },
     {
       "name": "customDigestName",
       "type": [
         "null",
         "string"
-      ]
+      ],
+      "doc": "An optional digest algorithm name, set to non null value if the hash should be precalculated before passing to the provider (e.g. \"SHA512\"), note that the signatureName should not contain the digest (e.g. \"NONEwithECDSA\")."
     }
   ]
 }

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/WireSignatureWithKey.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/WireSignatureWithKey.avsc
@@ -2,14 +2,17 @@
   "type": "record",
   "name": "WireSignatureWithKey",
   "namespace": "net.corda.data.crypto.wire",
+  "doc": "Internal over-the-wire digital signature for crypto services",
   "fields": [
     {
       "name": "publicKey",
-      "type": "bytes"
+      "type": "bytes",
+      "doc": "Public keys which can be used to verify the signature"
     },
     {
       "name": "bytes",
-      "type": "bytes"
+      "type": "bytes",
+      "doc": "Byte array of the signature, exactly as returned by crypto signing operations"
     }
   ]
 }

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/freshkeys/WireFreshKeysEnsureWrappingKey.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/freshkeys/WireFreshKeysEnsureWrappingKey.avsc
@@ -2,6 +2,7 @@
   "type": "record",
   "name": "WireFreshKeysEnsureWrappingKey",
   "namespace": "net.corda.data.crypto.wire.freshkeys",
+  "doc": "Internal over-the-wire request to ensure that the wrapping key exists",
   "fields": [
   ]
 }

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/freshkeys/WireFreshKeysFilterMyKeys.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/freshkeys/WireFreshKeysFilterMyKeys.avsc
@@ -2,13 +2,15 @@
   "type": "record",
   "name": "WireFreshKeysFilterMyKeys",
   "namespace": "net.corda.data.crypto.wire.freshkeys",
+  "doc": "Internal over-the-wire request to filter out keys from the provided collection which don't belong to the member",
   "fields": [
     {
       "name": "keys",
       "type": {
         "type": "array",
         "items": "bytes"
-      }
+      },
+      "doc": "Candidate keys"
     }
   ]
 }

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/freshkeys/WireFreshKeysFreshKey.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/freshkeys/WireFreshKeysFreshKey.avsc
@@ -2,6 +2,7 @@
   "type": "record",
   "name": "WireFreshKeysFreshKey",
   "namespace": "net.corda.data.crypto.wire.freshkeys",
+  "doc": "Internal over-the-wire request to generate new wrapped key pair",
   "fields": [
     {
       "name": "externalId",
@@ -11,7 +12,8 @@
           "type": "string",
           "logicalType": "uuid"
         }
-      ]
+      ],
+      "doc": "If provided then the key will be associated with that id"
     }
   ]
 }

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/freshkeys/WireFreshKeysRequest.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/freshkeys/WireFreshKeysRequest.avsc
@@ -2,23 +2,28 @@
   "type": "record",
   "name": "WireFreshKeysRequest",
   "namespace": "net.corda.data.crypto.wire.freshkeys",
+  "doc": "Internal over-the-wire request for crypto's [FreshKeysSigningService], the service operations are multiplexed",
   "fields": [
     {
       "name": "requestingComponent",
-      "type": "string"
+      "type": "string",
+      "doc": "Name of the component which requested the operation"
     },
     {
       "name": "requestTimestamp",
       "type": "long",
-      "logicalType": "timestamp-millis"
+      "logicalType": "timestamp-millis",
+      "doc": "Time ([Instant]) in milliseconds of the request"
     },
     {
       "name": "correlation",
-      "type": "string"
+      "type": "string",
+      "doc": "Optional correlation id"
     },
     {
       "name": "memberId",
-      "type": "string"
+      "type": "string",
+      "doc": "Member's ID on which behalf the request is made"
     },
     {
       "name": "request",
@@ -27,7 +32,8 @@
         "WireFreshKeysEnsureWrappingKey",
         "WireFreshKeysSign",
         "WireFreshKeysFilterMyKeys"
-      ]
+      ],
+      "doc": "Request's payload, depends on the requested operation"
     }
   ]
 }

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/freshkeys/WireFreshKeysResponse.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/freshkeys/WireFreshKeysResponse.avsc
@@ -2,28 +2,34 @@
   "type": "record",
   "name": "WireFreshKeysResponse",
   "namespace": "net.corda.data.crypto.wire.freshkeys",
+  "doc": "Internal over-the-wire response for crypto's [FreshKeysSigningService] operations",
   "fields": [
     {
       "name": "requestingComponent",
-      "type": "string"
+      "type": "string",
+      "doc": "Name of the component which requested the operation, copied from the corresponding request"
     },
     {
       "name": "requestTimestamp",
       "type": "long",
-      "logicalType": "timestamp-millis"
+      "logicalType": "timestamp-millis",
+      "doc": "Time ([Instant]) in milliseconds of the request, copied from the corresponding request"
     },
     {
       "name": "responseTimestamp",
       "type": "long",
-      "logicalType": "timestamp-millis"
+      "logicalType": "timestamp-millis",
+      "doc": "Time ([Instant]) in milliseconds of the response"
     },
     {
       "name": "correlation",
-      "type": "string"
+      "type": "string",
+      "doc": "Optional correlation id, copied from the corresponding request"
     },
     {
       "name": "memberId",
-      "type": "string"
+      "type": "string",
+      "doc": "Member's ID on which behalf the request is made, copied from the corresponding request"
     },
     {
       "name": "response",
@@ -31,7 +37,8 @@
         "net.corda.data.crypto.wire.WirePublicKey",
         "net.corda.data.crypto.wire.WirePublicKeys",
         "net.corda.data.crypto.wire.WireSignatureWithKey"
-      ]
+      ],
+      "doc": "Response's payload, depends on the requested operation"
     }
   ]
 }

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/freshkeys/WireFreshKeysSign.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/freshkeys/WireFreshKeysSign.avsc
@@ -2,21 +2,25 @@
   "type": "record",
   "name": "WireFreshKeysSign",
   "namespace": "net.corda.data.crypto.wire.freshkeys",
+  "doc": "Internal over-the-wire request to sign",
   "fields": [
     {
       "name": "publicKey",
-      "type": "bytes"
+      "type": "bytes",
+      "doc": "It's used to look up the matching private key information and sign the data"
     },
     {
       "name": "signatureSpec",
       "type": [
         "null",
         "net.corda.data.crypto.wire.WireSignatureSpec"
-      ]
+      ],
+      "doc": "If provided than it overrides the default signature scheme, otherwise the default scheme is used"
     },
     {
       "name": "bytes",
-      "type": "bytes"
+      "type": "bytes",
+      "doc": "The data to sign"
     }
   ]
 }

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/signing/WireSigningFindPublicKey.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/signing/WireSigningFindPublicKey.avsc
@@ -2,6 +2,7 @@
   "type": "record",
   "name": "WireSigningFindPublicKey",
   "namespace": "net.corda.data.crypto.wire.signing",
+  "doc": "Internal over-the-wire request to find public matching the alias, if the key is not found it returns null",
   "fields": [
     {
       "name": "alias",

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/signing/WireSigningGenerateKeyPair.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/signing/WireSigningGenerateKeyPair.avsc
@@ -2,10 +2,12 @@
   "type": "record",
   "name": "WireSigningGenerateKeyPair",
   "namespace": "net.corda.data.crypto.wire.signing",
+  "doc": "Internal over-the-wire request to generate new key pair",
   "fields": [
     {
       "name": "alias",
-      "type": "string"
+      "type": "string",
+      "doc": "Alias to be associated with the key pair"
     }
   ]
 }

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/signing/WireSigningGetSupportedSchemes.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/signing/WireSigningGetSupportedSchemes.avsc
@@ -2,6 +2,7 @@
   "type": "record",
   "name": "WireSigningGetSupportedSchemes",
   "namespace": "net.corda.data.crypto.wire.signing",
+  "doc": "Internal over-the-wire request which signature schemes are supported by the service instance",
   "fields": [
   ]
 }

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/signing/WireSigningRequest.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/signing/WireSigningRequest.avsc
@@ -2,23 +2,31 @@
   "type": "record",
   "name": "WireSigningRequest",
   "namespace": "net.corda.data.crypto.wire.signing",
+  "doc": "Internal over-the-wire request for crypto's [SigningService], the service operations are multiplexed",
   "fields": [
     {
       "name": "requestingComponent",
-      "type": "string"
+      "type": "string",
+      "doc": "Name of the component which requested the operation"
     },
     {
       "name": "requestTimestamp",
       "type": "long",
-      "logicalType": "timestamp-millis"
+      "logicalType": "timestamp-millis",
+      "doc": "Time ([Instant]) in milliseconds of the request"
     },
     {
       "name": "correlation",
-      "type": "string"
+      "type": [
+        "null",
+        "string"
+      ],
+      "doc": "Optional correlation id"
     },
     {
       "name": "memberId",
-      "type": "string"
+      "type": "string",
+      "doc": "Member's ID on which behalf the request is made"
     },
     {
       "name": "request",
@@ -27,7 +35,8 @@
         "WireSigningGenerateKeyPair",
         "WireSigningSign",
         "WireSigningGetSupportedSchemes"
-      ]
+      ],
+      "doc": "Request's payload, depends on the requested operation"
     }
   ]
 }

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/signing/WireSigningResponse.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/signing/WireSigningResponse.avsc
@@ -2,28 +2,34 @@
   "type": "record",
   "name": "WireSigningResponse",
   "namespace": "net.corda.data.crypto.wire.signing",
+  "doc": "Internal over-the-wire response for crypto's [SigningService] operations",
   "fields": [
     {
       "name": "requestingComponent",
-      "type": "string"
+      "type": "string",
+      "doc": "Name of the component which requested the operation, copied from the corresponding request"
     },
     {
       "name": "requestTimestamp",
       "type": "long",
-      "logicalType": "timestamp-millis"
+      "logicalType": "timestamp-millis",
+      "doc": "Time ([Instant]) in milliseconds of the request, copied from the corresponding request"
     },
     {
       "name": "responseTimestamp",
       "type": "long",
-      "logicalType": "timestamp-millis"
+      "logicalType": "timestamp-millis",
+      "doc": "Time ([Instant]) in milliseconds of the response"
     },
     {
       "name": "correlation",
-      "type": "string"
+      "type": "string",
+      "doc": "Optional correlation id, copied from the corresponding request"
     },
     {
       "name": "memberId",
-      "type": "string"
+      "type": "string",
+      "doc": "Member's ID on which behalf the request is made, copied from the corresponding request"
     },
     {
       "name": "response",
@@ -33,7 +39,8 @@
         "net.corda.data.crypto.wire.WireSignature",
         "net.corda.data.crypto.wire.WireSignatureWithKey",
         "net.corda.data.crypto.wire.WireSignatureSchemes"
-      ]
+      ],
+      "doc": "Response's payload, depends on the requested operation"
     }
   ]
 }

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/signing/WireSigningSign.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/signing/WireSigningSign.avsc
@@ -2,31 +2,36 @@
   "type": "record",
   "name": "WireSigningSign",
   "namespace": "net.corda.data.crypto.wire.signing",
+  "doc": "Internal over-the-wire request to sign, either [publicKey] or alias must be specified",
   "fields": [
     {
       "name": "publicKey",
       "type": [
         "null",
         "bytes"
-      ]
+      ],
+      "doc": "If provided then it's used to look up the matching private key information and sign the data"
     },
     {
       "name": "alias",
       "type": [
         "null",
         "string"
-      ]
+      ],
+      "doc": "If provided then it's used to look up the matching private key information and sign the data"
     },
     {
       "name": "signatureSpec",
       "type": [
         "null",
         "net.corda.data.crypto.wire.WireSignatureSpec"
-      ]
+      ],
+      "doc": "If provided than it overrides the default signature scheme, otherwise the default scheme is used"
     },
     {
       "name": "bytes",
-      "type": "bytes"
+      "type": "bytes",
+      "doc": "The data to sign"
     }
   ]
 }


### PR DESCRIPTION
The AVRO models are added to support RCP-over-bus for:

```
interface FreshKeySigningService {
    fun freshKey(): PublicKey
    fun freshKey(externalId: UUID): PublicKey
    fun sign(publicKey: PublicKey, data: ByteArray): DigitalSignature.WithKey
    fun sign(publicKey: PublicKey, signatureSpec: SignatureSpec, data: ByteArray): DigitalSignature.WithKey
    fun ensureWrappingKey()
    fun filterMyKeys(candidateKeys: Iterable<PublicKey>): Iterable<PublicKey>
}

interface SigningService {
    val supportedSchemes: Array<SignatureScheme>
    fun findPublicKey(alias: String): PublicKey?
    fun generateKeyPair(alias: String): PublicKey
    fun sign(publicKey: PublicKey, data: ByteArray): DigitalSignature.WithKey
    fun sign(publicKey: PublicKey, signatureSpec: SignatureSpec, data: ByteArray): DigitalSignature.WithKey
    fun sign(alias: String, data: ByteArray): ByteArray
    fun sign(alias: String, signatureSpec: SignatureSpec, data: ByteArray): ByteArray
}
```

Each service will have it's own RPC subscription with the operation multiplexing where separate request objects correspond to a group of operation.