### PR TITLE
CORE-4083: Upgrade to Bnd 6.2.0, and Corda Gradle plugins 6.0.0-BETA14.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ kotlinVersion = 1.4.32
 kotlin.stdlib.default.dependency = false
 
 # at the moment, required for packaging to build test cpks for unit tests
-gradlePluginsVersion = 6.0.0-BETA13
+gradlePluginsVersion = 6.0.0-BETA14
 cordaDevPreviewVersion = 5.0.0-DevPreview-RC06
 
 
@@ -58,6 +58,6 @@ mockitoVersion = 4.1.0
 mockitoKotlinVersion = 4.0.0
 
 # OSGi
-bndVersion = 6.1.0
+bndVersion = 6.2.0
 osgiVersion = 8.0.0
 osgiScrAnnotationVersion = 1.4.0


### PR DESCRIPTION
Corda Gradle plugins 6.0.0-BETA14 also uses Bnd 6.2.0, so upgrade these two together.