### PR TITLE
NOTICK: Add owning holding identity to membership schemas

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/SignedMemberInfo.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/SignedMemberInfo.avsc
@@ -5,6 +5,11 @@
   "doc": "Avro representation of signed MemberInfo.",
   "fields": [
     {
+      "name": "owningHoldingIdentity",
+      "doc": "Holding identity of the member owning the data view.",
+      "type": "net.corda.data.identity.HoldingIdentity"
+    },
+    {
       "name": "memberContext",
       "doc": "Member provided data in MemberInfo serialised as byte array by using KeyValuePairList.",
       "type": "bytes"

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/WireCpiWhitelist.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/WireCpiWhitelist.avsc
@@ -5,6 +5,11 @@
   "doc": "Avro representation of the CpiWhitelist data part, which will be sent over the wire, wrapped into the MembershipPackage.",
   "fields": [
     {
+      "name": "owningHoldingIdentity",
+      "doc": "Holding identity of the member owning the data view.",
+      "type": "net.corda.data.identity.HoldingIdentity"
+    },
+    {
       "name": "cpiWhitelist",
       "doc": "The CpiWhiteList, listing the current, accepted CpiVersions, serialised as bytes by using CpiVersionEntries.",
       "type": "bytes"

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/WireGroupParameters.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/WireGroupParameters.avsc
@@ -5,6 +5,11 @@
   "doc": "Avro representation of GroupParameters data part, which will be sent over the wire, wrapped into the MembershipPackage.",
   "fields": [
     {
+      "name": "owningHoldingIdentity",
+      "doc": "Holding identity of the member owning the data view.",
+      "type": "net.corda.data.identity.HoldingIdentity"
+    },
+    {
       "name": "groupParameters",
       "doc": "GroupParameters entries serialised as byte array by using KeyValuePairList.",
       "type": "bytes"


### PR DESCRIPTION
Adds `owningHoldingIdentity: HoldingIdentity` to `SignedMemberInfo`, `WireGroupParameters`, and `WireCpiWhitelist` schemas.