### PR TITLE
NOTICK: update to have team leads owners of gradle.prop file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,3 @@
-# All documentation should be reviewed by the technical writers
-*.md	@corda/technical-writers
 
 # Build scripts should be audited by BLT
 *.gradle           @corda/blt


### PR DESCRIPTION
To prevent bottle necks dependent on BLT for property version bumps added a new github group with corda5-team-leads  

Group details here https://github.com/orgs/corda/teams/corda5-team-leads/members?query=

