### PR TITLE
CORE-2094 Port `KeyManagementService` java api test

### DIFF
--- a/application/src/test/java/net/corda/v5/application/services/crypto/KeyManagementServiceJavaApiTest.java
+++ b/application/src/test/java/net/corda/v5/application/services/crypto/KeyManagementServiceJavaApiTest.java
@@ -1,0 +1,78 @@
+package net.corda.v5.application.services.crypto;
+
+import net.corda.v5.application.crypto.DigitalSignatureAndMeta;
+import net.corda.v5.application.crypto.SignableData;
+import net.corda.v5.application.crypto.SignatureMetadata;
+import net.corda.v5.crypto.DigitalSignature;
+import net.corda.v5.crypto.SecureHash;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.security.PublicKey;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.mock;
+
+class KeyManagementServiceJavaApiTest {
+
+    private final KeyManagementService keyManagementService = mock(KeyManagementService.class);
+    private final PublicKey publicKey = mock(PublicKey.class);
+
+    @Test
+    void freshKeyTest() {
+        Mockito.when(keyManagementService.freshKey()).thenReturn(publicKey);
+
+        Assertions.assertThat(keyManagementService.freshKey()).isNotNull();
+        Assertions.assertThat(keyManagementService.freshKey()).isEqualTo(publicKey);
+    }
+
+    @Test
+    void freshKeyWithExternalIDTest() {
+        final UUID externalId = UUID.randomUUID();
+        Mockito.when(keyManagementService.freshKey(any())).thenReturn(publicKey);
+
+        Assertions.assertThat(keyManagementService.freshKey(externalId)).isNotNull();
+        Assertions.assertThat(keyManagementService.freshKey(externalId)).isEqualTo(publicKey);
+    }
+
+    @Test
+    void filterMyKeysTest() {
+        final List<PublicKey> keys = new ArrayList<>();
+        Mockito.when(keyManagementService.filterMyKeys(anyList())).thenReturn(Collections.singleton(publicKey));
+
+        Assertions.assertThat(keyManagementService.filterMyKeys(keys)).isNotEmpty();
+        Assertions.assertThat(keyManagementService.filterMyKeys(keys)).isEqualTo(Collections.singleton(publicKey));
+    }
+
+    @Test
+    void signWithByteArrayTest() {
+        final DigitalSignature.WithKey signatureWithKey = new DigitalSignature.WithKey(publicKey, "test".getBytes());
+        Mockito.when(keyManagementService.sign((byte[]) any(), any())).thenReturn(signatureWithKey);
+
+        Assertions.assertThat(keyManagementService.sign("test".getBytes(), publicKey)).isNotNull();
+        Assertions
+                .assertThat(keyManagementService.sign("test".getBytes(), publicKey))
+                .isEqualTo(signatureWithKey);
+    }
+
+    @Test
+    void signWithSignableDataTest() {
+        final SignatureMetadata signatureMetadata = new SignatureMetadata(11);
+        final SecureHash secureHash = new SecureHash("testAlgorithm", new byte[10101]);
+        final DigitalSignatureAndMeta signatureAndMeta =
+                new DigitalSignatureAndMeta("test".getBytes(), publicKey, signatureMetadata);
+        SignableData signableData = new SignableData(secureHash, signatureMetadata);
+        Mockito.when(keyManagementService.sign((SignableData) any(), any())).thenReturn(signatureAndMeta);
+
+        Assertions.assertThat(keyManagementService.sign(signableData, publicKey)).isNotNull();
+        Assertions
+                .assertThat(keyManagementService.sign(signableData, publicKey))
+                .isEqualTo(signatureAndMeta);
+    }
+}


### PR DESCRIPTION
Ports `KeyManagementService` java api test from corda5 repo.