### PR TITLE
NOTICK Make avro `Chunk.checksum` nullable

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/chunking/Chunk.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/chunking/Chunk.avsc
@@ -16,7 +16,10 @@
     },
     {
       "name": "checksum",
-      "type": "net.corda.data.crypto.SecureHash",
+      "type": [
+        "null",
+        "net.corda.data.crypto.SecureHash"
+        ],
       "doc": "checksum of assembled chunks"
     },
     {


### PR DESCRIPTION
This is needed as normal `Chunk`s (i.e. not last `Chunk` (zero `Chunk`)) do not have the input stream's checksum as it is not calculated yet. Therefore `Chunk.checksum` is null for those.