### PR TITLE
CORE-2840: Move RPC topic constants to a separate file

### DIFF
--- a/data/topic-schema/src/main/java/net/corda/rpc/schema/package-info.java
+++ b/data/topic-schema/src/main/java/net/corda/rpc/schema/package-info.java
@@ -1,0 +1,4 @@
+@Export
+package net.corda.rpc.schema;
+
+import org.osgi.annotation.bundle.Export;

--- a/data/topic-schema/src/main/kotlin/net/corda/p2p/schema/Schema.kt
+++ b/data/topic-schema/src/main/kotlin/net/corda/p2p/schema/Schema.kt
@@ -8,12 +8,5 @@ class Schema {
         const val LINK_OUT_TOPIC = "link.out"
         const val LINK_IN_TOPIC = "link.in"
         const val SESSION_OUT_PARTITIONS = "session.out.partitions"
-
-        // RPC Permissions
-        const val RPC_PERM_MGMT_REQ_TOPIC = "rpc.permissions.management"
-        const val RPC_PERM_MGMT_RESP_TOPIC = "rpc.permissions.management.resp"
-        const val RPC_PERM_USER_TOPIC = "rpc.permissions.user"
-        const val RPC_PERM_GROUP_TOPIC = "rpc.permissions.group"
-        const val RPC_PERM_ROLE_TOPIC = "rpc.permissions.role"
     }
 }

--- a/data/topic-schema/src/main/kotlin/net/corda/rpc/schema/Schema.kt
+++ b/data/topic-schema/src/main/kotlin/net/corda/rpc/schema/Schema.kt
@@ -1,0 +1,12 @@
+package net.corda.rpc.schema
+
+class Schema {
+    companion object {
+        // RPC Permissions
+        const val RPC_PERM_MGMT_REQ_TOPIC = "rpc.permissions.management"
+        const val RPC_PERM_MGMT_RESP_TOPIC = "rpc.permissions.management.resp"
+        const val RPC_PERM_USER_TOPIC = "rpc.permissions.user"
+        const val RPC_PERM_GROUP_TOPIC = "rpc.permissions.group"
+        const val RPC_PERM_ROLE_TOPIC = "rpc.permissions.role"
+    }
+}


### PR DESCRIPTION
Just realised I added RPC constants earlier into P2P specific file.
