### PR TITLE
NOTICK - adding a permission management response to capture responses

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/permissions/management/PermissionManagementResponse.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/permissions/management/PermissionManagementResponse.avsc
@@ -1,0 +1,15 @@
+{
+  "type": "record",
+  "name": "PermissionManagementResponse",
+  "namespace": "net.corda.data.permissions.management",
+  "fields": [
+    {
+      "name": "response",
+      "type": [
+        "boolean",
+        "net.corda.data.ExceptionEnvelope",
+        "net.corda.data.permissions.User"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
… from the database worker. For example, create user return the newly created user.
