### PR TITLE
CORE-4415 CPI Info DB/Kafka reconciliation

### DIFF
--- a/data/config-schema/src/main/kotlin/net/corda/schema/configuration/ConfigKeys.kt
+++ b/data/config-schema/src/main/kotlin/net/corda/schema/configuration/ConfigKeys.kt
@@ -47,6 +47,7 @@ object ConfigKeys {
     // Scheduled reconciliation tasks
     const val RECONCILIATION_PERMISSION_SUMMARY_INTERVAL_MS = "permissionSummary.intervalMs"
     const val RECONCILIATION_CPK_WRITE_INTERVAL_MS = "cpkWrite.intervalMs"
+    const val RECONCILIATION_CPI_INFO_INTERVAL_MS = "cpiInfo.intervalMs"
 
     // Sandbox
     const val SANDBOX_CACHE_SIZE = "cache.size"

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/reconciliation/1.0/corda.reconciliation.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/reconciliation/1.0/corda.reconciliation.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://corda.r3.com/net/corda/schema/configuration/reconciliation/1.0/corda.reconciliation.json",
+  "title": "Corda Reconciliation Configuration Schema",
+  "description": "Configuration schema for the reconciliation subsection.",
+  "type": "object",
+  "properties": {}
+}

--- a/data/config-schema/src/test/kotlin/net/corda/schema/configuration/provider/impl/SchemaProviderImplTest.kt
+++ b/data/config-schema/src/test/kotlin/net/corda/schema/configuration/provider/impl/SchemaProviderImplTest.kt
@@ -8,6 +8,7 @@ import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
 import net.corda.schema.configuration.ConfigKeys.P2P_CONFIG
 import net.corda.schema.configuration.ConfigKeys.PLATFORM_CONFIG
 import net.corda.schema.configuration.ConfigKeys.POLICY_CONFIG
+import net.corda.schema.configuration.ConfigKeys.RECONCILIATION_CONFIG
 import net.corda.schema.configuration.ConfigKeys.RPC_CONFIG
 import net.corda.schema.configuration.ConfigKeys.SANDBOX_CONFIG
 import net.corda.schema.configuration.ConfigKeys.SECRETS_CONFIG
@@ -37,7 +38,8 @@ class SchemaProviderImplTest {
             POLICY_CONFIG,
             RPC_CONFIG,
             SECRETS_CONFIG,
-            SANDBOX_CONFIG
+            SANDBOX_CONFIG,
+            RECONCILIATION_CONFIG
         )
         private val VERSIONS = listOf("1.0")
 

