### PR TITLE
CORE-4205 add retry test plugin for flaky tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ plugins {
     id 'org.jetbrains.kotlin.plugin.allopen' apply false
     id 'org.jetbrains.kotlin.plugin.jpa' apply false
     id 'io.gitlab.arturbosch.detekt' apply false
+    id "org.gradle.test-retry" apply false
     id 'org.ajoberstar.grgit' // used for GIT interaction (e.g. extract commit hash)
     id 'com.r3.internal.gradle.plugins.r3ArtifactoryPublish'
     id 'maven-publish'
@@ -99,6 +100,8 @@ subprojects {
             }
         }
     }
+
+    apply plugin: "org.gradle.test-retry" 
 
     pluginManager.withPlugin('org.jetbrains.kotlin.jvm') {
         apply plugin: 'io.gitlab.arturbosch.detekt'
@@ -227,6 +230,13 @@ subprojects {
         doFirst {
             // Create all temporary files within the build directory.
             systemProperty 'java.io.tmpdir', buildDir.absolutePath
+        }
+
+        retry {
+            if (System.getenv().containsKey("JENKINS_URL")) {
+                maxRetries = 2
+                maxFailures = 10
+            }
         }
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -65,3 +65,4 @@ gradleEnterpriseVersion = 3.8.1
 gradleDataPlugin = 1.6.2
 org.gradle.caching = false
 gradleEnterpriseUrl = https://gradle.dev.r3.com
+gradleTestRetryPluginVersion = 1.3.1

--- a/settings.gradle
+++ b/settings.gradle
@@ -54,6 +54,8 @@ pluginManagement {
         id 'org.jetbrains.dokka' version dokkaVersion
         id "com.github.davidmc24.gradle.plugin.avro-base" version avroGradlePluginVersion
         id 'com.github.ben-manes.versions' version gradleVersions
+        id "org.gradle.test-retry" version gradleTestRetryPluginVersion
+
     }
 }
 plugins {


### PR DESCRIPTION
allows for flakey tests analysis and re running of said tests. IF a test fails as part of the test task it will attempt to re run it, marking it as flakey if it subsequently fails, we can then get stats on these in Gradle enterprise.