### PR TITLE
CORE-2875: Allow a new CPK to replace any existing copy.

### DIFF
--- a/packaging/src/main/kotlin/net/corda/packaging/internal/CPKLoader.kt
+++ b/packaging/src/main/kotlin/net/corda/packaging/internal/CPKLoader.kt
@@ -24,6 +24,7 @@ import java.io.IOException
 import java.io.InputStream
 import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.StandardCopyOption.REPLACE_EXISTING
 import java.security.DigestInputStream
 import java.security.MessageDigest
 import java.security.cert.Certificate
@@ -118,7 +119,7 @@ internal object CPKLoader {
             val metadata = buildMetadata()
             val finalCPKFile = temporaryCPKFile?.let {
                 val destination = it.parent.resolve(metadata.hash.toHexString())
-                Files.move(it, destination)
+                Files.move(it, destination, REPLACE_EXISTING)
                 destination.toFile()
             } ?: throw IllegalStateException("This should never happen")
 


### PR DESCRIPTION
Allow a new copy of a CPK to replace any existing one. This can be very handy when you are re-executing JUnit tests.