### PR TITLE
CORE-2734: Upgrade to Corda Gradle plugins 6.0.0-DevPreview.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ kotlinVersion = 1.4.32
 kotlin.stdlib.default.dependency = false
 
 # at the moment, required for packaging to build test cpks for unit tests
-gradlePluginsVersion = 6.0.0-DevPreview-RC07
+gradlePluginsVersion = 6.0.0-DevPreview
 cordaDevPreviewVersion = 5.0.0-DevPreview-RC06
 
 


### PR DESCRIPTION
Use the "release" version 6.0.0-DevPreview of the Corda Gradle plugins.