### PR TITLE
CORE-3067 Expose path and original cpk name

### DIFF
--- a/packaging/src/main/kotlin/net/corda/packaging/CPK.kt
+++ b/packaging/src/main/kotlin/net/corda/packaging/CPK.kt
@@ -26,8 +26,10 @@ interface CPK : AutoCloseable {
         fun from(inputStream : InputStream,
                  cacheDir : Path,
                  cpkLocation : String? = null,
-                 verifySignature : Boolean = jarSignatureVerificationEnabledByDefault()) : CPK =
-            CPKLoader.loadCPK(inputStream, cacheDir, cpkLocation, verifySignature)
+                 verifySignature : Boolean = jarSignatureVerificationEnabledByDefault(),
+                 cpkFileName: String? = null
+        ) : CPK =
+            CPKLoader.loadCPK(inputStream, cacheDir, cpkLocation, verifySignature, cpkFileName)
 
         @JvmStatic
         @JvmOverloads
@@ -197,6 +199,16 @@ interface CPK : AutoCloseable {
      * Stores the metadata associated with this [CPK] file
      */
     val metadata : Metadata
+
+    /**
+     * Path to cpk if it has been extracted or unpacked.  The filename
+     * part of the path should not be depended on and probably won't be the
+     * original name of the cpk.
+     */
+    val path : Path? get() = null
+
+    /** File name of cpk, if known */
+    val originalFileName : String? get() = null
 
     /**
      * Returns an [InputStream] with the content of the associated resource inside the [CPK] archive

--- a/packaging/src/main/kotlin/net/corda/packaging/internal/CPILoader.kt
+++ b/packaging/src/main/kotlin/net/corda/packaging/internal/CPILoader.kt
@@ -10,6 +10,7 @@ import net.corda.v5.crypto.DigestAlgorithmName
 import net.corda.v5.crypto.SecureHash
 import java.io.InputStream
 import java.nio.file.Path
+import java.nio.file.Paths
 import java.security.DigestInputStream
 import java.security.MessageDigest
 import java.util.jar.JarInputStream
@@ -56,7 +57,9 @@ internal object CPILoader {
                                 uncloseableInputStream,
                                 expansionLocation,
                                 cpkLocation = cpiLocation.plus("/${entry.name}"),
-                                verifySignature = verifySignature)
+                                verifySignature = verifySignature,
+                                cpkFileName = Paths.get(entry.name).fileName.toString()
+                            )
                             cpks += cpk
                             cpkMetadata += cpk.metadata
                         } else {

--- a/packaging/src/main/kotlin/net/corda/packaging/internal/CPKImpl.kt
+++ b/packaging/src/main/kotlin/net/corda/packaging/internal/CPKImpl.kt
@@ -6,6 +6,7 @@ import net.corda.packaging.PackagingException
 import net.corda.packaging.VersionComparator
 import net.corda.v5.crypto.SecureHash
 import java.io.IOException
+import java.nio.file.Path
 import java.security.cert.Certificate
 import java.util.NavigableSet
 import java.util.jar.JarFile
@@ -44,12 +45,23 @@ internal data class CPKMetadataImpl(
     )
 }
 
-internal class CPKImpl(override val metadata: CPK.Metadata, private val jarFile : JarFile) : CPK {
+internal class CPKImpl(
+    override val metadata: CPK.Metadata,
+    private val jarFile: JarFile,
+    private val cpkPath: Path,
+    private val cpkFileName: String?
+) : CPK {
     override fun getResourceAsStream(resourceName: String) = jarFile.getJarEntry(resourceName)
         ?.let(jarFile::getInputStream)
         ?: throw IOException("Unknown resource $resourceName")
 
     override fun close() = jarFile.close()
+
+    override val path: Path?
+        get() = cpkPath
+
+    override val originalFileName: String?
+        get() = cpkFileName
 }
 
 internal data class CPKFormatVersionImpl(override val major: Int, override val minor: Int) : CPK.FormatVersion {

--- a/packaging/src/main/kotlin/net/corda/packaging/internal/CPKLoader.kt
+++ b/packaging/src/main/kotlin/net/corda/packaging/internal/CPKLoader.kt
@@ -120,7 +120,8 @@ internal object CPKLoader {
         var cpkManifest: CPK.Manifest?,
         val libraryMap: NavigableMap<String, SecureHash>,
         var libraryConstraints: NavigableMap<String, SecureHash>,
-        var cpkDependencies: NavigableSet<CPK.Identifier>
+        var cpkDependencies: NavigableSet<CPK.Identifier>,
+        val cpkFileName: String?
     ) {
         @Suppress("ThrowsCount")
         fun validate() {
@@ -153,7 +154,9 @@ internal object CPKLoader {
 
             return CPKImpl(
                 metadata = metadata,
-                jarFile = JarFile(finalCPKFile, verifySignature)
+                jarFile = JarFile(finalCPKFile, verifySignature),
+                cpkPath = finalCPKFile.toPath(),
+                cpkFileName = cpkFileName
             )
         }
 
@@ -283,7 +286,8 @@ internal object CPKLoader {
         source: InputStream,
         cacheDir: Path?,
         cpkLocation: String?,
-        verifySignature: Boolean
+        verifySignature: Boolean,
+        cpkFileName: String?
     ): CPKContext {
         val ctx = CPKContext(
             buffer = ByteArray(DEFAULT_BUFFER_SIZE),
@@ -306,7 +310,8 @@ internal object CPKLoader {
                 { msg: String -> msg }
             } else {
                 { msg: String -> "$msg in CPK at $cpkLocation" }
-            }
+            },
+            cpkFileName = cpkFileName
         )
         var stream2BeFullyConsumed: InputStream = DigestInputStream(source, ctx.cpkDigest)
         val temporaryCPKFile = ctx.temporaryCPKFile
@@ -339,11 +344,11 @@ internal object CPKLoader {
         return ctx
     }
 
-    fun loadCPK(source: InputStream, cacheDir: Path?, cpkLocation: String?, verifySignature: Boolean) =
-        createContext(source, cacheDir, cpkLocation, verifySignature).buildCPK()
+    fun loadCPK(source: InputStream, cacheDir: Path?, cpkLocation: String?, verifySignature: Boolean, cpkFileName: String?) =
+        createContext(source, cacheDir, cpkLocation, verifySignature, cpkFileName).buildCPK()
 
     fun loadMetadata(source: InputStream, cpkLocation: String?, verifySignature: Boolean) =
-        createContext(source, null, cpkLocation, verifySignature).buildMetadata()
+        createContext(source, null, cpkLocation, verifySignature, null).buildMetadata()
 
     /**
      * [Iterator] for traversing every [Element] within a [NodeList].


### PR DESCRIPTION
Expose both the expanded path to a cpk if it has been written to disk
and also the original filename, if expanded from a cpi/cpk, using the
jar archive's `entry.name`
