### PR TITLE
NOTICK Fixed bug with calculation of signers summary hash

### DIFF
--- a/packaging/src/main/kotlin/net/corda/packaging/Cpk.kt
+++ b/packaging/src/main/kotlin/net/corda/packaging/Cpk.kt
@@ -30,7 +30,7 @@ sealed class Cpk(
         val signerSummaryHash = hash {
             cordappCertificates
                 .asSequence()
-                .map { certificate -> certificate.encoded.hash() }
+                .map { certificate -> certificate.publicKey.encoded.hash() }
                 .sortedWith(Identifier.secureHashComparator)
                 .map(SecureHash::toString)
                 .map(String::toByteArray)

--- a/packaging/src/test/kotlin/net/corda/packaging/CpkTests.kt
+++ b/packaging/src/test/kotlin/net/corda/packaging/CpkTests.kt
@@ -381,10 +381,18 @@ class CpkTests {
     }
 
     @Test
-    fun `corda-api dependencies are not included in in cpk dependencies`() {
+    fun `corda-api dependencies are not included in cpk dependencies`() {
         Assertions.assertTrue(workflowCpk.dependencies.none {
             it == flowsCpk.id
         })
+    }
+
+    @Test
+    fun `signers summary hash is computed correctly`() {
+        val md = MessageDigest.getInstance(DigestAlgorithmName.DEFAULT_ALGORITHM_NAME.name)
+        md.update(cordaDevKey.toString().toByteArray())
+        val expectedHash = SecureHash(DigestAlgorithmName.DEFAULT_ALGORITHM_NAME.name, md.digest())
+        Assertions.assertEquals(expectedHash, flowsCpk.id.signerSummaryHash)
     }
 }
 


### PR DESCRIPTION
It is currently computed using the encoded version of the whole certificated (including all the metadata information) as opposed to the signer's public key alone