--- a/data/db-schema/src/main/kotlin/net/corda/db/schema/DbSchema.kt
+++ b/data/db-schema/src/main/kotlin/net/corda/db/schema/DbSchema.kt
@@ -28,10 +28,6 @@ object DbSchema {
 
     const val DB_MESSAGE_BUS = "DB_MESSAGE_BUS"
 
-    // The values here are placeholders, until reasonable values are determined.
-    const val CPI_REVISION_SEQUENCE = "r_db"
-    const val CPI_REVISION_SEQUENCE_ALLOC_SIZE = 1
-
     const val CRYPTO = "CRYPTO"
     const val CRYPTO_WRAPPING_KEY_TABLE = "crypto_wrapping_key"
     const val CRYPTO_SIGNING_KEY_TABLE = "crypto_signing_key"

--- a/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/cpx-creation-v1.0.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/cpx-creation-v1.0.xml
@@ -36,6 +36,12 @@
             <column name="file_upload_request_id" type="VARCHAR(255)">
                 <constraints nullable="true"/>
             </column>
+            <column name="entity_version" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="is_deleted" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
             <column name="insert_ts" type="TIMESTAMP"
                     defaultValueComputed="CURRENT_TIMESTAMP">
                 <constraints nullable="false"/>
@@ -81,6 +87,28 @@
             <column name="cpk_file_checksum" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
+            <column name="cpk_main_bundle_name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="cpk_main_bundle_version" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="cpk_signer_summary_hash" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="cpk_manifest_major_version" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="cpk_manifest_minor_version" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <!-- duplicate with cpk_main_bundle_name? -->
+            <column name="cpk_main_bundle" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="cpk_type" type="VARCHAR(255)">
+                <constraints nullable="true"/>
+            </column>
             <column name="insert_ts" type="TIMESTAMP"
                     defaultValueComputed="CURRENT_TIMESTAMP">
                 <constraints nullable="false"/>
@@ -102,5 +130,132 @@
                                  baseTableSchemaName="${schema.name}"
                                  referencedTableSchemaName="${schema.name}"/>
 
+        <createTable tableName="cpk_library" schemaName="${schema.name}">
+            <column name="cpi_name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="cpi_version" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="cpi_signer_summary_hash" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="cpk_file_checksum" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="library_name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addPrimaryKey tableName="cpk_library"
+                       columnNames="cpi_name, cpi_version, cpi_signer_summary_hash, cpk_file_checksum, library_name"
+                       constraintName="cpk_library_pk"
+                       schemaName="${schema.name}"/>
+
+        <addForeignKeyConstraint baseTableName="cpk_library" baseColumnNames="cpi_name, cpi_version, cpi_signer_summary_hash, cpk_file_checksum"
+                                 referencedTableName="cpi_cpk" referencedColumnNames="cpi_name, cpi_version, cpi_signer_summary_hash, cpk_file_checksum"
+                                 constraintName="FK_cpk_library_cpi_cpk"
+                                 baseTableSchemaName="${schema.name}"
+                                 referencedTableSchemaName="${schema.name}"/>
+
+        <createTable tableName="cpk_dependency" schemaName="${schema.name}">
+            <column name="cpi_name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="cpi_version" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="cpi_signer_summary_hash" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="cpk_file_checksum" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="main_bundle_name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="main_bundle_version" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="signer_summary_hash" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addPrimaryKey tableName="cpk_dependency"
+                       columnNames="cpi_name, cpi_version, cpi_signer_summary_hash, cpk_file_checksum, main_bundle_name, main_bundle_version, signer_summary_hash"
+                       constraintName="cpk_dependency_pk"
+                       schemaName="${schema.name}"/>
+
+        <addForeignKeyConstraint baseTableName="cpk_dependency" baseColumnNames="cpi_name, cpi_version, cpi_signer_summary_hash, cpk_file_checksum"
+                                 referencedTableName="cpi_cpk" referencedColumnNames="cpi_name, cpi_version, cpi_signer_summary_hash, cpk_file_checksum"
+                                 constraintName="FK_cpk_dependency_cpi_cpk"
+                                 baseTableSchemaName="${schema.name}"
+                                 referencedTableSchemaName="${schema.name}"/>
+
+        <createTable tableName="cpk_cordapp_manifest" schemaName="${schema.name}">
+            <column name="cpi_name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="cpi_version" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="cpi_signer_summary_hash" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="cpk_file_checksum" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <!-- Check if we could rename this to main_bundle_name -->
+            <column name="bundle_symbolic_name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <!-- Check if we could rename this to main_bundle_version -->
+            <column name="bundle_version" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="min_platform_version" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="target_platform_version" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="contract_info_short_name" type="VARCHAR(255)">
+                <constraints nullable="true"/>
+            </column>
+            <column name="contract_info_vendor" type="VARCHAR(255)">
+                <constraints nullable="true"/>
+            </column>
+            <column name="contract_info_version_id" type="INT">
+                <constraints nullable="true"/>
+            </column>
+            <column name="contract_info_license" type="VARCHAR(255)">
+                <constraints nullable="true"/>
+            </column>
+            <column name="work_flow_info_short_name" type="VARCHAR(255)">
+                <constraints nullable="true"/>
+            </column>
+            <column name="work_flow_info_vendor" type="VARCHAR(255)">
+                <constraints nullable="true"/>
+            </column>
+            <column name="work_flow_info_version_id" type="INT">
+                <constraints nullable="true"/>
+            </column>
+            <column name="work_flow_info_license" type="VARCHAR(255)">
+                <constraints nullable="true"/>
+            </column>
+        </createTable>
+
+        <addPrimaryKey tableName="cpk_cordapp_manifest"
+                       columnNames="cpi_name, cpi_version, cpi_signer_summary_hash, cpk_file_checksum, bundle_symbolic_name, bundle_version, min_platform_version, target_platform_version"
+                       constraintName="cpk_cordapp_manifest_pk"
+                       schemaName="${schema.name}"/>
+
+        <addForeignKeyConstraint baseTableName="cpk_cordapp_manifest" baseColumnNames="cpi_name, cpi_version, cpi_signer_summary_hash, cpk_file_checksum"
+                                 referencedTableName="cpi_cpk" referencedColumnNames="cpi_name, cpi_version, cpi_signer_summary_hash, cpk_file_checksum"
+                                 constraintName="FK_cpk_cordapp_manifest_cpi_cpk"
+                                 baseTableSchemaName="${schema.name}"
+                                 referencedTableSchemaName="${schema.name}"/>
     </changeSet>
 </databaseChangeLog>

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 98
+cordaApiRevision = 99
 
 # Main
 kotlinVersion = 1.6.21


### PR DESCRIPTION
- adds version field to `cpi` table (CPI metadata table) which is meant for addressing race conditions from updating compacted topics (readers of the compacted topic should keep track of version and if they encounter a lesser version ignore it).
- adds `is_deleted` flag at `cpi` table for soft DB deletes.
- adds missing `CPK` metadata.

Its complement `corda-runtime-os` PR is [#1137](https://github.com/corda/corda-runtime-os/pull/1137).