### PR TITLE
NOTICK Improve exception message when parsing a `SecureHash`

### DIFF
--- a/crypto/src/main/kotlin/net/corda/v5/crypto/SecureHash.kt
+++ b/crypto/src/main/kotlin/net/corda/v5/crypto/SecureHash.kt
@@ -28,7 +28,7 @@ class SecureHash(val algorithm: String, bytes: ByteArray) : OpaqueBytes(bytes) {
         fun create(str: String): SecureHash {
             val idx = str.indexOf(DELIMITER)
             return if (idx == -1) {
-                throw IllegalArgumentException("Provided string should be of format algorithm:hexadecimal")
+                throw IllegalArgumentException("Provided string: $str should be of format algorithm:hexadecimal")
             } else {
                 val algorithm = str.substring(0, idx)
                 val value = str.substring(idx + 1)


### PR DESCRIPTION
Adds the argument string to `SecureHash.create` thrown exception for better exception message.