### PR TITLE
CORE-2025: Add ledger to the corda-api platform.

### DIFF
--- a/corda-api/build.gradle
+++ b/corda-api/build.gradle
@@ -12,6 +12,7 @@ dependencies {
         api project(':crypto')
         api project(':data:avro-schema')
         api project(':data:topic-schema')
+        api project(':ledger')
         api project(':packaging')
         api project(':persistence')
         api project(':serialization')

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ kotlinVersion = 1.4.21
 kotlin.stdlib.default.dependency = false
 
 # at the moment, required for packaging to build test cpks for unit tests
-gradlePluginsVersion = 6.0.0-DevPreview-RC04
+gradlePluginsVersion = 6.0.0-DevPreview-RC06
 cordaDevPreviewVersion = 5.0.0-DevPreview-RC04
 
 

--- a/ledger/build.gradle
+++ b/ledger/build.gradle
@@ -7,14 +7,17 @@ plugins {
 description 'Corda Ledger'
 
 dependencies {
-    implementation "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlinVersion"
-    implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi:$kotlinVersion"
-    // Concluded this is the one acceptable dependency in addition to kotlin.
-    implementation "org.slf4j:slf4j-api:$slf4jVersion"
-    implementation("org.hibernate:hibernate-osgi:$hibernateVersion") {
+    api platform(project(':corda-api'))
+
+    api 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    api 'javax.persistence:javax.persistence-api'
+    api 'org.slf4j:slf4j-api'
+
+    compileOnly 'org.osgi:osgi.annotation'
+    // We only need Hibernate for its annotations.
+    compileOnly("org.hibernate:hibernate-osgi:$hibernateVersion") {
         exclude group: 'org.osgi'
     }
-    api "javax.persistence:javax.persistence-api:$javaxPersistenceApiVersion"
 
     implementation project(":crypto")
     implementation project(":serialization")
@@ -24,7 +27,4 @@ dependencies {
     testImplementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
     testImplementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
     testImplementation "org.assertj:assertj-core:$assertjVersion"
-
-    compileOnly "org.osgi:osgi.core:$osgiVersion"
-    compileOnly "org.osgi:osgi.annotation:$osgiVersion"
 }

--- a/ledger/src/main/kotlin/net/corda/v5/ledger/UniqueIdentifier.kt
+++ b/ledger/src/main/kotlin/net/corda/v5/ledger/UniqueIdentifier.kt
@@ -2,7 +2,7 @@ package net.corda.v5.ledger
 
 import net.corda.v5.base.annotations.CordaSerializable
 import net.corda.v5.base.annotations.VisibleForTesting
-import java.util.*
+import java.util.UUID
 
 /**
  * This class provides a truly unique identifier of a trade, state, or other business object, bound to any existing

--- a/ledger/src/main/kotlin/net/corda/v5/ledger/contracts/Amount.kt
+++ b/ledger/src/main/kotlin/net/corda/v5/ledger/contracts/Amount.kt
@@ -4,7 +4,7 @@ import net.corda.v5.base.annotations.CordaSerializable
 import net.corda.v5.base.util.exactAdd
 import java.math.BigDecimal
 import java.math.RoundingMode
-import java.util.*
+import java.util.Currency
 
 /**
  * This interface is used by [Amount] to determine the conversion ratio from

--- a/ledger/src/main/kotlin/net/corda/v5/ledger/services/vault/events/VaultStateEvent.kt
+++ b/ledger/src/main/kotlin/net/corda/v5/ledger/services/vault/events/VaultStateEvent.kt
@@ -1,10 +1,10 @@
 package net.corda.v5.ledger.services.vault.events
 
+import net.corda.v5.base.annotations.DoNotImplement
 import net.corda.v5.ledger.contracts.ContractState
 import net.corda.v5.ledger.contracts.StateAndRef
 import net.corda.v5.ledger.services.vault.VaultEventType
 import java.time.Instant
-import net.corda.v5.base.annotations.DoNotImplement
 
 /**
  * [VaultStateEvent] contains information about state changes to the vault.

--- a/ledger/src/main/kotlin/net/corda/v5/ledger/services/vault/events/VaultStateEventService.kt
+++ b/ledger/src/main/kotlin/net/corda/v5/ledger/services/vault/events/VaultStateEventService.kt
@@ -2,12 +2,12 @@ package net.corda.v5.ledger.services.vault.events
 
 import net.corda.v5.application.injection.CordaServiceInjectable
 import net.corda.v5.application.services.CordaService
+import net.corda.v5.base.annotations.DoNotImplement
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.base.stream.DurableCursor
 import net.corda.v5.base.stream.CursorException
 import net.corda.v5.ledger.contracts.ContractState
 import java.util.function.BiConsumer
-import net.corda.v5.base.annotations.DoNotImplement
 
 /**
  * [VaultStateEventService] allows [CordaService]s to subscribe to vault state events triggered by the recording of [ContractState]s to the


### PR DESCRIPTION
Add the `ledger` as a new constraint in the `corda-api` platform. This also allows us to use the platform's versions of its component dependencies.

Also:
- Demote Hibernate to a `compileOnly` dependency because we are only interested in applying some of its annotations.
- Remove unused dependency on `osgi.core`
- Replace wildcard `java.util.*` imports.
- Upgrade Corda Gradle plugins.