### PR TITLE
CORE-3065 Chunk ack message

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/chunking/ChunkAck.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/chunking/ChunkAck.avsc
@@ -1,0 +1,31 @@
+{
+  "type": "record",
+  "name": "ChunkAck",
+  "namespace": "net.corda.data.chunking",
+  "doc": "Sent from db worker to rpc worker to acknowledge successful delivery of a {@link net.corda.data.chunking.Chunk}.",
+  "fields": [
+    {
+      "name": "requestId",
+      "type": "string",
+      "doc": "unique identifier that indicates the group this chunk belongs to"
+    },
+    {
+      "name": "partNumber",
+      "type": "int",
+      "doc": "number of chunk received by db worker"
+    },
+    {
+      "name": "success",
+      "type": "boolean",
+      "doc": "whether the request was successful"
+    },
+    {
+      "name": "exception",
+      "type": [
+        "null",
+        "net.corda.data.ExceptionEnvelope"
+      ],
+      "doc": "cause of failure if the request was unsuccessful"
+    }
+  ]
+}


### PR DESCRIPTION
Adds acknowledge message for `net.corda.data.chunking.Chunk`. This proposes an ack message per \`Chunk\` to track progress of `Chunk`s sending.  