### PR TITLE
CORE-2871 Add `PermissionManagementRequest` schema

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/permissions/management/PermissionManagementRequest.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/permissions/management/PermissionManagementRequest.avsc
@@ -4,6 +4,19 @@
   "namespace": "net.corda.data.permissions.management",
   "fields": [
     {
+      "name": "requestUserId",
+      "type": "string",
+      "doc": "ID of user who invoked this request."
+    },
+    {
+      "name": "virtualNodeId",
+      "type": [
+        "null",
+        "string"
+      ],
+      "doc": "ID of virtual node or null"
+    },
+    {
       "name": "request",
       "type": [
         "net.corda.data.permissions.management.user.CreateUserRequest"

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/permissions/management/user/CreateUserRequest.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/permissions/management/user/CreateUserRequest.avsc
@@ -38,11 +38,6 @@
     {
       "name": "parentGroupId",
       "type": [ "null", "string" ]
-    },
-    {
-      "name": "requestUserId",
-      "type": "string",
-      "doc": "ID of user who invoked this request."
     }
   ]
 }


### PR DESCRIPTION
Add a top level schema that will cover all permission management
requests by using a union type of the `request` field. Other specific
permission management requests can then be added as needed in the
future.