### PR TITLE
CORE-3876: Upgrade to Corda Gradle plugins 6.0.0-BETA13.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ kotlinVersion = 1.4.32
 kotlin.stdlib.default.dependency = false
 
 # at the moment, required for packaging to build test cpks for unit tests
-gradlePluginsVersion = 6.0.0-BETA12
+gradlePluginsVersion = 6.0.0-BETA13
 cordaDevPreviewVersion = 5.0.0-DevPreview-RC06
 
 


### PR DESCRIPTION
Fixes an issue with transitive CPK dependencies.