### PR TITLE
CORE-4100: activate build scans for Gradle Enterprise

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -62,5 +62,7 @@ bndVersion = 6.2.0
 osgiVersion = 8.0.0
 osgiScrAnnotationVersion = 1.4.0
 
+gradleEnterpriseVersion = 3.8.1
+gradleDataPlugin = 1.6.2
 org.gradle.caching = false
 gradleEnterpriseUrl = https://gradle.dev.r3.com

--- a/settings.gradle
+++ b/settings.gradle
@@ -39,8 +39,8 @@ pluginManagement {
     }
 
     plugins {
-        id 'com.gradle.enterprise' version '3.8.1'
-        id 'com.gradle.common-custom-user-data-gradle-plugin' version '1.6.2'
+        id 'com.gradle.enterprise' version gradleEnterpriseVersion
+        id 'com.gradle.common-custom-user-data-gradle-plugin' version gradleDataPlugin
         id 'net.corda.plugins.cordapp-cpk' version gradlePluginsVersion
         id 'org.jetbrains.kotlin.jvm' version kotlinVersion
         id 'org.jetbrains.kotlin.plugin.allopen' version kotlinVersion


### PR DESCRIPTION
Activate Build scans for Corda-api gradle enterprise trial.

If API key is set build scan will be published other wise no action is taken 