### PR TITLE
CORE-4783 entity error response

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/virtualnode/EntityResponse.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/virtualnode/EntityResponse.avsc
@@ -17,12 +17,11 @@
       "doc": "id of this request for tracking"
     },
     {
-      "name": "result",
-      "doc": "Result of request",
+      "name": "responseType",
+      "doc": "Result of request, either a success or failure message",
       "type": [
-        "null",
-        "bytes",
-        "net.corda.data.ExceptionEnvelope"
+        "net.corda.data.virtualnode.EntityResponseSuccess",
+        "net.corda.data.virtualnode.EntityResponseFailure"
       ]
     }
   ]

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/virtualnode/EntityResponseFailure.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/virtualnode/EntityResponseFailure.avsc
@@ -1,0 +1,27 @@
+{
+  "type": "record",
+  "name": "EntityResponseFailure",
+  "namespace": "net.corda.data.virtualnode",
+  "fields": [
+    {
+      "name": "errorType",
+      "doc": "Error type",
+      "type": {
+        "name": "Error",
+        "type": "enum",
+        "doc": "FATAL: almost certainly unrecoverable.\nNOT_READY: the component has not yet started or received all cpks.\nDATABASE: an error during database execution.\nVIRTUAL_NODE: problems retrieving vnode info\nUNKNOWN_COMMAND: an unhandled request payload type",
+        "symbols": [
+          "FATAL",
+          "NOT_READY",
+          "DATABASE",
+          "VIRTUAL_NODE"
+        ]
+      }
+    },
+    {
+      "name": "exception",
+      "doc": "Exception information",
+      "type": "net.corda.data.ExceptionEnvelope"
+    }
+  ]
+}

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/virtualnode/EntityResponseSuccess.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/virtualnode/EntityResponseSuccess.avsc
@@ -1,0 +1,15 @@
+{
+  "type": "record",
+  "name": "EntityResponseSuccess",
+  "namespace": "net.corda.data.virtualnode",
+  "fields": [
+    {
+      "name": "result",
+      "doc": "Result of request, either null, or (amqp) serialized bytes",
+      "type": [
+        "null",
+        "bytes"
+      ]
+    }
+  ]
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 101
+cordaApiRevision = 102
 
 # Main
 kotlinVersion = 1.6.21


### PR DESCRIPTION
Return richer error information to the flow worker, when it makes a request via the PersistenceService to the db worker (entity processor).

Some categories of errors have been added in corda-api.

Please review those and decide whether there are enough or too many.

See also https://github.com/corda/corda-runtime-os/pull/1323

(yes I probably need to bump the version).