### PR TITLE
CORE-2816 CPI and CPK implement AutoCloaseable

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 16
+cordaApiRevision = 17
 
 # Main
 kotlinVersion = 1.4.32

--- a/packaging/src/main/kotlin/net/corda/packaging/CPI.kt
+++ b/packaging/src/main/kotlin/net/corda/packaging/CPI.kt
@@ -11,7 +11,7 @@ import java.io.Reader
 import java.nio.file.Path
 import javax.security.auth.x500.X500Principal
 
-interface CPI {
+interface CPI : AutoCloseable {
 
     companion object {
 

--- a/packaging/src/main/kotlin/net/corda/packaging/CPK.kt
+++ b/packaging/src/main/kotlin/net/corda/packaging/CPK.kt
@@ -15,7 +15,7 @@ import java.util.NavigableSet
 import java.util.TreeMap
 
 /** Represents a [CPK] file in the filesystem */
-interface CPK {
+interface CPK : AutoCloseable {
 
     companion object {
         const val fileExtension = ".cpk"

--- a/packaging/src/main/kotlin/net/corda/packaging/internal/CPIImpl.kt
+++ b/packaging/src/main/kotlin/net/corda/packaging/internal/CPIImpl.kt
@@ -70,4 +70,6 @@ internal class CPIImpl(override val metadata: CPI.Metadata, cpks : Iterable<CPK>
     }
 
     override fun getCPKById(id: CPK.Identifier): CPK? = cpkMap[id]
+
+    override fun close() = cpks.forEach(CPK::close)
 }

--- a/packaging/src/main/kotlin/net/corda/packaging/internal/CPKImpl.kt
+++ b/packaging/src/main/kotlin/net/corda/packaging/internal/CPKImpl.kt
@@ -52,6 +52,8 @@ internal class CPKImpl(override val metadata: CPK.Metadata, private val jarFile 
     override fun getResourceAsStream(resourceName: String) = jarFile.getJarEntry(resourceName)
         ?.let(jarFile::getInputStream)
         ?: throw IOException("Unknown resource $resourceName")
+
+    override fun close() = jarFile.close()
 }
 
 internal data class CPKFormatVersionImpl(override val major: Int, override val minor: Int) : CPK.FormatVersion {

--- a/packaging/src/test/kotlin/net/corda/packaging/CPKTests.kt
+++ b/packaging/src/test/kotlin/net/corda/packaging/CPKTests.kt
@@ -7,6 +7,7 @@ import net.corda.packaging.util.UncloseableInputStream
 import net.corda.packaging.util.ZipTweaker
 import net.corda.v5.crypto.DigestAlgorithmName
 import net.corda.v5.crypto.SecureHash
+import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
@@ -70,6 +71,11 @@ class CPKTests {
         }.collect(Collectors.toUnmodifiableMap({it.first}, {it.second}))
         referenceExtractionPath = testDir.resolve("unzippedCPK")
         referenceUnzipMethod(workflowCPKPath, referenceExtractionPath)
+    }
+
+    @AfterAll
+    fun teardown() {
+        workflowCPK.close()
     }
 
 
@@ -346,6 +352,7 @@ class CPKTests {
         }
         assertThrows<PackagingException> {
             CPK.from(Files.newInputStream(nonJarFile), processedWorkflowCPKPath, nonJarFile.toString())
+                .also(CPK::close)
         }
     }
 


### PR DESCRIPTION
This is to make it possible to close the enclosed JarFile inside a CPK object
