### PR TITLE
CORE-2441 - Cluster admin AVRO schema

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/poc/persistence/ClusterAdminEvent.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/poc/persistence/ClusterAdminEvent.avsc
@@ -1,0 +1,16 @@
+{
+  "type": "record",
+  "name": "ClusterAdminEvent",
+  "namespace": "net.corda.data.poc.persistence",
+  "fields": [
+    {
+      "name": "type",
+      "type": {
+        "type": "enum",
+        "name": "AdminEventType",
+        "symbols": ["DB_SCHEMA_UPDATE"]
+      },
+      "doc": "Type of cluster admin event"
+    }
+  ]
+}


### PR DESCRIPTION
For persistence POC (hence in POC folder), will need to be (re)moved later.

(Maybe we don't need to merge this if I hardcode the version number for the POC).