### PR TITLE
CORE-3065 Rename offset in chunk table

### DIFF
--- a/data/db-schema/src/main/resources/net/corda/db/schema/chunks/migration/chunking-creation-v1.0.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/chunks/migration/chunking-creation-v1.0.xml
@@ -26,7 +26,7 @@
             <column name="part_nr" type="INT">
                 <constraints nullable="false"/>
             </column>
-            <column name="offset" type="INT">
+            <column name="data_offset" type="INT">
                 <constraints nullable="false"/>
             </column>
             <!-- 8 * 1024 * 1024 - if you change this field change the MAX_CHUNK_SIZE in corda-runtime-os -->


### PR DESCRIPTION
offset is a reserved keyword in postgres
and hibernate outputs a dialect error otherwise.

Needs merging before the corda-runtime-os version