### PR TITLE
CORE-3096 CPI Info service - add Kafka topic

### DIFF
--- a/data/topic-schema/src/main/kotlin/net/corda/schema/Schemas.kt
+++ b/data/topic-schema/src/main/kotlin/net/corda/schema/Schemas.kt
@@ -95,6 +95,7 @@ class Schemas {
          * Virtual Node schema
          */
         const val VIRTUAL_NODE_INFO_TOPIC = "virtual.node.info"
+        const val CPI_INFO_TOPIC = "cpi.info"
 
         fun getRPCResponseTopic(topic: String) = "$topic.resp"
     }


### PR DESCRIPTION
Trivial PR - simply adds the Kafka topic for the cpi info service.