### PR TITLE
CORE-4194 - Add reconciliation configurations for permission summary and CPK write

### DIFF
--- a/data/config-schema/src/main/kotlin/net/corda/schema/configuration/ConfigDefaults.kt
+++ b/data/config-schema/src/main/kotlin/net/corda/schema/configuration/ConfigDefaults.kt
@@ -13,6 +13,8 @@ package net.corda.schema.configuration
 object ConfigDefaults {
     const val JDBC_DRIVER = "org.postgresql.Driver"
     const val DB_POOL_MAX_SIZE = 10
+    const val RECONCILIATION_PERMISSION_SUMMARY_INTERVAL_MS: Long = 60000L
+    const val RECONCILIATION_CPK_WRITE_INTERVAL_MS: Long = 10000L
 
     val WORKSPACE_DIR = "${System.getProperty("java.io.tmpdir")}/corda/workspace"
     val TEMP_DIR = "${System.getProperty("java.io.tmpdir")}/corda/tmp"

--- a/data/config-schema/src/main/kotlin/net/corda/schema/configuration/ConfigKeys.kt
+++ b/data/config-schema/src/main/kotlin/net/corda/schema/configuration/ConfigKeys.kt
@@ -45,4 +45,8 @@ object ConfigKeys {
 
     const val WORKSPACE_DIR = "dir.workspace"
     const val TEMP_DIR = "dir.tmp"
+
+    // Scheduled reconciliation tasks
+    const val RECONCILIATION_PERMISSION_SUMMARY_INTERVAL_MS = "reconciliation.permissionSummary.intervalMs"
+    const val RECONCILIATION_CPK_WRITE_INTERVAL_MS = "reconciliation.cpkWrite.intervalMs"
 }


### PR DESCRIPTION
Adding config keys shouldn't be a breaking change and we shouldn't have to increment version number.

https://github.com/corda/corda-runtime-os/pull/1106 uses the config key and defaults for reconciliation tasks in the database worker.

