### PR TITLE
CORE-3562 Adding enabled flag into the user permission summary 

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/permissions/summary/UserPermissionSummary.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/permissions/summary/UserPermissionSummary.avsc
@@ -8,6 +8,10 @@
       "type": "string"
     },
     {
+      "name": "enabled",
+      "type": "boolean"
+    },
+    {
       "name": "permissions",
       "type": {
         "type": "array",

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 75
+cordaApiRevision = 76
 
 # Main
 kotlinVersion = 1.4.32


### PR DESCRIPTION
This will allow us to disable a user and update the flag in the kafka topics.

An alternative is that when we disable a user we remove all permissions from the user's summary in kafka, this logic would need to be added into the permission-storage-reader and when a user is disabled it will appear like they have no permissions.

It may be more explicit and better to just include this enabled flag in the summary topic.