### PR TITLE
NOTICK Ensure any temporary CPK file is deleted in case of parsing failure

### DIFF
--- a/packaging/src/test/kotlin/net/corda/packaging/CPKTests.kt
+++ b/packaging/src/test/kotlin/net/corda/packaging/CPKTests.kt
@@ -421,10 +421,13 @@ class CPKTests {
         assertThrows<PackagingException> {
             CPK.Metadata.from(Files.newInputStream(nonJarFile), nonJarFile.toString())
         }
+        val cpkCacheSubfolder = Files.createTempDirectory(testDir, null)
         assertThrows<PackagingException> {
-            CPK.from(Files.newInputStream(nonJarFile), processedWorkflowCPKPath, nonJarFile.toString())
+            CPK.from(Files.newInputStream(nonJarFile), cpkCacheSubfolder, nonJarFile.toString())
                 .also(CPK::close)
         }
+        //Make sure any temporary file is deleted when an exception occurs parsing a CPK file
+        Assertions.assertEquals(0, Files.list(cpkCacheSubfolder).count())
     }
 
     @Test


### PR DESCRIPTION
Previously, in case there was a failure parsing a CPK file with `CPK.from` (as with the file wasn't a JAR file at all), the temporary file written on the disk was leaked
