### PR TITLE
NOTICK: Remove redundant dependency on SLF4J

### DIFF
--- a/packaging/build.gradle
+++ b/packaging/build.gradle
@@ -39,7 +39,6 @@ dependencies {
     compileOnly "org.osgi:org.osgi.service.component.annotations"
     implementation "net.corda.kotlin:kotlin-stdlib-jdk8-osgi"
     implementation "com.typesafe:config:$typesafeConfigVersion"
-    implementation "org.slf4j:slf4j-api"
 
     api platform(project(':corda-api'))
 


### PR DESCRIPTION
Where they are already provided by `:base` module.
