### PR TITLE
INFRA-1697: use gradle public server for wrapper

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -254,5 +254,4 @@ tasks.named("dependencyUpdates").configure {
 wrapper {
     gradleVersion = '7.3.2'
     distributionType = Wrapper.DistributionType.BIN
-    distributionUrl="https://services.gradle.org/distributions/gradle-$gradleVersion-bin.zip"
 }


### PR DESCRIPTION
use gradle public server for wrapper, CI jobs will still use proxy to prevent flooding gradle servers with requests from our IP addresses. Logic already in place in the Jenkins Shared library project to handle this, 