### PR TITLE
CORE-4807 remove ability to have NOTICK tickets from all open sourced repos

### DIFF
--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -9,6 +9,6 @@ jobs:
     steps:
       - uses: morrisoncole/pr-lint-action@v1.4.2
         with:
-          title-regex: '^((CORDA|EG|ENT|INFRA|CORE)-\d+|NOTICK)(.*)'
+          title-regex: '^((CORDA|EG|ENT|INFRA|CORE)-\d+)(.*)'
           on-failed-regex-comment: "PR title failed to match regex -> `%regex%`"
           repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Improve JIra hygiene - going forward this will check to ensure you have a valid Jira reference when committing work on this repo - NOTICK will not suffice