### PR TITLE
NOTICK - bump version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 65
+cordaApiRevision = 66
 
 # Main
 kotlinVersion = 1.4.32


### PR DESCRIPTION
Pump version number as release built is failing.

This is due to this merge: https://github.com/corda/corda-api/pull/282

The 65 revision must have been merged to the main branch between the build and merge of PR 282