### PR TITLE
NOTICK replaced set of signer key hashes with summary hash

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 9
+cordaApiRevision = 10
 
 # Main
 kotlinVersion = 1.4.32

--- a/packaging/src/main/kotlin/net/corda/packaging/internal/Utils.kt
+++ b/packaging/src/main/kotlin/net/corda/packaging/internal/Utils.kt
@@ -4,8 +4,24 @@ import net.corda.v5.crypto.DigestAlgorithmName
 import net.corda.v5.crypto.SecureHash
 import java.security.MessageDigest
 
-fun ByteArray.hash(algo : DigestAlgorithmName = DigestAlgorithmName.SHA2_256) : SecureHash {
+/**
+ * Compute the [SecureHash] of a [ByteArray] using the specified [DigestAlgorithmName]
+ */
+internal fun ByteArray.hash(algo : DigestAlgorithmName = DigestAlgorithmName.DEFAULT_ALGORITHM_NAME) : SecureHash {
     val md = MessageDigest.getInstance(algo.name)
     md.update(this)
     return SecureHash(algo.name, md.digest())
+}
+
+/**
+ * Creates a [SecureHash] instance with the specified [algorithm]
+ * @param algorithm the hash algorithm to be used
+ * @param withDigestAction a callback that receives a [MessageDigest] instance and is responsible to call
+ * [MessageDigest.update] with the data that needs to be hashed
+ * @return the resulting [SecureHash]
+ */
+internal inline fun hash(algorithm : DigestAlgorithmName = DigestAlgorithmName.DEFAULT_ALGORITHM_NAME, withDigestAction : (MessageDigest) -> Unit) : SecureHash {
+    val md = MessageDigest.getInstance(algorithm.name)
+    withDigestAction(md)
+    return SecureHash(algorithm.name, md.digest())
 }

--- a/packaging/src/test/kotlin/net/corda/packaging/internal/CpkDependencyResolverTest.kt
+++ b/packaging/src/test/kotlin/net/corda/packaging/internal/CpkDependencyResolverTest.kt
@@ -14,12 +14,19 @@ import java.util.TreeSet
 
 private fun id(name: String,
                version : String,
-               signers : NavigableSet<SecureHash> = Collections.emptyNavigableSet()) =
-        Cpk.Identifier(name, version, signers)
+               signers : NavigableSet<SecureHash> = Collections.emptyNavigableSet()) : Cpk.Identifier {
+    val signersSummaryHash = hash { md ->
+        signers.map(SecureHash::toString)
+            .map(String::toByteArray)
+            .forEach(md::update)
+    }
+    return Cpk.Identifier(name, version, signersSummaryHash)
+}
+
 private fun ids(vararg ids : Cpk.Identifier) = ids.toCollection(TreeSet())
 
 private fun signers(vararg publicKey : String) =
-    publicKey.mapTo(TreeSet()) { SecureHash.create("SHA256:$it") } as NavigableSet<SecureHash>
+    publicKey.mapTo(TreeSet(Cpk.Identifier.secureHashComparator)) { SecureHash.create("SHA256:$it") } as NavigableSet<SecureHash>
 
 private fun dependencyMap(vararg pairs : Pair<Cpk.Identifier, NavigableSet<Cpk.Identifier>>) =
         pairs.associateByTo(TreeMap(),


### PR DESCRIPTION
as an alternative to [240](https://github.com/corda/corda-runtime-os/pull/240)