### PR TITLE
CORE-4080 Add missing request type to crypto RPC ops

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/ops/rpc/RpcOpsRequest.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/ops/rpc/RpcOpsRequest.avsc
@@ -17,6 +17,7 @@
         "SignWithAliasSpecRpcCommand",
         "SignWithSpecRpcCommand",
         "GenerateFreshKeyRpcCommand",
+        "GenerateKeyPairCommand",
         "PublicKeyRpcQuery",
         "FilterMyKeysRpcQuery",
         "SupportedSchemesRpcQuery",


### PR DESCRIPTION
Add crypto request type which is missing from the crypto RPC ops request for generating a new key pair.