### PR TITLE
NOTICK Fix `:membership-identity` Java API tests

### DIFF
--- a/membership-identity/src/test/java/net/corda/v5/membership/identity/MemberContextJavaApiTest.java
+++ b/membership-identity/src/test/java/net/corda/v5/membership/identity/MemberContextJavaApiTest.java
@@ -3,6 +3,7 @@ package net.corda.v5.membership.identity;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.util.Map;
 import java.util.Set;
 
 import static org.mockito.Mockito.mock;
@@ -17,25 +18,25 @@ public class MemberContextJavaApiTest {
     @Test
     public void get() {
         final String key = "key";
-        final Object object = new Object();
-        when(memberContext.get(key)).thenReturn(object);
+        final String value = "value";
+        when(memberContext.get(key)).thenReturn(value);
 
         final Object obj = memberContext.get(key);
 
         Assertions.assertThat(obj).isNotNull();
-        Assertions.assertThat(obj).isEqualTo(object);
+        Assertions.assertThat(obj).isEqualTo(value);
         verify(memberContext, times(1)).get(key);
     }
 
     @Test
     public void getKeys() {
-        Set<String> keys = Set.of("key1", "key2");
-        when(memberContext.getKeys()).thenReturn(keys);
+        Set<Map.Entry<String, String>> entries = Map.of("key", "value").entrySet();
+        when(memberContext.getEntries()).thenReturn(entries);
 
-        Set<String> keysTest = memberContext.getKeys();
+        Set<Map.Entry<String, String>> entriesTest = memberContext.getEntries();
 
-        Assertions.assertThat(keysTest).isNotNull();
-        Assertions.assertThat(keysTest).isEqualTo(keys);
-        verify(memberContext, times(1)).getKeys();
+        Assertions.assertThat(entriesTest).isNotNull();
+        Assertions.assertThat(entriesTest).isEqualTo(entries);
+        verify(memberContext, times(1)).getEntries();
     }
 }

--- a/membership-identity/src/test/java/net/corda/v5/membership/identity/MemberInfoJavaApiTest.java
+++ b/membership-identity/src/test/java/net/corda/v5/membership/identity/MemberInfoJavaApiTest.java
@@ -29,10 +29,10 @@ public class MemberInfoJavaApiTest {
 
     @Test
     public void getMgmProvidedContext() {
-        MemberContext test = mock(MemberContext.class);
+        MGMContext test = mock(MGMContext.class);
         when(memberInfo.getMgmProvidedContext()).thenReturn(test);
 
-        MemberContext result = memberInfo.getMgmProvidedContext();
+        MGMContext result = memberInfo.getMgmProvidedContext();
 
         Assertions.assertThat(result).isNotNull();
         Assertions.assertThat(result).isEqualTo(test);


### PR DESCRIPTION
Due to 2 merges going in at the same time without conflicts, the build
was failing to compile `:membership-identity`'s test classes. The tests
have been fixed by updating the APIs used in the test.