### PR TITLE
NOTICK: Add `install` task for local publishing, and resolve Maven version warning.

### DIFF
--- a/buildSrc/src/main/groovy/corda.common-publishing.gradle
+++ b/buildSrc/src/main/groovy/corda.common-publishing.gradle
@@ -26,4 +26,8 @@ if (System.getenv('CORDA_ARTIFACTORY_USERNAME') != null || project.hasProperty('
             }
         }
     }
+
+    tasks.register('install') {
+        dependsOn 'publishToMavenLocal'
+    }
 }

--- a/data/avro-schema/build.gradle
+++ b/data/avro-schema/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     // Constraints block can be removed when Avro is upgraded to v1.11
     // For more details, please see: https://issues.apache.org/jira/browse/AVRO-3215
     constraints {
-        implementation('org.apache.commons:commons-compress:1.21+') {
+        implementation('org.apache.commons:commons-compress:1.21') {
             because 'CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090'
         }
     }


### PR DESCRIPTION
Add an `install` task for external users to publish to a local Maven repository, and resolve warning about "1.21+" being an invalid version for Maven POM format.

"1.21+" is a Gradle dynamic version, and so makes the build non-deterministic anyway.