### PR TITLE
CORE-4724: Revert generate information from Nexus

### DIFF
--- a/.ci/nightly/JenkinsfileNexusScan
+++ b/.ci/nightly/JenkinsfileNexusScan
@@ -1,6 +1,5 @@
 @Library('corda-shared-build-pipeline-steps@5.0') _
 
 cordaNexusScanPipeline(
-    nexusAppId: 'net.corda-api-5.0',
-    nexusAppStage: 'build'
+    nexusAppId: 'net.corda-api-5.0'
 )


### PR DESCRIPTION
This reverts commit 16f058c0c698ab62a37b7b9f1465a8590a54a98c. (#368)

It is no longer needed as a newly introduced parameter has been removed.

Test build at https://ci02.dev.r3.com/blue/organizations/jenkins/Corda5%2FNexus-Scan-Corda-API/detail/CORE-4724-fixes/1/artifacts