### PR TITLE
CORE-2739: Upgrade to Bnd 6.0.0.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,9 +4,6 @@ import static org.gradle.api.JavaVersion.*
 buildscript {
     ext {
         vcsUrl = System.getenv('GIT_URL') ?: 'https://github.com/corda/corda-api.git'
-
-        // Remember where our Java executable lives (until Bnd supports Gradle toolchains).
-        javaExecutable = file("${System.getProperty('java.home')}/bin/java")
     }
 }
 

--- a/buildSrc/src/main/groovy/corda-api.common-library.gradle
+++ b/buildSrc/src/main/groovy/corda-api.common-library.gradle
@@ -29,8 +29,10 @@ dependencies {
 
 tasks.named('jar', Jar) {
     archiveBaseName = "corda-" + project.name
-    bnd """
+    bundle {
+        bnd '''\
 Bundle-Name: \${project.description}
 Bundle-SymbolicName: \${project.group}.\${project.name}
-"""
+'''
+    }
 }

--- a/cipher-suite/build.gradle
+++ b/cipher-suite/build.gradle
@@ -25,9 +25,11 @@ dependencies {
 }
 
 tasks.named('jar', Jar) {
-    bnd '''\
+    bundle {
+        bnd '''\
 Import-Package:\
     net.i2p.crypto.eddsa.math;resolution:=optional,\
     *
 '''
+    }
 }

--- a/crypto/build.gradle
+++ b/crypto/build.gradle
@@ -24,9 +24,11 @@ dependencies {
 }
 
 tasks.named('jar', Jar) {
-    bnd '''\
+    bundle {
+        bnd '''\
 Import-Package:\
     net.i2p.crypto.eddsa.math;resolution:=optional,\
     *
 '''
+    }
 }

--- a/data/avro-schema/build.gradle
+++ b/data/avro-schema/build.gradle
@@ -139,9 +139,11 @@ tasks.named('processResources', ProcessResources) {
 tasks.named('jar', Jar) {
     archiveBaseName = "corda-" + project.name
 
-    bnd """
+    bundle {
+        bnd '''\
 Bundle-Name: \${project.description}
 Bundle-SymbolicName: \${project.group}.\${project.name}
 Fragment-Host: avro
-"""
+'''
+    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ kotlinVersion = 1.4.32
 kotlin.stdlib.default.dependency = false
 
 # at the moment, required for packaging to build test cpks for unit tests
-gradlePluginsVersion = 6.0.0-DevPreview
+gradlePluginsVersion = 6.0.0-BETA09
 cordaDevPreviewVersion = 5.0.0-DevPreview-RC06
 
 
@@ -64,6 +64,6 @@ mockitoVersion = 2.28.2
 mockitoKotlinVersion = 3.2.0
 
 # OSGi
-bndVersion = 5.3.0
+bndVersion = 6.0.0
 osgiVersion = 8.0.0
 osgiScrAnnotationVersion = 1.4.0

--- a/ledger/build.gradle
+++ b/ledger/build.gradle
@@ -19,9 +19,9 @@ dependencies {
         exclude group: 'org.osgi'
     }
 
+    api project(":application")
     implementation project(":crypto")
     implementation project(":serialization")
-    implementation project(":application")
     implementation project(":persistence")
 
     testImplementation "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"

--- a/packaging/test/contract-cpk/build.gradle
+++ b/packaging/test/contract-cpk/build.gradle
@@ -4,9 +4,10 @@ plugins {
 }
 
 dependencies {
+    cordaProvided platform(project(':corda-api'))
     cordaProvided project(':application')
     cordaProvided project(':ledger')
-    cordaProvided "org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlinVersion"
+    cordaProvided 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
 }
 
 tasks.named('jar', Jar) {

--- a/packaging/test/workflow-cpk/build.gradle
+++ b/packaging/test/workflow-cpk/build.gradle
@@ -9,6 +9,7 @@ configurations {
 }
 
 dependencies {
+    cordaProvided platform(project(':corda-api'))
     cordaProvided project(':application')
     cordaProvided project(':ledger')
     cordaProvided project(':crypto')

--- a/settings.gradle
+++ b/settings.gradle
@@ -25,6 +25,9 @@ pluginManagement {
 
         maven {
             url "$artifactoryContextUrl/engineering-tools-maven"
+            authentication {
+                basic(BasicAuthentication)
+            }
             credentials {
                 username = settings.ext.find('cordaArtifactoryUsername') ?: System.getenv('CORDA_ARTIFACTORY_USERNAME')
                 password = settings.ext.find('cordaArtifactoryPassword') ?: System.getenv('CORDA_ARTIFACTORY_PASSWORD')


### PR DESCRIPTION
Bnd 6.0.0 stops using deprecated Gradle behaviour, and allows our `cordapp-cpk` Gradle plugin not to generate some useless warnings.