### PR TITLE
CORE-3226 - db connection config

### DIFF
--- a/data/db-schema/src/main/kotlin/net/corda/db/schema/CordaDb.kt
+++ b/data/db-schema/src/main/kotlin/net/corda/db/schema/CordaDb.kt
@@ -1,15 +1,13 @@
 package net.corda.db.schema
 
-import java.util.UUID
-
 /**
  * Corda DB Types
  *
- * When UUID is set, it is the PK for the connection details to be fetched from the cluster DB.
+ * [persistenceUnitName] also used as ID for the connection in the db_connections table.
  */
-enum class CordaDb(val persistenceUnitName: String, val id: UUID? = null) {
+enum class CordaDb(val persistenceUnitName: String) {
     CordaCluster("corda-cluster"),
-    RBAC("corda-rbac", UUID.fromString("fd301442-7ac7-11ec-90d6-0242ac120003")),
+    RBAC("corda-rbac"),
     Vault("corda-vault"),
     Crypto("corda-crypto"),
 }

--- a/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/config-creation-v1.0.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/config-creation-v1.0.xml
@@ -64,6 +64,13 @@
             <column name="connection_id" type="UUID">
                 <constraints nullable="false"/>
             </column>
+            <column name="connection_name" type="VARCHAR(64)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="privilege" type="VARCHAR(3)">
+                <!-- DDL or DML -->
+                <constraints nullable="false"  />
+            </column>
             <column name="version" type="INT">
                 <constraints nullable="false"/>
             </column>
@@ -84,7 +91,9 @@
                 <constraints nullable="false"  />
             </column>
         </createTable>
-        <addPrimaryKey columnNames="connection_id" constraintName="db_connection_pk" tableName="db_connection"
+        <addPrimaryKey tableName="db_connection" columnNames="connection_id" constraintName="db_connection_pk"
                        schemaName="${schema.name}"/>
+        <addUniqueConstraint tableName="db_connection" columnNames="connection_name, privilege" constraintName="db_connection_uc1"
+                             schemaName="${schema.name}"/>
     </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
Change to DB Connection Manager DB script so to use name and privilege as a key rather than ID as it makes it cleaner to look up and avoids hardcoding UUIDs for "well known" DBs (RBAC, Crypto etc).