### PR TITLE
CORE-2103: Upgrade to Hibernate 5.5.7.Final.

### DIFF
--- a/cordapp-configuration/src/main/resources/net/corda/cordapp/cordapp-configuration.properties
+++ b/cordapp-configuration/src/main/resources/net/corda/cordapp/cordapp-configuration.properties
@@ -15,8 +15,7 @@ Minimum-Corda-Plugins-Version=6.0.0
 # CorDapps must always import these packages so that Corda can
 # still create lazy JPA proxies within the OSGi framework.
 Required-Packages=org.hibernate.annotations,\
-    org.hibernate.proxy,\
-    javassist.util.proxy
+    org.hibernate.proxy
 
 # The OSGi "consumer policy" for Corda's API packages.
 Import-Policy-Packages=net.corda.v5.*

--- a/gradle.properties
+++ b/gradle.properties
@@ -51,7 +51,7 @@ eddsaVersion = 0.3.0
 grgitPluginVersion = 4.0.2
 taskTreePluginVersion = 2.1.0
 javaxPersistenceApiVersion = 2.2
-hibernateVersion = 5.4.32.Final
+hibernateVersion = 5.5.7.Final
 jacksonVersion = 2.11.1
 
 # Used by packaging to manipulate metadata


### PR DESCRIPTION
Hibernate 5.x has replaced `javassist` with `bytebuddy`, so CPKs no longer need to import the `javassist.util.proxy` package dynamically.

Also update the `:ledger` module to use the correct version of the Hibernate annotations