### PR TITLE
CORE-3078 rename networkPolicy to groupPolicy

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/packaging/CPIMetadata.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/packaging/CPIMetadata.avsc
@@ -16,7 +16,7 @@
       "type": { "type": "array", "items": "net.corda.data.packaging.CPKMetadata" }
     },
     {
-      "name": "networkPolicy",
+      "name": "groupPolicy",
       "type": ["string", "null"]
     }
   ]

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 29
+cordaApiRevision = 30
 
 # Main
 kotlinVersion = 1.4.32

--- a/packaging/packaging-avro-converters/src/main/kotlin/net/corda/packaging/converters/Converters.kt
+++ b/packaging/packaging-avro-converters/src/main/kotlin/net/corda/packaging/converters/Converters.kt
@@ -137,13 +137,12 @@ fun CPIMetadata.toCorda() = CPI.Metadata.newInstance(
     id.toCorda(),
     net.corda.v5.crypto.SecureHash(hash.algorithm, hash.serverHash.array()),
     cpks.map(CPKMetadata::toCorda),
-    networkPolicy
+    groupPolicy
 )
 
 fun CPI.Metadata.toAvro() = CPIMetadata.newBuilder().also {
     it.id = id.toAvro()
     it.hash = SecureHash(hash.algorithm, ByteBuffer.wrap(hash.bytes))
     it.cpks = cpks.map(CPK.Metadata::toAvro)
-    it.networkPolicy = networkPolicy
+    it.groupPolicy = groupPolicy
 }.build()
-

--- a/packaging/packaging-avro-converters/src/test/kotlin/net/corda/packaging/converters/ConvertersTest.kt
+++ b/packaging/packaging-avro-converters/src/test/kotlin/net/corda/packaging/converters/ConvertersTest.kt
@@ -80,7 +80,7 @@ class ConvertersTest {
             cpiMetadata1.cpks.asSequence().zip(cpiMetadata2.cpks.asSequence()).forEach {
                 Assertions.assertEquals(it.first, it.second)
             }
-            Assertions.assertEquals(cpiMetadata1.networkPolicy, cpiMetadata2.networkPolicy)
+            Assertions.assertEquals(cpiMetadata1.groupPolicy, cpiMetadata2.groupPolicy)
         }
     }
 

--- a/packaging/src/main/kotlin/net/corda/packaging/CPI.kt
+++ b/packaging/src/main/kotlin/net/corda/packaging/CPI.kt
@@ -17,7 +17,7 @@ interface CPI : AutoCloseable {
 
         /**
          * Known file extensions for a CPI file; the only difference between CPI and CPB files is that CPB files
-         * have no [CPI.Metadata.networkPolicy]
+         * have no [CPI.Metadata.groupPolicy]
          */
         val fileExtensions = listOf(".cpb", ".cpi")
 
@@ -107,7 +107,7 @@ interface CPI : AutoCloseable {
         val id : Identifier
         val hash : SecureHash
         val cpks : Collection<CPK.Metadata>
-        val networkPolicy : String?
+        val groupPolicy : String?
 
         /**
          * @return a [CPK.Metadata] instance with containing the information about a single [CPK]
@@ -132,8 +132,8 @@ interface CPI : AutoCloseable {
                 CPILoader.loadMetadata(inputStream, cpiLocation, verifySignature)
 
             @JvmStatic
-            fun newInstance(id : Identifier, hash: SecureHash, cpks: Iterable<CPK.Metadata>, networkPolicy : String?) : Metadata =
-                CPIMetadataImpl(id, hash, cpks, networkPolicy)
+            fun newInstance(id : Identifier, hash: SecureHash, cpks: Iterable<CPK.Metadata>, groupPolicy : String?) : Metadata =
+                CPIMetadataImpl(id, hash, cpks, groupPolicy)
         }
     }
 

--- a/packaging/src/main/kotlin/net/corda/packaging/internal/CPIImpl.kt
+++ b/packaging/src/main/kotlin/net/corda/packaging/internal/CPIImpl.kt
@@ -27,7 +27,7 @@ internal class CPIMetadataImpl(
     override val id: CPI.Identifier,
     override val hash : SecureHash,
     cpks: Iterable<CPK.Metadata>,
-    override val networkPolicy: String?) : CPI.Metadata {
+    override val groupPolicy: String?) : CPI.Metadata {
     private val cpkMap : NavigableMap<CPK.Identifier, CPK.Metadata>
 
     init {

--- a/packaging/src/main/kotlin/net/corda/packaging/internal/CPILoader.kt
+++ b/packaging/src/main/kotlin/net/corda/packaging/internal/CPILoader.kt
@@ -77,7 +77,7 @@ internal object CPILoader {
                 signatureCollector.certificates.asSequence().certSummaryHash()),
             hash = SecureHash(DigestAlgorithmName.SHA2_256.name, md.digest()),
             cpks = cpkMetadata,
-            networkPolicy = null
+            groupPolicy = null
         ), cpks.takeIf { expansionLocation != null } )
     }
 }


### PR DESCRIPTION
As per comment in CORE-3078, and consistency with terminology, rename `networkPolicy` usages to `groupPolicy`
