### PR TITLE
CORE-2471: Add schemas/topics for stub network map for link manager

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/test/NetworkMapEntry.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/test/NetworkMapEntry.avsc
@@ -21,7 +21,7 @@
     },
     {
       "name": "networkType",
-      "type": "net.corda.p2p.test.NetworkType"
+      "type": "net.corda.p2p.NetworkType"
     }
   ]
 }

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/test/NetworkType.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/test/NetworkType.avsc
@@ -1,6 +1,0 @@
-{
-  "type": "enum",
-  "name": "NetworkType",
-  "namespace": "net.corda.p2p.test",
-  "symbols": [ "CORDA_4_LEGACY", "MODERN" ]
-}


### PR DESCRIPTION
Adding schemas and topic used by the stub network map implementation for Link Manager. 
Implementation that makes use of the schemas and the topic available here: https://github.com/corda/corda-runtime-os/pull/262