### PR TITLE
NOTICK: Expose Kotlin and Slf4J as `api` from `:base`

### DIFF
--- a/base/build.gradle
+++ b/base/build.gradle
@@ -8,7 +8,7 @@ description 'Corda Base'
 
 dependencies {
     implementation platform(project(':corda-api'))
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    api 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
     // Concluded this is the one acceptable dependency in addition to kotlin.
     // We are also returning `Logger` from extensions methods like `Any.contextLogger()` hance "api"
     api 'org.slf4j:slf4j-api'


### PR DESCRIPTION
Or else in all the dependant modules where `contextLogger()` is used
it is also necessary to add: `implementation 'org.slf4j:slf4j-api'` and `implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'`
