### PR TITLE
NOTICK fixed bug

### DIFF
--- a/packaging/src/main/kotlin/net/corda/packaging/util/ZipTweaker.kt
+++ b/packaging/src/main/kotlin/net/corda/packaging/util/ZipTweaker.kt
@@ -121,7 +121,7 @@ open class ZipTweaker {
                     }
                 }.run(Files.newInputStream(jarFile), Files.newOutputStream(destination))
                 if(outFile == null) {
-                    Files.move(destination, jarFile, StandardCopyOption.REPLACE_EXISTING)
+                    Files.move(jarFile, destination, StandardCopyOption.REPLACE_EXISTING)
                 }
             } catch (e: Throwable) {
                 destination.takeIf(Files::exists)?.let(Files::delete)


### PR DESCRIPTION
`Files.move` takes `source` as a first argument and then `target` as a second argument. This class is currently only used for tests so it shouldn't have a big impact.

