### PR TITLE
NOTICK Fixed comparator of CPK.Identifier and CPI.Identifier

### DIFF
--- a/packaging/src/main/kotlin/net/corda/packaging/CPI.kt
+++ b/packaging/src/main/kotlin/net/corda/packaging/CPI.kt
@@ -2,6 +2,7 @@ package net.corda.packaging
 
 import net.corda.packaging.internal.CPIBuilder
 import net.corda.packaging.internal.CPIIdentifierImpl
+import net.corda.packaging.internal.CPIIdentityImpl
 import net.corda.packaging.internal.CPILoader
 import net.corda.packaging.internal.jarSignatureVerificationEnabledByDefault
 import net.corda.v5.crypto.SecureHash
@@ -87,6 +88,11 @@ interface CPI : AutoCloseable {
          * The unique identifier of a Corda network
          */
         val groupId : String
+
+        companion object {
+            @JvmStatic
+            fun newInstance(name : X500Principal, groupId : String): Identity = CPIIdentityImpl(name, groupId)
+        }
     }
 
     /**

--- a/packaging/src/main/kotlin/net/corda/packaging/internal/CPIImpl.kt
+++ b/packaging/src/main/kotlin/net/corda/packaging/internal/CPIImpl.kt
@@ -13,9 +13,9 @@ import javax.security.auth.x500.X500Principal
 internal data class CPIIdentityImpl(override val name: X500Principal,
                       override val groupId: String) : CPI.Identity {
 
-    private companion object {
-        private val comparator : Comparator<CPI.Identity> = Comparator.comparing(CPI.Identity::groupId)
-            .thenComparing { identity -> identity.name.name }
+    internal companion object {
+        internal val comparator : Comparator<CPI.Identity> =
+            Comparator.comparing(CPI.Identity::groupId).thenComparing { identity -> identity.name.name }
     }
 
     override fun compareTo(other: CPI.Identity) = comparator.compare(this, other)
@@ -32,6 +32,7 @@ data class CPIIdentifierImpl(
         private val identifierComparator = Comparator.comparing(CPI.Identifier::name)
             .thenComparing(CPI.Identifier::version, VersionComparator())
             .thenComparing(CPI.Identifier::signerSummaryHash, secureHashComparator)
+            .thenComparing(CPI.Identifier::identity, Comparator.nullsFirst(CPIIdentityImpl.comparator))
     }
 
     override fun compareTo(other: CPI.Identifier) = identifierComparator.compare(this, other)

--- a/packaging/src/main/kotlin/net/corda/packaging/internal/CPKImpl.kt
+++ b/packaging/src/main/kotlin/net/corda/packaging/internal/CPKImpl.kt
@@ -7,7 +7,6 @@ import net.corda.packaging.VersionComparator
 import net.corda.v5.crypto.SecureHash
 import java.io.IOException
 import java.security.cert.Certificate
-import java.util.Arrays
 import java.util.NavigableSet
 import java.util.jar.JarFile
 
@@ -17,9 +16,6 @@ internal data class CPKIdentifierImpl(
     override val signerSummaryHash: SecureHash?) : CPK.Identifier {
 
     companion object {
-        val secureHashComparator = Comparator.nullsFirst(
-            Comparator.comparing(SecureHash::algorithm)
-            .then { h1, h2 -> Arrays.compare(h1?.bytes, h2?.bytes) })
         private val identifierComparator = Comparator.comparing(CPK.Identifier::name)
             .thenComparing(CPK.Identifier::version, VersionComparator())
             .thenComparing(CPK.Identifier::signerSummaryHash, secureHashComparator)

--- a/packaging/src/main/kotlin/net/corda/packaging/internal/Utils.kt
+++ b/packaging/src/main/kotlin/net/corda/packaging/internal/Utils.kt
@@ -6,8 +6,9 @@ import java.security.MessageDigest
 import java.security.cert.Certificate
 import java.util.Arrays
 
-internal val secureHashComparator = Comparator.comparing(SecureHash::algorithm)
-    .then { h1, h2 -> Arrays.compare(h1?.bytes, h2?.bytes) }
+internal val secureHashComparator = Comparator.nullsFirst(
+    Comparator.comparing(SecureHash::algorithm)
+        .then { h1, h2 -> Arrays.compare(h1?.bytes, h2?.bytes) })
 
 /**
  * Compute the [SecureHash] of a [ByteArray] using the specified [DigestAlgorithmName]

--- a/packaging/src/test/kotlin/net/corda/packaging/internal/CPIImplTest.kt
+++ b/packaging/src/test/kotlin/net/corda/packaging/internal/CPIImplTest.kt
@@ -1,0 +1,36 @@
+package net.corda.packaging.internal
+
+import net.corda.packaging.CPI
+import net.corda.v5.crypto.DigestAlgorithmName
+import net.corda.v5.crypto.SecureHash
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import java.util.Collections
+import java.util.NavigableSet
+import java.util.TreeSet
+import javax.security.auth.x500.X500Principal
+
+class CPIImplTest {
+    @Test
+    fun `CPI identifiers without a signerSummaryHash and an identity compares correctly`() {
+        val id1 = CPI.Identifier.newInstance("a", "1.0", null, null)
+        val id2 = CPI.Identifier.newInstance("a", "1.0",
+            SecureHash(DigestAlgorithmName.DEFAULT_ALGORITHM_NAME.name, ByteArray(32)), null)
+        val id3 = CPI.Identifier.newInstance(
+            "a",
+            "1.0",
+            SecureHash(DigestAlgorithmName.DEFAULT_ALGORITHM_NAME.name, ByteArray(32)),
+            CPI.Identity.newInstance(X500Principal("C=IE, L=Dublin, CN=somebody"), "groupId")
+        )
+        var ids : NavigableSet<CPI.Identifier> = Collections.emptyNavigableSet()
+        Assertions.assertDoesNotThrow {
+             ids = TreeSet<CPI.Identifier>().apply {
+                 add(id1)
+                 add(id2)
+                 add(id3)
+            }
+        }
+        // Check the id with null signerSummaryHash and null identity comes first
+        Assertions.assertEquals(setOf(id1, id2, id3), ids)
+    }
+}

--- a/packaging/src/test/kotlin/net/corda/packaging/internal/CPKImplTest.kt
+++ b/packaging/src/test/kotlin/net/corda/packaging/internal/CPKImplTest.kt
@@ -1,0 +1,29 @@
+package net.corda.packaging.internal
+
+import net.corda.packaging.CPK
+import net.corda.v5.crypto.DigestAlgorithmName
+import net.corda.v5.crypto.SecureHash
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import java.util.Collections
+import java.util.NavigableSet
+import java.util.TreeSet
+
+class CPKImplTest {
+    @Test
+    fun `CPK identifiers without a signerSummaryHash compares correctly`() {
+        val id1 = CPK.Identifier.newInstance("a", "1.0", null)
+        val id2 = CPK.Identifier.newInstance("a", "1.0", SecureHash(DigestAlgorithmName.DEFAULT_ALGORITHM_NAME.name, ByteArray(32)))
+        val id3 = CPK.Identifier.newInstance("a", "2.0", SecureHash(DigestAlgorithmName.DEFAULT_ALGORITHM_NAME.name, ByteArray(32)))
+        var ids : NavigableSet<CPK.Identifier> = Collections.emptyNavigableSet()
+        Assertions.assertDoesNotThrow {
+             ids = TreeSet<CPK.Identifier>().apply {
+                 add(id1)
+                 add(id2)
+                 add(id3)
+            }
+        }
+        // Check the id with null signerSummaryHash comes first
+        Assertions.assertEquals(setOf(id1, id2, id3), ids)
+    }
+}


### PR DESCRIPTION
Current code uses a comparator that doesn't accept null values for `CPK.Identifier.signerSummaryHash`
and ignores `identity` for `CPI.Identifier`
