### PR TITLE
CORE-2641: Adds a short identifier to CPKs, so that CPKs can be identified without individual signer hashes.

### DIFF
--- a/packaging/src/main/kotlin/net/corda/packaging/Cpk.kt
+++ b/packaging/src/main/kotlin/net/corda/packaging/Cpk.kt
@@ -37,7 +37,7 @@ sealed class Cpk(
     }
 
     val shortId = let {
-        val signerBytes = id.signers.sorted().joinToString("").toByteArray()
+        val signerBytes = id.signers.joinToString("").toByteArray()
         val digest = MessageDigest.getInstance(hashAlgorithm)
         val signerSummaryHash = SecureHash(digest.algorithm, digest.digest(signerBytes))
 


### PR DESCRIPTION
Required for https://r3-cev.atlassian.net/browse/CORE-2641.

For sandboxing, we want to move to providing a summary hash only for the signers in the class-info/class-tag objects. This is much easier if a method is available on the CPK to create a summary ID.