### PR TITLE
NOTICK: Print correct stream size when debugging.

### DIFF
--- a/packaging/src/test/kotlin/net/corda/packaging/CPKTests.kt
+++ b/packaging/src/test/kotlin/net/corda/packaging/CPKTests.kt
@@ -116,11 +116,11 @@ class CPKTests {
                 var size = 0
                 while (true) {
                     val read = stream.read(buffer)
-                    size += read
                     if (read < 0) {
                         println("Stream size: $size")
                         break
                     }
+                    size += read
                     md.update(buffer, 0, read)
                 }
             }


### PR DESCRIPTION
Reading -1 bytes only means "end of stream", so don't add -1 to the total number of bytes.