### PR TITLE
NOTICK:  revert remove duplicate `HoldingIdentity`, consolidate on `identity` version (#150)

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/app/AuthenticatedMessageHeader.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/app/AuthenticatedMessageHeader.avsc
@@ -5,11 +5,11 @@
   "fields": [
     {
       "name": "destination",
-      "type": "net.corda.data.identity.HoldingIdentity"
+      "type": "net.corda.p2p.app.HoldingIdentity"
     },
     {
       "name": "source",
-      "type": "net.corda.data.identity.HoldingIdentity"
+      "type": "net.corda.p2p.app.HoldingIdentity"
     },
     {
       "name": "ttl",

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/app/HoldingIdentity.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/app/HoldingIdentity.avsc
@@ -1,0 +1,15 @@
+{
+  "type": "record",
+  "name": "HoldingIdentity",
+  "namespace": "net.corda.p2p.app",
+  "fields": [
+    {
+      "name": "x500Name",
+      "type": "string"
+    },
+    {
+      "name": "groupId",
+      "type": "string"
+    }
+  ]
+}

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/app/UnauthenticatedMessageHeader.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/app/UnauthenticatedMessageHeader.avsc
@@ -5,11 +5,11 @@
   "fields": [
     {
       "name": "destination",
-      "type": "net.corda.data.identity.HoldingIdentity"
+      "type": "net.corda.p2p.app.HoldingIdentity"
     },
     {
       "name": "source",
-      "type": "net.corda.data.identity.HoldingIdentity"
+      "type": "net.corda.p2p.app.HoldingIdentity"
     }
   ]
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 28
+cordaApiRevision = 27
 
 # Main
 kotlinVersion = 1.4.32


### PR DESCRIPTION
Merged too quickly - didn't manage to test the downstream changes using `alpha` tag, so reverting temporarily.