### PR TITLE
NOTICK: bump meta space workaround for javadoc issue

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -28,7 +28,7 @@ artifactoryContextUrl = https://software.r3.com/artifactory
 
 # Gradle
 # dokka need more metaspace - https://github.com/Kotlin/dokka/issues/1405
-org.gradle.jvmargs=-XX:MaxMetaspaceSize=1g
+org.gradle.jvmargs=-XX:MaxMetaspaceSize=2g
 internalPublishVersion = 1.+
 dokkaVersion = 1.4.+
 


### PR DESCRIPTION
Jobs failing due to known dokka issue, bumping space as a workaround