### PR TITLE
CORE-3127: Upgrade Bnd 6.0.0 -> 6.1.0.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,14 +7,14 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 29
+cordaApiRevision = 30
 
 # Main
 kotlinVersion = 1.4.32
 kotlin.stdlib.default.dependency = false
 
 # at the moment, required for packaging to build test cpks for unit tests
-gradlePluginsVersion = 6.0.0-BETA09
+gradlePluginsVersion = 6.0.0-BETA11
 cordaDevPreviewVersion = 5.0.0-DevPreview-RC06
 
 

--- a/packaging/src/main/kotlin/net/corda/packaging/internal/CPKDependencyResolver.kt
+++ b/packaging/src/main/kotlin/net/corda/packaging/internal/CPKDependencyResolver.kt
@@ -3,16 +3,12 @@ package net.corda.packaging.internal
 import net.corda.packaging.CPK
 import net.corda.packaging.DependencyResolutionException
 import net.corda.packaging.VersionComparator
-import net.corda.v5.crypto.SecureHash
 import java.util.Collections
 import java.util.NavigableMap
 import java.util.NavigableSet
 import java.util.TreeSet
 
 internal object CPKDependencyResolver {
-
-    //We need an SecureHash instance that compares lower against with all other
-    private val zerothHash = SecureHash("", ByteArray(1))
 
     @Suppress("NestedBlockDepth", "ComplexMethod", "ThrowsCount")
     fun resolveDependencies(roots: Iterable<CPK.Identifier>,

--- a/packaging/src/main/kotlin/net/corda/packaging/internal/SignatureCollector.kt
+++ b/packaging/src/main/kotlin/net/corda/packaging/internal/SignatureCollector.kt
@@ -2,7 +2,8 @@ package net.corda.packaging.internal
 
 import java.security.CodeSigner
 import java.security.cert.Certificate
-import java.util.*
+import java.util.Arrays
+import java.util.Collections
 import java.util.jar.JarEntry
 
 /**

--- a/packaging/src/main/resources/corda-cpk-1.0.xsd
+++ b/packaging/src/main/resources/corda-cpk-1.0.xsd
@@ -29,10 +29,15 @@
     </xs:complexType>
 
     <xs:complexType name="signersType">
-        <xs:sequence>
-            <xs:element maxOccurs="unbounded" minOccurs="0" name="signer" type="cpk:hashType"/>
-        </xs:sequence>
+        <xs:choice minOccurs="0">
+            <xs:sequence maxOccurs="unbounded">
+                <xs:element name="signer" type="cpk:hashType"/>
+            </xs:sequence>
+            <xs:element name="sameAsMe" type="cpk:sameAsMeType"/>
+        </xs:choice>
     </xs:complexType>
+
+    <xs:complexType name="sameAsMeType"/>
 
     <xs:complexType name="dependencyConstraintsType">
         <xs:sequence>


### PR DESCRIPTION
Upgrade Bnd 6.0.0 -> 6.1.0.

Requires updating `corda-packaging` to understand CPKs with `<sameAsMe/>` signers.