### PR TITLE
NOTICK - fix name of parentGroupId to parentGroupAssociation

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/permissions/Group.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/permissions/Group.avsc
@@ -20,7 +20,7 @@
       "type": "string"
     },
     {
-      "name": "parentGroupId",
+      "name": "parentGroupAssociation",
       "type": [ "null", "net.corda.data.permissions.GroupAssociation" ],
       "doc": "Optional parent group associated with this group."
     },

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/permissions/User.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/permissions/User.avsc
@@ -40,7 +40,7 @@
       "type": "boolean"
     },
     {
-      "name": "parentGroupId",
+      "name": "parentGroupAssociation",
       "type": [ "null", "net.corda.data.permissions.GroupAssociation" ],
       "doc": "Optional parent group associated with this User."
     },

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 25
+cordaApiRevision = 26
 
 # Main
 kotlinVersion = 1.4.32


### PR DESCRIPTION
Fixing the name of parentGroupId to parentGroupAssociation.
Breaking change as corda-runtime-os has references to `parentGroup.parentGroupId` in `PermissionValidatorImpl`