### PR TITLE
NOTICK: Update corda-api platform for publishing to Maven Central.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,8 @@ import static org.gradle.api.JavaVersion.*
 
 buildscript {
     ext {
+        vcsUrl = System.getenv('GIT_URL') ?: 'https://github.com/corda/corda-api.git'
+
         // Remember where our Java executable lives (until Bnd supports Gradle toolchains).
         javaExecutable = file("${System.getProperty('java.home')}/bin/java")
     }

--- a/corda-api/build.gradle
+++ b/corda-api/build.gradle
@@ -4,6 +4,8 @@ plugins {
     id 'com.jfrog.artifactory'
 }
 
+description = 'Declares the Corda API component versions.'
+
 dependencies {
     constraints {
         api project(':application')
@@ -34,6 +36,12 @@ publishing {
 
             pom {
                 name = 'Corda API Platform'
+                description = project.description
+
+                url = vcsUrl - '.git'
+                scm {
+                    url = vcsUrl
+                }
 
                 licenses {
                     license {

--- a/cordapp-configuration-publish/build.gradle
+++ b/cordapp-configuration-publish/build.gradle
@@ -14,8 +14,6 @@ ext {
     pluginGroup = 'net.corda.cordapp'
     pluginName = 'cordapp-configuration'
     pluginId = 'net.corda.cordapp.cordapp-configuration'
-
-    vcsUrl = System.getenv('GIT_URL') ?: 'https://github.com/corda/corda-api.git'
 }
 
 configurations {


### PR DESCRIPTION
Add Maven Central's required tags to the `corda-api` Gradle platform POM.