### PR TITLE
CORE-3066 binary chunk avro message

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/chunking/Chunk.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/chunking/Chunk.avsc
@@ -14,7 +14,7 @@
       "doc": "checksum of assembled chunks"
     },
     {
-      "name": "chunk",
+      "name": "chunkNumber",
       "type": "int",
       "doc": "number of chunk"
     },
@@ -26,10 +26,10 @@
     {
       "name": "offset",
       "type": "long",
-      "doc": "offset of this chunk"
+      "doc": "offset of this chunk from beginning of complete byte array"
     },
     {
-      "name": "payloadSize",
+      "name": "length",
       "type": "long",
       "doc": "number of bytes in payload"
     },


### PR DESCRIPTION
Basic binary chunk to be sent over kafka,
and to be reassembled into a binary larger
than the minimum kafka message.

Generic usage, so *not* in `packaging`.

I think that the `chunkCount` field will ultimately be deleted in favour of returning a zero-sized chunk as a terminator, as per https://datatracker.ietf.org/doc/html/rfc7230#section-4.1

> The chunked transfer coding is complete
>   when a chunk with a chunk-size of zero is received, possibly followed
>   by a trailer, and finally terminated by an empty line.
