### PR TITLE
NOTICK: Configure all tests to create temporary files in build directory.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -197,6 +197,11 @@ subprojects {
         // Added to support junit5 tests
         tasks.withType(Test).configureEach {
             useJUnitPlatform()
+
+            doFirst {
+                // Create all temporary files within the build directory.
+                systemProperty 'java.io.tmpdir', buildDir.absolutePath
+            }
         }
 
         tasks.register('compileAll') { task ->

--- a/packaging/build.gradle
+++ b/packaging/build.gradle
@@ -70,7 +70,6 @@ tasks.named('test', Test) {
 
     doFirst {
         systemProperties([
-            'java.io.tmpdir' : buildDir.absolutePath,
             'net.corda.dev.cert' : certificateProvider.get(),
             'net.corda.packaging.test.workflow.libs' : configurations.workflowLibs.collect { it.toURI() }.join(' '),
             'net.corda.flows.cpk' : configurations.flowsCPK.singleFile.toURI(),


### PR DESCRIPTION
Prevent all tests from creating temporary files outside of the build tree.