### PR TITLE
CORE-4095 Correct bnd scan for entities

### DIFF
--- a/cordapp-configuration/src/main/resources/net/corda/cordapp/cordapp-configuration.properties
+++ b/cordapp-configuration/src/main/resources/net/corda/cordapp/cordapp-configuration.properties
@@ -8,7 +8,7 @@ Corda-NotaryService-Classes=EXTENDS;net.corda.v5.ledger.notary.NotaryService
 Corda-StateAndRefPostProcessor-Classes=IMPLEMENTS;net.corda.v5.ledger.services.vault.StateAndRefPostProcessor
 Corda-CustomQueryPostProcessor-Classes=IMPLEMENTS;net.corda.v5.application.persistence.query.CustomQueryPostProcessor
 Corda-DigestAlgorithmFactory-Classes=IMPLEMENTS;net.corda.v5.cipher.suite.DigestAlgorithmFactory
-Corda-Entity-Classes=ANNOTATED;javax.persistence.Entity
+Corda-Entity-Classes=ANNOTATED;javax.persistence.Entity;ANNOTATED;net.corda.v5.base.annotations.CordaSerializable
 
 # Corda should adjust this version over time, as required.
 Minimum-Corda-Plugins-Version=6.0.0


### PR DESCRIPTION
Since we're serializing the entities using AMQP, we need to also mark
them as `@CordaSerializable`.  If we don't, the bnd scanner will produce
a list of every `@Entity` in a cpk, rather than the subset of ones
that we can actually use to persist from flow (worker) to db (processor).

Tested against in-flight branch in corda-runtime-os