### PR TITLE
CORE-2094 Port `MemberLookupService` java api test

### DIFF
--- a/application/src/test/java/net/corda/v5/application/services/MemberLookupServiceJavaApiTest.java
+++ b/application/src/test/java/net/corda/v5/application/services/MemberLookupServiceJavaApiTest.java
@@ -1,0 +1,62 @@
+package net.corda.v5.application.services;
+
+import net.corda.v5.application.identity.CordaX500Name;
+import net.corda.v5.membership.identity.MemberInfo;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.security.PublicKey;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class MemberLookupServiceJavaApiTest {
+
+    private final MemberLookupService memberLookupService = mock(MemberLookupService.class);
+
+    private final CordaX500Name bobName = new CordaX500Name("Bob Plc", "Rome", "IT");
+    private final MemberInfo memberInfo = mock(MemberInfo.class);
+    private final PublicKey bobPublicKey = mock(PublicKey.class);
+
+    @Test
+    public void myInfo() {
+        when(memberLookupService.myInfo()).thenReturn(memberInfo);
+
+        MemberInfo test = memberLookupService.myInfo();
+
+        Assertions.assertThat(test).isNotNull();
+        Assertions.assertThat(test).isEqualTo(memberInfo);
+    }
+
+    @Test
+    public void lookupCordaX500Name() {
+        when(memberLookupService.lookup(bobName)).thenReturn(memberInfo);
+
+        MemberInfo test = memberLookupService.lookup(bobName);
+
+        Assertions.assertThat(test).isNotNull();
+        Assertions.assertThat(test).isEqualTo(memberInfo);
+    }
+
+    @Test
+    public void lookupPublicKey() {
+        when(memberLookupService.lookup(bobPublicKey)).thenReturn(memberInfo);
+
+        MemberInfo test = memberLookupService.lookup(bobPublicKey);
+
+        Assertions.assertThat(test).isNotNull();
+        Assertions.assertThat(test).isEqualTo(memberInfo);
+    }
+
+    @Test
+    public void lookupMemberInfo() {
+        List<MemberInfo> memberInfos = List.of(memberInfo);
+        when(memberLookupService.lookup()).thenReturn(memberInfos);
+
+        List<MemberInfo> test = memberLookupService.lookup();
+
+        Assertions.assertThat(test).isNotNull();
+        Assertions.assertThat(test).isEqualTo(memberInfos);
+    }
+}


### PR DESCRIPTION
Ports `MemberLookupService` java api test from corda5 repo.