### PR TITLE
CORE-3066 remove unneeded fields from avro Chunk class

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 48
+cordaApiRevision = 47
 
 # Main
 kotlinVersion = 1.4.32


### PR DESCRIPTION
We do not need `length` as that is passed in the final
'zero sized' Chunk as the `offset` and we do not need
the size of the `payload`, as that is available via the
`payload` bytes.
