### PR TITLE
CORE-4141: Changes for DB Audit Tables

### DIFF
--- a/data/db-schema/src/main/kotlin/net/corda/db/schema/DbSchema.kt
+++ b/data/db-schema/src/main/kotlin/net/corda/db/schema/DbSchema.kt
@@ -9,11 +9,15 @@ object DbSchema {
     const val RPC_RBAC = "RPC_RBAC"
 
     const val CONFIG = "CONFIG"
-    const val CONFIG_DB_TABLE = "config"
-    const val CONFIG_AUDIT_DB_TABLE = "config_audit"
+    const val CONFIG_TABLE = "config"
+    const val CONFIG_AUDIT_TABLE = "config_audit"
     const val CONFIG_AUDIT_ID_SEQUENCE = "config_audit_id_seq"
     const val CONFIG_AUDIT_ID_SEQUENCE_ALLOC_SIZE = 1
-    const val CONFIG_DB_CONNECTION_TABLE = "db_connection"
+    
+    const val DB_CONNECTION_TABLE = "db_connection"
+    const val DB_CONNECTION_AUDIT_TABLE = "db_connection_audit"
+    const val DB_CONNECTION_AUDIT_ID_SEQUENCE = "db_connection_audit_id_seq"
+    const val DB_CONNECTION_AUDIT_ID_SEQUENCE_ALLOC_SIZE = 1
 
     const val VNODE = "VNODE"
     const val VNODE_INSTANCE_DB_TABLE = "vnode_instance"

--- a/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/config-creation-v1.0.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/config-creation-v1.0.xml
@@ -54,7 +54,6 @@
                 <constraints nullable="false"/>
             </column>
         </createTable>
-
         <addPrimaryKey columnNames="change_number" constraintName="config_audit_pk" tableName="config_audit"
                        schemaName="${schema.name}"/>
         <createSequence sequenceName="config_audit_id_seq"/>
@@ -91,6 +90,40 @@
                        schemaName="${schema.name}"/>
         <addUniqueConstraint tableName="db_connection" columnNames="connection_name, privilege" constraintName="db_connection_uc1"
                              schemaName="${schema.name}"/>
+
+        <createTable tableName="db_connection_audit" schemaName="${schema.name}">
+            <column name="change_number" type="SERIAL">
+                <constraints nullable="false"/>
+            </column>
+            <column name="connection_id" type="UUID">
+                <constraints nullable="false"/>
+            </column>
+            <column name="connection_name" type="VARCHAR(64)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="privilege" type="VARCHAR(3)">
+                <!-- DDL or DML -->
+                <constraints nullable="false"  />
+            </column>
+            <column name="version" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="update_ts" type="DATETIME">
+                <constraints nullable="false"/>
+            </column>
+            <column name="update_actor" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="description" type="VARCHAR(255)">
+                <constraints nullable="true"/>
+            </column>
+            <column name="config" type="TEXT">
+                <constraints nullable="false"  />
+            </column>
+        </createTable>
+        <addPrimaryKey tableName="db_connection_audit" columnNames="change_number" constraintName="db_connection_audit_pk"
+                       schemaName="${schema.name}"/>
+        <createSequence sequenceName="db_connection_audit_id_seq"/>
 
         <!-- virtual nodes -->
         <createTable tableName="holding_identity" schemaName="${schema.name}">

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 74
+cordaApiRevision = 75
 
 # Main
 kotlinVersion = 1.4.32


### PR DESCRIPTION
Updates to corda-api for changes to DB Audit Tables.
(This PR replaces a previous one which will be closed & deleted).