### PR TITLE
NOTICK: API JAR projects should apply java-library plugin.

### DIFF
--- a/cipher-suite/build.gradle
+++ b/cipher-suite/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'org.jetbrains.kotlin.jvm'
     id 'com.r3.internal.gradle.plugins.r3Publish'
-    id 'biz.aQute.bnd.builder'
+    id 'corda-api.common-library'
 }
 
 description 'Corda Cipher Suite'
@@ -25,12 +25,9 @@ dependencies {
 }
 
 tasks.named('jar', Jar) {
-    archiveBaseName = 'corda-cipher-suite'
-    bnd """\
-Bundle-Name: Corda Cipher Suite
-Bundle-SymbolicName: \${project.group}.cipher-suite
+    bnd '''\
 Import-Package:\
     net.i2p.crypto.eddsa.math;resolution:=optional,\
     *
-"""
+'''
 }

--- a/crypto/build.gradle
+++ b/crypto/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'org.jetbrains.kotlin.jvm'
     id 'com.r3.internal.gradle.plugins.r3Publish'
-    id 'biz.aQute.bnd.builder'
+    id 'corda-api.common-library'
 }
 
 description 'Corda Crypto'
@@ -24,12 +24,9 @@ dependencies {
 }
 
 tasks.named('jar', Jar) {
-    archiveBaseName = 'corda-crypto'
-    bnd """\
-Bundle-Name: Corda Crypto
-Bundle-SymbolicName: \${project.group}.crypto
+    bnd '''\
 Import-Package:\
     net.i2p.crypto.eddsa.math;resolution:=optional,\
     *
-"""
+'''
 }

--- a/data/avro-schema/build.gradle
+++ b/data/avro-schema/build.gradle
@@ -7,6 +7,7 @@ plugins {
     id 'com.r3.internal.gradle.plugins.r3Publish'
     id "com.github.davidmc24.gradle.plugin.avro-base"
     id 'biz.aQute.bnd.builder'
+    id 'java-library'
 }
 
 dependencies {

--- a/data/topic-schema/build.gradle
+++ b/data/topic-schema/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'org.jetbrains.kotlin.jvm'
     id 'com.r3.internal.gradle.plugins.r3Publish'
+    id 'java-library'
 }
 
 description 'Definition of Topics'


### PR DESCRIPTION
Apply `corda-api.common-library` plugin to Crypto API projects, and `java-library` to Avro projects. This will ensure that everything is applying the `java-library` plugin consistently.

Note that the `org.jetbrains.kotlin.jvm` plugin _does not_ apply `java-library` automatically.