### PR TITLE
NOTICK: Update the internal publish plugin

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -29,7 +29,7 @@ artifactoryContextUrl = https://software.r3.com/artifactory
 # Gradle
 # dokka need more metaspace - https://github.com/Kotlin/dokka/issues/1405
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=1g
-internalPublishVersion = 0.1.+
+internalPublishVersion = 1.+
 dokkaVersion = 1.4.+
 
 


### PR DESCRIPTION
* start using released versions (first one is 1.0.0)
* use Gradle mechanism to find the newest version for the plugin
