### PR TITLE
NOTICK bump dependency versions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -30,7 +30,7 @@ org.gradle.jvmargs=-XX:MaxMetaspaceSize=2g
 internalPublishVersion = 1.+
 dokkaVersion = 1.6.+
 detektPluginVersion = 1.19.+
-gradleVersions=0.42.+
+dependencyCheckVersion=0.42.+
 artifactoryPluginVersion = 4.28.2
 
 # Logging

--- a/settings.gradle
+++ b/settings.gradle
@@ -38,7 +38,7 @@ pluginManagement {
         id 'biz.aQute.bnd.builder' version bndVersion // used to create OSGi bundles
         id 'org.jetbrains.dokka' version dokkaVersion
         id "com.github.davidmc24.gradle.plugin.avro-base" version avroGradlePluginVersion
-        id 'com.github.ben-manes.versions' version gradleVersions
+        id 'com.github.ben-manes.versions' version dependencyCheckVersion
         id "org.gradle.test-retry" version gradleTestRetryPluginVersion
         id "com.jfrog.artifactory" version artifactoryPluginVersion
     }


### PR DESCRIPTION
gradleVersions refers to com.github.ben-manes.versions this IDs potential upgrades for us via a custom gradle task also renamed to dependencyCheckVersion for clarity
gradle test retry plugin also bumped