### PR TITLE
CORE-2625: Upgrade to Kotlin 1.4.32.

### DIFF
--- a/application/src/main/kotlin/net/corda/v5/application/cordapp/CordappInfo.kt
+++ b/application/src/main/kotlin/net/corda/v5/application/cordapp/CordappInfo.kt
@@ -5,15 +5,15 @@ import net.corda.v5.crypto.SecureHash
 /**
  * A [CordappInfo] describes a single CorDapp currently installed on the node
  *
- * @param type A description of what sort of CorDapp this is - either a contract, workflow, or a combination.
- * @param name The name of the JAR file that defines the CorDapp
- * @param shortName The name of the CorDapp
- * @param minimumPlatformVersion The minimum platform version the node must be at for the CorDapp to run
- * @param targetPlatformVersion The target platform version this CorDapp has been tested against
- * @param version The version of this CorDapp
- * @param vendor The vendor of this CorDapp
- * @param licence The name of the licence this CorDapp is released under
- * @param jarHash The hash of the JAR file that defines this CorDapp
+ * @property type A description of what sort of CorDapp this is - either a contract, workflow, or a combination.
+ * @property name The name of the JAR file that defines the CorDapp
+ * @property shortName The name of the CorDapp
+ * @property minimumPlatformVersion The minimum platform version the node must be at for the CorDapp to run
+ * @property targetPlatformVersion The target platform version this CorDapp has been tested against
+ * @property version The version of this CorDapp
+ * @property vendor The vendor of this CorDapp
+ * @property licence The name of the licence this CorDapp is released under
+ * @property jarHash The hash of the JAR file that defines this CorDapp
  */
 interface CordappInfo {
     val type: String

--- a/application/src/main/kotlin/net/corda/v5/application/crypto/DigitalSignatureAndMeta.kt
+++ b/application/src/main/kotlin/net/corda/v5/application/crypto/DigitalSignatureAndMeta.kt
@@ -4,7 +4,6 @@ import net.corda.v5.base.annotations.CordaSerializable
 import net.corda.v5.crypto.DigitalSignature
 import net.corda.v5.crypto.PartialMerkleTree
 import java.security.PublicKey
-import java.util.Arrays
 
 /**
  * A wrapper over the signature output accompanied by signer's public key and signature metadata.
@@ -33,7 +32,7 @@ class DigitalSignatureAndMeta(
         if (this === other) return true
         if (other !is DigitalSignatureAndMeta) return false
 
-        return (Arrays.equals(bytes, other.bytes)
+        return (bytes.contentEquals(other.bytes)
                 && by == other.by
                 && signatureMetadata == other.signatureMetadata)
     }

--- a/application/src/main/kotlin/net/corda/v5/application/flows/FlowId.kt
+++ b/application/src/main/kotlin/net/corda/v5/application/flows/FlowId.kt
@@ -1,7 +1,7 @@
 package net.corda.v5.application.flows
 
 import net.corda.v5.base.annotations.CordaSerializable
-import java.util.*
+import java.util.UUID
 
 /**
  * A unique identifier for a single top level flow instance, valid across node restarts. Note that a single run always

--- a/application/src/main/kotlin/net/corda/v5/application/flows/IdentifiableException.kt
+++ b/application/src/main/kotlin/net/corda/v5/application/flows/IdentifiableException.kt
@@ -1,4 +1,4 @@
-package net.corda.v5.application.flows;
+package net.corda.v5.application.flows
 
 /**
  * An exception that may be identified with an ID. If an exception originates in a counter-flow this ID will be

--- a/application/src/main/kotlin/net/corda/v5/application/flows/InitiatedBy.kt
+++ b/application/src/main/kotlin/net/corda/v5/application/flows/InitiatedBy.kt
@@ -5,7 +5,7 @@ import kotlin.reflect.KClass
 
 /**
  * This annotation is required by any [FlowLogic] that is designed to be initiated by a counterparty flow. The class must
- * have at least a constructor which takes in a single [net.corda.core.identity.Party] parameter which represents the
+ * have at least a constructor which takes in a single [net.corda.v5.application.identity.Party] parameter which represents the
  * initiating counterparty. The [FlowLogic] that does the initiating is specified by the [value] property and itself must be annotated
  * with [InitiatingFlow].
  *

--- a/application/src/main/kotlin/net/corda/v5/application/flows/JsonConstructor.kt
+++ b/application/src/main/kotlin/net/corda/v5/application/flows/JsonConstructor.kt
@@ -2,8 +2,8 @@ package net.corda.v5.application.flows
 
 /**
  * Marks a constructor of a flow indicating that it can be instantiated from a JSON String.
- * Flows that are available to start via the RPC service with [net.corda.client.rpc.flow.RpcStartFlowRequestParameters] must have a
- * constructor with this annotation.
+ * Flows that are available to start via the RPC service with [RpcStartFlowRequestParameters]
+ * must have a constructor with this annotation.
  */
 @Target(AnnotationTarget.CONSTRUCTOR)
 @Retention(AnnotationRetention.RUNTIME)

--- a/application/src/main/kotlin/net/corda/v5/application/flows/StartableByService.kt
+++ b/application/src/main/kotlin/net/corda/v5/application/flows/StartableByService.kt
@@ -3,8 +3,9 @@ package net.corda.v5.application.flows
 import kotlin.annotation.AnnotationTarget.CLASS
 
 /**
- * Any [Flow] which is to be started by the [FlowStarterService] interface from within a [CordaService] must have this annotation. If it's
- * missing the flow will not be allowed to start and an exception will be thrown.
+ * Any [Flow] which is to be started by the [FlowStarterService][net.corda.v5.application.services.flows]
+ * interface from within a [CordaService][net.corda.v5.application.services.CordaService] must have this
+ * annotation. If it's missing the flow will not be allowed to start and an exception will be thrown.
  */
 @Target(CLASS)
 @MustBeDocumented

--- a/application/src/main/kotlin/net/corda/v5/application/flows/flowservices/FlowAuditor.kt
+++ b/application/src/main/kotlin/net/corda/v5/application/flows/flowservices/FlowAuditor.kt
@@ -9,7 +9,7 @@ import net.corda.v5.base.annotations.Suspendable
 interface FlowAuditor : CordaFlowInjectable {
     /**
      * Flows can call this method to ensure that the active FlowInitiator is authorised for a particular action.
-     * This provides fine grained control over application level permissions, when RPC control over starting the flow is insufficient,
+     * This provides fine-grained control over application level permissions, when RPC control over starting the flow is insufficient,
      * or the permission is runtime dependent upon the choices made inside long lived flow code.
      * For example some users may have restricted limits on how much cash they can transfer, or whether they can change certain fields.
      * An audit event is always recorded whenever this method is used.

--- a/application/src/main/kotlin/net/corda/v5/application/flows/flowservices/FlowEngine.kt
+++ b/application/src/main/kotlin/net/corda/v5/application/flows/flowservices/FlowEngine.kt
@@ -14,7 +14,7 @@ import java.time.Duration
 @DoNotImplement
 interface FlowEngine : CordaFlowInjectable {
     /**
-     * Returns a wrapped [java.util.UUID] object that identifies this flow or it's top level instance (i.e. subflows have the same
+     * Returns a wrapped [UUID][java.util.UUID] object that identifies this flow or it's top level instance (i.e. subflows have the same
      * identifier as their parents).
      */
     val flowId: FlowId

--- a/application/src/main/kotlin/net/corda/v5/application/flows/flowservices/FlowMessaging.kt
+++ b/application/src/main/kotlin/net/corda/v5/application/flows/flowservices/FlowMessaging.kt
@@ -11,7 +11,7 @@ import net.corda.v5.base.annotations.Suspendable
 @DoNotImplement
 interface FlowMessaging : CordaFlowInjectable {
     /**
-     * Creates a communication session with [destination]. Subsequently you may send/receive using this session object. How the messaging
+     * Creates a communication session with [destination]. Subsequently, you may send/receive using this session object. How the messaging
      * is routed depends on the [Destination] type, including whether this call does any initial communication.
      */
     @Suspendable

--- a/application/src/main/kotlin/net/corda/v5/application/injection/CordaInject.kt
+++ b/application/src/main/kotlin/net/corda/v5/application/injection/CordaInject.kt
@@ -3,15 +3,16 @@ package net.corda.v5.application.injection
 import kotlin.annotation.AnnotationTarget.FIELD
 
 /**
- * This annotation can be used with [Flow] and [CordaService] to indicate which dependencies should be injected.
+ * This annotation can be used with [Flow][net.corda.v5.application.flows.Flow] and
+ * [CordaService][net.corda.v5.application.services.CordaService] to indicate which dependencies should be injected.
  */
 @Target(FIELD)
 @MustBeDocumented
 annotation class CordaInject
 
 /**
- * This annotation can be used with [CordaService] to indicate which dependencies should be injected before starting
- * the service.
+ * This annotation can be used with [CordaService][net.corda.v5.application.services.CordaService]
+ * to indicate which dependencies should be injected before starting the service.
  * Combined with the corda service lifecycle support, this allows starting a service to depend on another service. It
  * is not be possible to inject dependencies for use within a service constructor, so in order to use a service to start
  * another service it must be injected before the service start lifecycle event is distributed using this annotation.

--- a/application/src/main/kotlin/net/corda/v5/application/injection/CordaServiceInjectable.kt
+++ b/application/src/main/kotlin/net/corda/v5/application/injection/CordaServiceInjectable.kt
@@ -1,7 +1,8 @@
 package net.corda.v5.application.injection
 
 /**
- * Interfaces that extend [CordaServiceInjectable] can be injected into [net.corda.v5.application.services.CordaService]s
- * or [net.corda.v5.ledger.notary.NotaryService] using [CordaInject].
+ * Interfaces that extend [CordaServiceInjectable] can be injected into
+ * [CordaService][net.corda.v5.application.services.CordaService]s
+ * or [NotaryService][net.corda.v5.ledger.notary.NotaryService] using [CordaInject].
  */
 interface CordaServiceInjectable

--- a/application/src/main/kotlin/net/corda/v5/application/node/NodeDiagnosticInfo.kt
+++ b/application/src/main/kotlin/net/corda/v5/application/node/NodeDiagnosticInfo.kt
@@ -4,14 +4,14 @@ import net.corda.v5.application.cordapp.CordappInfo
 
 /**
  * A [NodeDiagnosticInfo] holds information about the current node version.
- * @param version The current node version string, e.g. 4.3, 4.4-SNAPSHOT. Note that this string is effectively freeform, and so should only
+ * @property version The current node version string, e.g. 4.3, 4.4-SNAPSHOT. Note that this string is effectively freeform, and so should only
  *                be used for providing diagnostic information. It should not be used to make functionality decisions (the platformVersion
  *                is a better fit for this).
- * @param revision The git commit hash this node was built from
- * @param platformVersion The platform version of this node. This number represents a released API version, and should be used to make
+ * @property revision The git commit hash this node was built from
+ * @property platformVersion The platform version of this node. This number represents a released API version, and should be used to make
  *                        functionality decisions (e.g. enabling an app feature only if an underlying platform feature exists)
- * @param vendor The vendor of this node
- * @param cordapps A list of CorDapps currently installed on this node
+ * @property vendor The vendor of this node
+ * @property cordapps A list of CorDapps currently installed on this node
  */
 interface NodeDiagnosticInfo {
     val version: String

--- a/application/src/main/kotlin/net/corda/v5/application/services/diagnostics/NodeVersionInfo.kt
+++ b/application/src/main/kotlin/net/corda/v5/application/services/diagnostics/NodeVersionInfo.kt
@@ -4,10 +4,10 @@ package net.corda.v5.application.services.diagnostics
  * Version info about the node. Note that this data should be used for diagnostics purposes only - it is unsafe to rely on this for
  * functional decisions.
  *
- * @param releaseVersion The release version string of the node, e.g. 4.3, 4.4-SNAPSHOT.
- * @param revision The git commit hash this node was built from
- * @param platformVersion The platform version of this node, representing the released API version.
- * @param vendor The vendor of this node
+ * @property releaseVersion The release version string of the node, e.g. 4.3, 4.4-SNAPSHOT.
+ * @property revision The git commit hash this node was built from
+ * @property platformVersion The platform version of this node, representing the released API version.
+ * @property vendor The vendor of this node
  */
 interface NodeVersionInfo {
     val releaseVersion: String

--- a/application/src/main/kotlin/net/corda/v5/application/services/lifecycle/ServiceLifecycleObserver.kt
+++ b/application/src/main/kotlin/net/corda/v5/application/services/lifecycle/ServiceLifecycleObserver.kt
@@ -13,7 +13,7 @@ import net.corda.v5.application.services.CordaService
 interface ServiceLifecycleObserver {
 
     /**
-     * Method allowing allowing a service to react to certain lifecycle events. Default implementation does nothing so services only need to
+     * Method allowing a service to react to certain lifecycle events. Default implementation does nothing so services only need to
      * implement the method if specific behaviour is required.
      *
      * @see ServiceLifecycleEvent

--- a/application/src/test/java/net/corda/v5/application/services/flows/FlowStarterServiceJavaApiTest.java
+++ b/application/src/test/java/net/corda/v5/application/services/flows/FlowStarterServiceJavaApiTest.java
@@ -11,14 +11,16 @@ import static org.mockito.Mockito.when;
 public class FlowStarterServiceJavaApiTest {
 
     private final FlowStarterService flowStarterService = mock(FlowStarterService.class);
-    private final FlowHandle flowHandle = mock(FlowHandle.class);
-    private final Flow flow = mock(Flow.class);
+    @SuppressWarnings("unchecked")
+    private final FlowHandle<? super Object> flowHandle = mock(FlowHandle.class);
+    @SuppressWarnings("unchecked")
+    private final Flow<Object> flow = mock(Flow.class);
 
     @Test
     public void startFlow() {
         when(flowStarterService.startFlow(flow)).thenReturn(flowHandle);
 
-        FlowHandle result = flowStarterService.startFlow(flow);
+        FlowHandle<?> result = flowStarterService.startFlow(flow);
 
         Assertions.assertThat(result).isNotNull();
         Assertions.assertThat(result).isEqualTo(flowHandle);

--- a/base/src/main/kotlin/net/corda/v5/base/types/ByteArrays.kt
+++ b/base/src/main/kotlin/net/corda/v5/base/types/ByteArrays.kt
@@ -5,9 +5,9 @@ package net.corda.v5.base.types
 import net.corda.v5.base.annotations.CordaSerializable
 import java.io.ByteArrayInputStream
 import java.io.OutputStream
-import java.lang.Math.max
-import java.lang.Math.min
 import java.nio.ByteBuffer
+import kotlin.math.max
+import kotlin.math.min
 
 /**
  * An abstraction of a byte array, with offset and size that does no copying of bytes unless asked to.

--- a/base/src/main/kotlin/net/corda/v5/base/util/NetworkHostAndPort.kt
+++ b/base/src/main/kotlin/net/corda/v5/base/util/NetworkHostAndPort.kt
@@ -6,8 +6,8 @@ import java.net.URISyntaxException
 
 /**
  * Tuple of host and port. Use [NetworkHostAndPort.parse] on untrusted data.
- * @param host a hostname or IP address. IPv6 addresses must not be enclosed in square brackets.
- * @param port a valid port number.
+ * @property host a hostname or IP address. IPv6 addresses must not be enclosed in square brackets.
+ * @property port a valid port number.
  */
 @CordaSerializable
 data class NetworkHostAndPort(val host: String, val port: Int) {

--- a/base/src/main/kotlin/net/corda/v5/base/util/UuidGenerator.kt
+++ b/base/src/main/kotlin/net/corda/v5/base/util/UuidGenerator.kt
@@ -1,6 +1,6 @@
 package net.corda.v5.base.util
 
-import java.util.*
+import java.util.UUID
 
 class UuidGenerator {
 

--- a/build.gradle
+++ b/build.gradle
@@ -99,7 +99,7 @@ subprojects {
             // Test libraries -> keep consistent across modules
             testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlinVersion"
             testImplementation "org.mockito:mockito-core:$mockitoVersion"
-            testImplementation("com.nhaarman:mockito-kotlin:$mockitoKotlinVersion") {
+            testImplementation("org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion") {
                 // Excluding mockito-core and adding it implicitly above. This is done to allow the use of the latest version of mockito.
                 exclude group: 'mockito-core'
             }

--- a/cipher-suite/src/main/kotlin/net/corda/v5/cipher/suite/schemes/DigestScheme.kt
+++ b/cipher-suite/src/main/kotlin/net/corda/v5/cipher/suite/schemes/DigestScheme.kt
@@ -2,8 +2,8 @@ package net.corda.v5.cipher.suite.schemes
 
 /**
  * This class is used to define a digital digest scheme.
- * @param algorithmName digest's algorithm name (e.g. SHA-256, SHA-512, etc.).
- * @param providerName the provider's name (e.g. "BC").
+ * @property algorithmName digest's algorithm name (e.g. SHA-256, SHA-512, etc.).
+ * @property providerName the provider's name (e.g. "BC").
  */
 data class DigestScheme(val algorithmName: String, val providerName: String) {
     init {

--- a/cipher-suite/src/main/kotlin/net/corda/v5/cipher/suite/schemes/SignatureScheme.kt
+++ b/cipher-suite/src/main/kotlin/net/corda/v5/cipher/suite/schemes/SignatureScheme.kt
@@ -5,17 +5,17 @@ import java.security.spec.AlgorithmParameterSpec
 
 /**
  * This class is used to define a digital key scheme.
- * @param codeName unique code name for this key scheme (e.g. CORDA.RSA, CORDA.ECDSA.SECP256K1, CORDA.ECDSA_SECP256R1,
+ * @property codeName unique code name for this key scheme (e.g. CORDA.RSA, CORDA.ECDSA.SECP256K1, CORDA.ECDSA_SECP256R1,
  * CORDA.EDDSA.ED25519, CORDA.SPHINCS-256).
- * @param algorithmOIDs ASN.1 algorithm identifiers for keys of the signature which are used to match keys to their schemes.
+ * @property algorithmOIDs ASN.1 algorithm identifiers for keys of the signature which are used to match keys to their schemes.
  * There must be at least one defined.
- * @param providerName the provider's name (e.g. "BC").
- * @param algorithmName which signature algorithm is used (e.g. RSA, ECDSA. EdDSA, SPHINCS-256).
- * @param algSpec parameter specs for the underlying algorithm. Note that RSA is defined by the key size rather than algSpec.
+ * @property providerName the provider's name (e.g. "BC").
+ * @property algorithmName which signature algorithm is used (e.g. RSA, ECDSA. EdDSA, SPHINCS-256).
+ * @property algSpec parameter specs for the underlying algorithm. Note that RSA is defined by the key size rather than algSpec.
  * eg. ECGenParameterSpec("secp256k1").
- * @param keySize the private key size (currently used for RSA only), it's used to initialize the key generator if the [algSpec] is not specified,
+ * @property keySize the private key size (currently used for RSA only), it's used to initialize the key generator if the [algSpec] is not specified,
  * if [algSpec] and [keySize] are bth null then default initialization is used.
- * @param signatureSpec the signature scheme
+ * @property signatureSpec the signature scheme
  */
 data class SignatureScheme(
     val codeName: String,

--- a/cipher-suite/src/main/kotlin/net/corda/v5/cipher/suite/schemes/SignatureSchemeTemplate.kt
+++ b/cipher-suite/src/main/kotlin/net/corda/v5/cipher/suite/schemes/SignatureSchemeTemplate.kt
@@ -5,16 +5,16 @@ import java.security.spec.AlgorithmParameterSpec
 
 /**
  * This class is used to define a digital key scheme template.
- * @param codeName unique code name for this key scheme (e.g. CORDA.RSA, CORDA.ECDSA.SECP256K1, CORDA.ECDSA_SECP256R1,
+ * @property codeName unique code name for this key scheme (e.g. CORDA.RSA, CORDA.ECDSA.SECP256K1, CORDA.ECDSA_SECP256R1,
  * CORDA.EDDSA.ED25519, CORDA.SPHINCS-256).
- * @param algorithmOIDs ASN.1 algorithm identifiers for keys of the signature which are used to match keys to their schemes.
+ * @property algorithmOIDs ASN.1 algorithm identifiers for keys of the signature which are used to match keys to their schemes.
  * There must be at least one defined.
- * @param algorithmName which signature algorithm is used (e.g. RSA, ECDSA. EdDSA, SPHINCS-256).
- * @param algSpec parameter specs for the underlying algorithm. Note that RSA is defined by the key size rather than algSpec.
+ * @property algorithmName which signature algorithm is used (e.g. RSA, ECDSA. EdDSA, SPHINCS-256).
+ * @property algSpec parameter specs for the underlying algorithm. Note that RSA is defined by the key size rather than algSpec.
  * eg. ECGenParameterSpec("secp256k1").
- * @param keySize the private key size (currently used for RSA only), it's used to initialize the key generator if the [algSpec] is not specified,
+ * @property keySize the private key size (currently used for RSA only), it's used to initialize the key generator if the [algSpec] is not specified,
  * if [algSpec] and [keySize] are bth null then default initialization is used.
- * @param signatureSpec the signature scheme
+ * @property signatureSpec the signature scheme
  */
 @Suppress("LongParameterList")
 class SignatureSchemeTemplate(

--- a/cipher-suite/src/main/kotlin/net/corda/v5/cipher/suite/schemes/SignatureSpec.kt
+++ b/cipher-suite/src/main/kotlin/net/corda/v5/cipher/suite/schemes/SignatureSpec.kt
@@ -3,12 +3,11 @@ package net.corda.v5.cipher.suite.schemes
 import net.corda.v5.crypto.DigestAlgorithmName
 import net.corda.v5.crypto.DigestService
 import org.bouncycastle.asn1.x509.AlgorithmIdentifier
-import java.security.Signature
 
 /**
  * This class is used to define a digital signature scheme.
- * @param signatureName a signature-scheme name as required to create [Signature] objects (e.g. "SHA256withECDSA")
- * @param customDigestName a digest algorithm name, set to non null value if the hash should be precalculated before passing
+ * @property signatureName a signature-scheme name as required to create [Signature][java.security.Signature] objects (e.g. "SHA256withECDSA")
+ * @property customDigestName a digest algorithm name, set to non null value if the hash should be precalculated before passing
  * to the provider (e.g. "SHA512"), note that the signatureName should not contain the digest (e.g. "NONEwithECDSA").
  *
  * When used for signing the [signatureName] must match the corresponding [SignatureScheme], e.g. you cannot use "SHA256withECDSA" with "RSA" keys.

--- a/crypto/src/main/kotlin/net/corda/v5/crypto/DigestAlgorithmName.kt
+++ b/crypto/src/main/kotlin/net/corda/v5/crypto/DigestAlgorithmName.kt
@@ -5,7 +5,7 @@ import net.corda.v5.base.annotations.CordaSerializable
 /**
  * The digest algorithm name. This class is to be used in Corda hashing API.
  *
- * @param name The name of the digest algorithm to be used for the instance.
+ * @property name The name of the digest algorithm to be used for the instance.
  */
 @CordaSerializable
 data class DigestAlgorithmName(val name: String) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,12 +10,12 @@ cordaProductVersion = 5.0.0
 cordaApiRevision = 8
 
 # Main
-kotlinVersion = 1.4.21
+kotlinVersion = 1.4.32
 kotlin.stdlib.default.dependency = false
 
 # at the moment, required for packaging to build test cpks for unit tests
-gradlePluginsVersion = 6.0.0-DevPreview-RC06
-cordaDevPreviewVersion = 5.0.0-DevPreview-RC04
+gradlePluginsVersion = 6.0.0-DevPreview-RC07
+cordaDevPreviewVersion = 5.0.0-DevPreview-RC06
 
 
 # License
@@ -61,7 +61,7 @@ typesafeConfigVersion = 1.4.1
 assertjVersion = 3.12.2
 junitVersion = 5.7.2
 mockitoVersion = 2.28.2
-mockitoKotlinVersion = 1.6.0
+mockitoKotlinVersion = 3.2.0
 
 # OSGi
 bndVersion = 5.3.0

--- a/ledger/src/main/kotlin/net/corda/v5/ledger/contracts/Contracts.kt
+++ b/ledger/src/main/kotlin/net/corda/v5/ledger/contracts/Contracts.kt
@@ -9,11 +9,11 @@ typealias ContractClassName = String
 
 /**
  * Implemented by a program that implements business logic on the shared ledger. All participants run this code for
- * every [net.corda.core.transactions.LedgerTransaction] they see on the network, for every input and output state. All
+ * every [LedgerTransaction][net.corda.v5.ledger.transactions.LedgerTransaction] they see on the network, for every input and output state. All
  * contracts must accept the transaction for it to be accepted: failure of any aborts the entire thing. The time is taken
  * from a trusted time-window attached to the transaction itself i.e. it is NOT necessarily the current time.
  *
- * TODO: Contract serialization is likely to change, so the annotation is likely temporary.
+ * TODO Contract serialization is likely to change, so the annotation is likely temporary.
  */
 @CordaSerializable
 interface Contract {

--- a/ledger/src/main/kotlin/net/corda/v5/ledger/contracts/Issued.kt
+++ b/ledger/src/main/kotlin/net/corda/v5/ledger/contracts/Issued.kt
@@ -5,18 +5,18 @@ import net.corda.v5.base.annotations.CordaSerializable
 
 /**
  * The [Issued] data class holds the details of an on ledger digital asset.
- * In particular it gives the public credentials of the entity that created these digital tokens
+ * In particular, it gives the public credentials of the entity that created these digital tokens
  * and the particular product represented.
  *
  * @param P the class type of product underlying the definition, for example [java.util.Currency].
- * @property issuer The [AbstractParty] details of the entity which issued the asset
- * and a reference blob, which can contain other details related to the token creation e.g. serial number,
- * warehouse location, etc.
+ * @property issuer The [AbstractParty][net.corda.v5.application.identity.AbstractParty] details of the entity
+ * which issued the asset and a reference blob, which can contain other details related to the token creation
+ * e.g. serial number, warehouse location, etc.
  * The issuer is the gatekeeper for creating, or destroying the tokens on the digital ledger and
- * only their [PrivateKey] signature can authorise transactions that do not conserve the total number
+ * only their [PrivateKey][java.security.PrivateKey] signature can authorise transactions that do not conserve the total number
  * of tokens on the ledger.
  * Other identities may own the tokens, but they can only create transactions that conserve the total token count.
- * Typically the issuer is also a well know organisation that can convert digital tokens to external assets
+ * Typically, the issuer is also a well-know organisation that can convert digital tokens to external assets
  * and thus underwrites the digital tokens.
  * Different issuer values may coexist for a particular product, but these cannot be merged.
  * @property product The details of the specific product represented by these digital tokens. The value

--- a/ledger/src/main/kotlin/net/corda/v5/ledger/contracts/States.kt
+++ b/ledger/src/main/kotlin/net/corda/v5/ledger/contracts/States.kt
@@ -93,7 +93,7 @@ data class StateRef(val txhash: SecureHash, val index: Int) {
 /** A StateAndRef is simply a (state, ref) pair. For instance, a vault (which holds available assets) contains these. */
 @CordaSerializable
 data class StateAndRef<out T : ContractState>(val state: TransactionState<T>, val ref: StateRef) {
-    /** For adding [StateAndRef]s as references to a [TransactionBuilder]. */
+    /** For adding [StateAndRef]s as references to a [TransactionBuilder][net.corda.v5.ledger.transactions.TransactionBuilder]. */
     fun referenced() = ReferencedStateAndRef(this)
 }
 

--- a/ledger/src/main/kotlin/net/corda/v5/ledger/contracts/TimeWindow.kt
+++ b/ledger/src/main/kotlin/net/corda/v5/ledger/contracts/TimeWindow.kt
@@ -12,8 +12,9 @@ import java.time.Instant
  * tolerance around it. This is what [TimeWindow] represents. Time windows can be open-ended (i.e. specify only one of
  * [fromTime] and [untilTime]) or they can be fully bounded.
  *
- * [WireTransaction] has an optional time-window property, which if specified, restricts the validity of the transaction
- * to that time-interval as the Consensus Service will not sign it if it's received outside of this window.
+ * [WireTransaction][net.corda.v5.ledger.transactions.WireTransaction] has an optional time-window property, which if
+ * specified, restricts the validity of the transaction to that time-interval as the Consensus Service will not sign
+ * it if it's received outside this window.
  */
 @CordaSerializable
 interface TimeWindow {

--- a/ledger/src/main/kotlin/net/corda/v5/ledger/contracts/TransactionVerificationException.kt
+++ b/ledger/src/main/kotlin/net/corda/v5/ledger/contracts/TransactionVerificationException.kt
@@ -14,7 +14,7 @@ import net.corda.v5.ledger.services.AttachmentId
  * The node asked a remote peer for the transaction identified by [hash] because it is a dependency of a transaction
  * being resolved, but the remote peer would not provide it.
  *
- * @property hash Merkle root of the transaction being resolved, see [net.corda.core.transactions.WireTransaction.id]
+ * @property hash Merkle root of the transaction being resolved, see [WireTransaction.id][net.corda.v5.ledger.transactions.WireTransaction.id]
  */
 open class TransactionResolutionException(val hash: SecureHash, message: String) : FlowException(message) {
 

--- a/ledger/src/main/kotlin/net/corda/v5/ledger/notary/NotaryService.kt
+++ b/ledger/src/main/kotlin/net/corda/v5/ledger/notary/NotaryService.kt
@@ -37,7 +37,7 @@ abstract class NotaryService : SingletonSerializeAsToken {
     abstract fun stop()
 
     /**
-     * Produces a notary service flow which has the corresponding sends and receives as [NotaryClientFlow].
+     * Produces a notary service flow which has the corresponding sends and receives as [NotaryClientFlow][net.corda.systemflows.NotaryClientFlow].
      * @param otherPartySession client [Party] making the request
      */
     abstract fun createServiceFlow(otherPartySession: FlowSession): Flow<Void?>

--- a/ledger/src/main/kotlin/net/corda/v5/ledger/serialization/MissingAttachmentsException.kt
+++ b/ledger/src/main/kotlin/net/corda/v5/ledger/serialization/MissingAttachmentsException.kt
@@ -4,7 +4,7 @@ import net.corda.v5.base.annotations.CordaSerializable
 import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.crypto.SecureHash
 
-/** Thrown during deserialization to indicate that an attachment needed to construct the [WireTransaction] is not found. */
+/** Thrown during deserialization to indicate that an attachment needed to construct the [WireTransaction][net.corda.v5.ledger.transactions.WireTransaction] is not found. */
 @CordaSerializable
 class MissingAttachmentsException(val ids: List<SecureHash>, message: String?) : CordaRuntimeException(message) {
 

--- a/ledger/src/main/kotlin/net/corda/v5/ledger/transactions/SignedTransactionDigest.kt
+++ b/ledger/src/main/kotlin/net/corda/v5/ledger/transactions/SignedTransactionDigest.kt
@@ -10,9 +10,9 @@ import net.corda.v5.crypto.SecureHash
  * Extract of data from [SignedTransaction], primarily to be sensibly represented in JSON
  * Also useful on the client side to inspect what was actually returned as result of the flow
  *
- * @param txId - The hex string of the transaction's ID
- * @param outputStates - The transaction's output states formatted as JSON
- * @param signatures - The Base64-encoded bytes of the transaction's signatures
+ * @property txId - The hex string of the transaction's ID
+ * @property outputStates - The transaction's output states formatted as JSON
+ * @property signatures - The Base64-encoded bytes of the transaction's signatures
  */
 @CordaSerializable
 data class SignedTransactionDigest(val txId: String, val outputStates: List<String>, val signatures: List<String>) : JsonRepresentable {

--- a/ledger/src/main/kotlin/net/corda/v5/ledger/transactions/TraversableTransaction.kt
+++ b/ledger/src/main/kotlin/net/corda/v5/ledger/transactions/TraversableTransaction.kt
@@ -23,19 +23,20 @@ interface TraversableTransaction : CoreTransaction {
     /** Hashes of the ZIP/JAR files that are needed to interpret the contents of this wire transaction. */
     val attachments: List<SecureHash>
 
-    /** Ordered list of ([CommandData], [PublicKey]) pairs that instruct the contracts what to do. */
+    /** Ordered list of ([CommandData][net.corda.v5.ledger.contracts.CommandData], [PublicKey][java.security.PublicKey])
+     * pairs that instruct the contracts what to do. */
     val commands: List<Command<*>>
 
     val timeWindow: TimeWindow?
 
     /**
      * Returns a list of all the component groups that are present in the transaction, excluding the privacySalt,
-     * in the following order (which is the same with the order in [ComponentGroupEnum]:
+     * in the following order (which is the same with the order in [ComponentGroupEnum][net.corda.v5.ledger.contracts.ComponentGroupEnum]:
      * - list of each input that is present
      * - list of each output that is present
      * - list of each command that is present
      * - list of each attachment that is present
-     * - The notary [Party], if present (list with one element)
+     * - The notary [Party][net.corda.v5.application.identity.Party], if present (list with one element)
      * - The time-window of the transaction, if present (list with one element)
      * - list of each reference input that is present
      * - network parameters hash if present

--- a/ledger/src/main/kotlin/net/corda/v5/ledger/transactions/WireTransaction.kt
+++ b/ledger/src/main/kotlin/net/corda/v5/ledger/transactions/WireTransaction.kt
@@ -27,10 +27,10 @@ import java.util.function.Predicate
  * if she is unable to read some of the "optional" component types. We stress that practically, a new type of
  * [WireTransaction] should only be considered compatible if and only if the following rules apply:
  * <p><ul>
- * <li>Component-type ordering is fixed (eg. inputs, then outputs, then commands etc, see [ComponentGroupEnum] for the actual ordering).
+ * <li>Component-type ordering is fixed (eg. inputs, then outputs, then commands etc, see [ComponentGroupEnum][net.corda.v5.ledger.contracts.ComponentGroupEnum] for the actual ordering).
  * <li>Removing a component-type that existed in older wire transaction types is not allowed, because it will affect the Merkle tree structure.
  * <li>Changing the order of existing component types is also not allowed, for the same reason.
- * <li>New component types must be added at the end of the list of [ComponentGroup] and update the [ComponentGroupEnum] with the new type. After a component is added, its ordinal must never change.
+ * <li>New component types must be added at the end of the list of [ComponentGroup] and update the [ComponentGroupEnum][net.corda.v5.ledger.contracts.ComponentGroupEnum] with the new type. After a component is added, its ordinal must never change.
  * <li>A new component type should always be an "optional value", in the sense that lack of its visibility does not change the transaction and contract logic and details. An example of "optional" components could be a transaction summary or some statistics.
  * </ul></p>
  */

--- a/ledger/src/test/java/net/corda/v5/ledger/crypto/TransactionDigestAlgorithmNamesFactoryJavaApiTest.java
+++ b/ledger/src/test/java/net/corda/v5/ledger/crypto/TransactionDigestAlgorithmNamesFactoryJavaApiTest.java
@@ -9,11 +9,11 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static com.nhaarman.mockito_kotlin.MockitoKt.eq;
 import static net.corda.v5.crypto.DigestAlgorithmName.SHA2_256;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mockito.kotlin.MatchersKt.eq;
 
 public class TransactionDigestAlgorithmNamesFactoryJavaApiTest {
 

--- a/ledger/src/test/kotlin/net/corda/v5/ledger/UniqueIdentifierTests.kt
+++ b/ledger/src/test/kotlin/net/corda/v5/ledger/UniqueIdentifierTests.kt
@@ -1,7 +1,7 @@
 package net.corda.v5.ledger
 
 import org.junit.jupiter.api.Test
-import java.util.*
+import java.util.UUID
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 

--- a/ledger/src/test/kotlin/net/corda/v5/ledger/contracts/AttachmentTest.kt
+++ b/ledger/src/test/kotlin/net/corda/v5/ledger/contracts/AttachmentTest.kt
@@ -1,8 +1,8 @@
 package net.corda.v5.ledger.contracts
 
-import com.nhaarman.mockito_kotlin.doAnswer
-import com.nhaarman.mockito_kotlin.spy
-import com.nhaarman.mockito_kotlin.whenever
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.spy
+import org.mockito.kotlin.whenever
 import org.junit.jupiter.api.Test
 import java.io.ByteArrayOutputStream
 import java.io.IOException

--- a/ledger/src/test/kotlin/net/corda/v5/ledger/services/vault/events/VaultStateEventCursorTest.kt
+++ b/ledger/src/test/kotlin/net/corda/v5/ledger/services/vault/events/VaultStateEventCursorTest.kt
@@ -1,7 +1,7 @@
 package net.corda.v5.ledger.services.vault.events
 
-import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.whenever
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 import net.corda.v5.application.identity.AbstractParty
 import net.corda.v5.base.stream.Cursor.PollResult
 import net.corda.v5.base.stream.Cursor.PollResult.PositionedValue
@@ -57,7 +57,7 @@ class VaultStateEventCursorTest {
     @Suppress("UNCHECKED_CAST", "NestedBlockDepth")
     private fun run() {
         while (!Thread.currentThread().isInterrupted) {
-            val result = cursor.poll(50, 5.minutes);
+            val result = cursor.poll(50, 5.minutes)
             if (!result.isEmpty) {
                 for (positionedValue in result.positionedValues) {
                     log.info("Processing value: ${positionedValue.value} at position: ${positionedValue.position}")

--- a/ledger/src/test/kotlin/net/corda/v5/ledger/services/vault/events/VaultStateEventServiceTest.kt
+++ b/ledger/src/test/kotlin/net/corda/v5/ledger/services/vault/events/VaultStateEventServiceTest.kt
@@ -1,8 +1,8 @@
 package net.corda.v5.ledger.services.vault.events
 
-import com.nhaarman.mockito_kotlin.any
-import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.whenever
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 import net.corda.v5.base.stream.DurableCursor
 import net.corda.v5.base.util.contextLogger
 import net.corda.v5.ledger.contracts.ContractState

--- a/ledger/src/test/kotlin/net/corda/v5/ledger/transactions/internalAccessTestHelpers.kt
+++ b/ledger/src/test/kotlin/net/corda/v5/ledger/transactions/internalAccessTestHelpers.kt
@@ -1,9 +1,8 @@
-package net.corda.coretests.internal
+package net.corda.v5.ledger.transactions
 
 import net.corda.v5.crypto.SecureHash
 import net.corda.v5.ledger.contracts.Contract
 import net.corda.v5.ledger.contracts.TransactionVerificationException
-import net.corda.v5.ledger.transactions.WireTransaction
 
 /**
  * A set of functions in core:test that allows testing of core internal classes in the core-tests project.

--- a/packaging/src/main/kotlin/net/corda/packaging/SigningParameters.kt
+++ b/packaging/src/main/kotlin/net/corda/packaging/SigningParameters.kt
@@ -12,9 +12,9 @@ import java.util.zip.ZipFile
 
 /**
  * Parameters for signing a jar file:
- * [keyStore] the keystore containing the private key
- * [keyAlias] alias name of the private key inside [keyStore]
- * [keyPassword] password (if any) for the private key inside the [keyStore]
+ * @property keyStore the keystore containing the private key
+ * @property keyAlias alias name of the private key inside [keyStore]
+ * @property keyPassword password (if any) for the private key inside the [keyStore]
  */
 class SigningParameters(
         val keyStore: KeyStore,

--- a/packaging/src/main/kotlin/net/corda/packaging/VersionComparator.kt
+++ b/packaging/src/main/kotlin/net/corda/packaging/VersionComparator.kt
@@ -1,5 +1,7 @@
 package net.corda.packaging
 
+import kotlin.math.min
+
 class VersionComparator : Comparator<String?> {
     data class Parts(val epoch: String, val version: String, val release: String, val hasRelease: Boolean)
 
@@ -125,8 +127,8 @@ class VersionComparator : Comparator<String?> {
                 if (rc != 0) return rc
 
                 // shrink the remaining string to process
-                remaining1 = remaining1.substring(Math.min(endIdx1, remaining1.length))
-                remaining2 = remaining2.substring(Math.min(endIdx2, remaining2.length))
+                remaining1 = remaining1.substring(min(endIdx1, remaining1.length))
+                remaining2 = remaining2.substring(min(endIdx2, remaining2.length))
             }
 
             // this catches the case where all numeric and alpha segments have

--- a/packaging/src/main/kotlin/net/corda/packaging/internal/ZipTweaker.kt
+++ b/packaging/src/main/kotlin/net/corda/packaging/internal/ZipTweaker.kt
@@ -124,7 +124,7 @@ open class ZipTweaker {
                     Files.move(destination, jarFile, StandardCopyOption.REPLACE_EXISTING)
                 }
             } catch (e: Throwable) {
-                destination.takeIf(Files::exists).let(Files::delete)
+                destination.takeIf(Files::exists)?.let(Files::delete)
                 throw e
             }
         }

--- a/packaging/src/test/kotlin/net/corda/packaging/CpkTests.kt
+++ b/packaging/src/test/kotlin/net/corda/packaging/CpkTests.kt
@@ -376,9 +376,9 @@ class CpkTests {
 
     @Test
     fun `corda-api dependencies are not included in in cpk dependencies`() {
-        Assertions.assertTrue(workflowCpk.dependencies.filter {
+        Assertions.assertTrue(workflowCpk.dependencies.none {
             it == flowsCpk.id
-        }.isEmpty())
+        })
     }
 }
 

--- a/packaging/src/test/kotlin/net/corda/packaging/versioning/VersionComparatorFuzzerTests.kt
+++ b/packaging/src/test/kotlin/net/corda/packaging/versioning/VersionComparatorFuzzerTests.kt
@@ -22,7 +22,7 @@ class VersionComparatorFuzzerTests {
         private fun randomAlpha(): String = randomChars(Random.nextInt(1, 10), alphaPool)
 
         private fun randomChars(length: Int, charPool: List<Char>): String = (1..length)
-            .map { kotlin.random.Random.nextInt(0, charPool.size) }
+            .map { Random.nextInt(0, charPool.size) }
             .map(charPool::get)
             .joinToString("")
 

--- a/packaging/test/contract-cpk/build.gradle
+++ b/packaging/test/contract-cpk/build.gradle
@@ -2,13 +2,11 @@ plugins {
     id 'org.jetbrains.kotlin.jvm'
     id 'net.corda.plugins.cordapp-cpk'
 }
-// compile(group: 'net.corda', name: 'corda-ledger', version: '5.0.0-DevPreview-RC02')
-dependencies {
-    cordaProvided project(":application")
-    // TODO:  using corda5 dev preview to build a cpk for the packaging unit tests, these libs aren't in corda-api yet
-    cordaProvided("net.corda:corda-ledger:$cordaDevPreviewVersion")
 
-    implementation group: 'org.jetbrains.kotlin', name: 'kotlin-osgi-bundle', version: kotlinVersion
+dependencies {
+    cordaProvided project(':application')
+    cordaProvided project(':ledger')
+    cordaProvided "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlinVersion"
 }
 
 tasks.named('jar', Jar) {

--- a/packaging/test/contract-cpk/src/main/java/net/corda/packaging/test/contract/package-info.java
+++ b/packaging/test/contract-cpk/src/main/java/net/corda/packaging/test/contract/package-info.java
@@ -1,5 +1,0 @@
-@Export
-package net.corda.packaging.test.contract;
-
-import org.osgi.annotation.bundle.Export;
-

--- a/packaging/test/workflow-cpk/build.gradle
+++ b/packaging/test/workflow-cpk/build.gradle
@@ -9,11 +9,11 @@ configurations {
 }
 
 dependencies {
-    cordaProvided project(":application")
+    cordaProvided project(':application')
+    cordaProvided project(':ledger')
+    cordaProvided project(':crypto')
     // TODO:  using corda5 dev preview to build a cpk for the packaging unit tests, these libs aren't in corda-api yet
-    cordaProvided("net.corda:corda-ledger:$cordaDevPreviewVersion")
-    cordaProvided("net.corda:corda-crypto-api:$cordaDevPreviewVersion")
-    cordapp("net.corda:corda-flows:$cordaDevPreviewVersion")
+    cordapp "net.corda:corda-flows:$cordaDevPreviewVersion"
 
     cordapp project(':packaging:test:contract-cpk')
 

--- a/packaging/test/workflow-cpk/src/main/java/net/corda/packaging/test/workflow/package-info.java
+++ b/packaging/test/workflow-cpk/src/main/java/net/corda/packaging/test/workflow/package-info.java
@@ -1,5 +1,0 @@
-@Export
-package net.corda.packaging.test.workflow;
-
-import org.osgi.annotation.bundle.Export;
-

--- a/persistence/src/main/kotlin/net/corda/v5/persistence/MappedSchema.kt
+++ b/persistence/src/main/kotlin/net/corda/v5/persistence/MappedSchema.kt
@@ -5,8 +5,8 @@ package net.corda.v5.persistence
  * also list the classes that may be used in the generated object graph in order to configure the ORM tool.
  *
  * @param schemaFamily A class to fully qualify the name of a schema family (i.e. excludes version)
- * @param version The version number of this instance within the family.
- * @param mappedTypes The JPA entity classes that the ORM layer needs to be configure with for this schema.
+ * @property version The version number of this instance within the family.
+ * @property mappedTypes The JPA entity classes that the ORM layer needs to be configure with for this schema.
  */
 open class MappedSchema(
     schemaFamily: Class<*>,

--- a/serialization/src/main/kotlin/net/corda/v5/serialization/SerializationWhitelist.kt
+++ b/serialization/src/main/kotlin/net/corda/v5/serialization/SerializationWhitelist.kt
@@ -10,8 +10,8 @@ interface SerializationWhitelist {
     /**
      * Optionally whitelist types for use in object serialization, as we lock down the types that can be serialized.
      *
-     * For example, if you add a new [net.corda.core.contracts.ContractState] it needs to be whitelisted.  You can do that
-     * either by adding the [net.corda.core.serialization.CordaSerializable] annotation or via this method.
+     * For example, if you add a new [ContractState][net.corda.v5.ledger.contracts.ContractState] it needs to be whitelisted.  You can do that
+     * either by adding the [CordaSerializable][net.corda.v5.base.annotations.CordaSerializable] annotation or via this method.
      */
     val whitelist: List<Class<*>>
 }


### PR DESCRIPTION
Update Corda 5 to use the latest version of Kotlin 1.4.

I have kept the API version at 8 because this change does not break `corda-runtime-os`.

Also:
- Update to Corda 5.0.0-DevPreview-RC06.
- Update to Corda Gradle plugins 6.0.0-DevPreview-RC07.
- Use Kotlin functions instead of Java ones, where available.
- Resolve KDoc warnings, e.g. broken links, `@param` -> `@property`.
- Remove stray semi-colons and wildcard imports.
- Upgrade to Kotlin Mockito 3.2.0.