### PR TITLE
CORE-3689 API support for MGM handling of registration requests

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/PersistentMemberInfo.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/PersistentMemberInfo.avsc
@@ -11,13 +11,13 @@
     },
     {
       "name": "memberContext",
-      "doc": "Member provided data in MemberInfo serialised as byte array by using KeyValuePairList.",
-      "type": "bytes"
+      "doc": "Member provided data in MemberInfo.",
+      "type": "net.corda.data.KeyValuePairList"
     },
     {
       "name": "mgmContext",
-      "doc": "MGM provided data in MemberInfo serialised as byte array by using KeyValuePairList.",
-      "type": "bytes"
+      "doc": "MGM provided data in MemberInfo.",
+      "type": "net.corda.data.KeyValuePairList"
     }
   ]
 }

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/command/registration/ApproveRegistration.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/command/registration/ApproveRegistration.avsc
@@ -1,0 +1,8 @@
+{
+  "type": "record",
+  "name": "ApproveRegistration",
+  "namespace": "net.corda.data.membership.command.registration",
+  "doc": "Command issued when a member registration has been fully approved and needs to be updated to approved status.",
+  "fields": [
+  ]
+}

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/command/registration/DeclineRegistration.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/command/registration/DeclineRegistration.avsc
@@ -1,0 +1,13 @@
+{
+  "type": "record",
+  "name": "DeclineRegistration",
+  "namespace": "net.corda.data.membership.command.registration",
+  "doc": "Command issued when a member registration has been declined and needs to be updated to declined status.",
+  "fields": [
+    {
+      "name": "reason",
+      "doc": "Reason that the request was declined.",
+      "type": "string"
+    }
+  ]
+}

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/command/registration/ProcessMemberVerification.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/command/registration/ProcessMemberVerification.avsc
@@ -1,0 +1,8 @@
+{
+  "type": "record",
+  "name": "ProcessMemberVerification",
+  "namespace": "net.corda.data.membership.command.registration",
+  "doc": "Command issued when a member responds to the member verification request send to the member by the MGM during registration.",
+  "fields": [
+  ]
+}

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/command/registration/RegistrationCommand.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/command/registration/RegistrationCommand.avsc
@@ -1,0 +1,19 @@
+{
+  "type": "record",
+  "name": "RegistrationCommand",
+  "namespace": "net.corda.data.membership.command.registration",
+  "doc": "Registration event type",
+  "fields": [
+    {
+      "name": "command",
+      "doc": "Indicator of the type of registration command that was issued.",
+      "type": [
+        "net.corda.data.membership.command.registration.StartRegistration",
+        "net.corda.data.membership.command.registration.VerifyMember",
+        "net.corda.data.membership.command.registration.ProcessMemberVerification",
+        "net.corda.data.membership.command.registration.ApproveRegistration",
+        "net.corda.data.membership.command.registration.DeclineRegistration"
+      ]
+    }
+  ]
+}

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/command/registration/StartRegistration.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/command/registration/StartRegistration.avsc
@@ -1,0 +1,23 @@
+{
+  "type": "record",
+  "name": "StartRegistration",
+  "namespace": "net.corda.data.membership.command.registration",
+  "doc": " Command issued when a member registration request is received and needs to be processed.",
+  "fields": [
+    {
+      "name": "destination",
+      "doc": "Holding identity of the target MGM.",
+      "type": "net.corda.data.identity.HoldingIdentity"
+    },
+    {
+      "name": "source",
+      "doc": "Holding identity of the requesting member.",
+      "type": "net.corda.data.identity.HoldingIdentity"
+    },
+    {
+      "name": "memberRegistrationRequest",
+      "doc": "The full registration request as received from a registering member. Optional as it may be persisted after initial processing.",
+      "type": "net.corda.data.membership.p2p.MembershipRegistrationRequest"
+    }
+  ]
+}

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/command/registration/StartRegistration.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/command/registration/StartRegistration.avsc
@@ -16,7 +16,7 @@
     },
     {
       "name": "memberRegistrationRequest",
-      "doc": "The full registration request as received from a registering member. Optional as it may be persisted after initial processing.",
+      "doc": "The full registration request as received from a registering member.",
       "type": "net.corda.data.membership.p2p.MembershipRegistrationRequest"
     }
   ]

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/command/registration/VerifyMember.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/command/registration/VerifyMember.avsc
@@ -1,0 +1,8 @@
+{
+  "type": "record",
+  "name": "VerifyMember",
+  "namespace": "net.corda.data.membership.command.registration",
+  "doc": "Command issued when a member registration request has been validated and the MGM must communication with the member for verify information provided.",
+  "fields": [
+  ]
+}

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/request/MembershipPersistenceRequest.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/request/MembershipPersistenceRequest.avsc
@@ -1,0 +1,22 @@
+{
+  "type": "record",
+  "name": "MembershipPersistenceRequest",
+  "namespace": "net.corda.data.membership.db.request",
+  "doc": "Internal request envelope for persistence operations over RPC.",
+  "fields": [
+    {
+      "name": "context",
+      "type": "net.corda.data.membership.db.request.MembershipRequestContext",
+      "doc": "Context for the given request"
+    },
+    {
+      "name": "request",
+      "type": [
+        "net.corda.data.membership.db.request.command.PersistRegistrationRequest",
+        "net.corda.data.membership.db.request.command.PersistMemberInfo",
+        "net.corda.data.membership.db.request.query.QueryMemberInfo"
+      ],
+      "doc": "Request's payload, depends on the requested operation."
+    }
+  ]
+}

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/request/MembershipRequestContext.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/request/MembershipRequestContext.avsc
@@ -1,0 +1,26 @@
+{
+  "type": "record",
+  "name": "MembershipRequestContext",
+  "namespace": "net.corda.data.membership.db.request",
+  "doc": "Context for a membership persistence request",
+  "fields": [
+    {
+      "name": "requestTimestamp",
+      "type": {
+        "type": "long",
+        "logicalType": "timestamp-millis"
+      },
+      "doc": "Time ([Instant]) in milliseconds of the request."
+    },
+    {
+      "name": "requestId",
+      "type": "string",
+      "doc": "Request id which can be used to track the request progress."
+    },
+    {
+      "name": "holdingIdentity",
+      "type": "net.corda.data.identity.HoldingIdentity",
+      "doc": "Holding identity of the member for which the request is made."
+    }
+  ]
+}

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/request/MembershipRequestContext.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/request/MembershipRequestContext.avsc
@@ -14,8 +14,11 @@
     },
     {
       "name": "requestId",
-      "type": "string",
-      "doc": "Request id which can be used to track the request progress."
+      "doc": "Request id which can be used to track the request progress.",
+      "type": {
+        "type": "string",
+        "logicalType": "uuid"
+      }
     },
     {
       "name": "holdingIdentity",

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/request/command/PersistMemberInfo.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/request/command/PersistMemberInfo.avsc
@@ -1,0 +1,16 @@
+{
+  "type": "record",
+  "name": "PersistMemberInfo",
+  "namespace": "net.corda.data.membership.db.request.command",
+  "doc": "Update or add a member info record.",
+  "fields": [
+    {
+      "name": "members",
+      "doc": "List of MemberInfos to persist.",
+      "type": {
+        "type": "array",
+        "items": "net.corda.data.membership.PersistentMemberInfo"
+      }
+    }
+  ]
+}

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/request/command/PersistRegistrationRequest.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/request/command/PersistRegistrationRequest.avsc
@@ -1,0 +1,34 @@
+{
+  "type": "record",
+  "name": "PersistRegistrationRequest",
+  "namespace": "net.corda.data.membership.db.request.command",
+  "doc": "Update or add a registration request.",
+  "fields": [
+    {
+      "name": "status",
+      "doc": "Indicator of the current status of the request.",
+      "type": {
+        "type": "enum",
+        "name": "RegistrationStatus",
+        "symbols": [
+          "NEW",
+          "PENDING_MEMBER_VERIFICATION",
+          "PENDING_APPROVAL_FLOW",
+          "PENDING_MANUAL_APPROVAL",
+          "DECLINED",
+          "APPROVED"
+        ]
+      }
+    },
+    {
+      "name": "registeringHoldingIdentity",
+      "type": "net.corda.data.identity.HoldingIdentity",
+      "doc": "Holding identity of the member owning the registration request."
+    },
+    {
+      "name": "registrationRequest",
+      "type": "net.corda.data.membership.p2p.MembershipRegistrationRequest",
+      "doc": "The full registration request to persist as received over the P2P layer."
+    }
+  ]
+}

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/request/query/QueryMemberInfo.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/request/query/QueryMemberInfo.avsc
@@ -1,0 +1,16 @@
+{
+  "type": "record",
+  "name": "QueryMemberInfo",
+  "namespace": "net.corda.data.membership.db.request.query",
+  "doc": "Query for one or more member infos",
+  "fields": [
+    {
+      "name": "queryIdentities",
+      "doc": "Holding identities of the members to retrieve.",
+      "type": {
+        "type": "array",
+        "items": "net.corda.data.identity.HoldingIdentity"
+      }
+    }
+  ]
+}

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/response/MembershipPersistenceResponse.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/response/MembershipPersistenceResponse.avsc
@@ -10,26 +10,14 @@
       "doc": "Context for the given request"
     },
     {
-      "name": "success",
-      "type": "boolean",
-      "doc": "Indicator as to whether persistence was successful or not"
-    },
-    {
       "name": "payload",
       "type": [
         "null",
         "net.corda.data.membership.db.response.query.MemberInfoQueryResponse",
-        "net.corda.data.membership.db.response.query.RegistrationRequestQueryResponse"
+        "net.corda.data.membership.db.response.query.RegistrationRequestQueryResponse",
+        "net.corda.data.membership.db.response.query.QueryFailedResponse"
       ],
-      "doc": "Response payload, depends on the requested operation."
-    },
-    {
-      "name": "errorMessage",
-      "type": [
-        "string",
-        "null"
-      ],
-      "doc": "Error message provided in the case of failure."
+      "doc": "Response payload which depends on the requested operation."
     }
   ]
 }

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/response/MembershipPersistenceResponse.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/response/MembershipPersistenceResponse.avsc
@@ -1,0 +1,35 @@
+{
+  "type": "record",
+  "name": "MembershipPersistenceResponse",
+  "namespace": "net.corda.data.membership.db.response",
+  "doc": "Internal response envelope for persistence operations over RPC.",
+  "fields": [
+    {
+      "name": "context",
+      "type": "net.corda.data.membership.db.response.MembershipResponseContext",
+      "doc": "Context for the given request"
+    },
+    {
+      "name": "success",
+      "type": "boolean",
+      "doc": "Indicator as to whether persistence was successful or not"
+    },
+    {
+      "name": "payload",
+      "type": [
+        "null",
+        "net.corda.data.membership.db.response.query.MemberInfoQueryResponse",
+        "net.corda.data.membership.db.response.query.RegistrationRequestQueryResponse"
+      ],
+      "doc": "Response payload, depends on the requested operation."
+    },
+    {
+      "name": "errorMessage",
+      "type": [
+        "string",
+        "null"
+      ],
+      "doc": "Error message provided in the case of failure."
+    }
+  ]
+}

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/response/MembershipResponseContext.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/response/MembershipResponseContext.avsc
@@ -14,8 +14,11 @@
     },
     {
       "name": "requestId",
-      "type": "string",
-      "doc": "Request id which can be used to track the request progress."
+      "doc": "Request id which can be used to track the request progress.",
+      "type": {
+        "type": "string",
+        "logicalType": "uuid"
+      }
     },
     {
       "name": "responseTimestamp",

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/response/MembershipResponseContext.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/response/MembershipResponseContext.avsc
@@ -1,0 +1,34 @@
+{
+  "type": "record",
+  "name": "MembershipResponseContext",
+  "namespace": "net.corda.data.membership.db.response",
+  "doc": "Context for a membership persistence response",
+  "fields": [
+    {
+      "name": "requestTimestamp",
+      "type": {
+        "type": "long",
+        "logicalType": "timestamp-millis"
+      },
+      "doc": "Time ([Instant]) in milliseconds of the request, copied from the corresponding request."
+    },
+    {
+      "name": "requestId",
+      "type": "string",
+      "doc": "Request id which can be used to track the request progress."
+    },
+    {
+      "name": "responseTimestamp",
+      "type": {
+        "type": "long",
+        "logicalType": "timestamp-millis"
+      },
+      "doc": "Time ([Instant]) in milliseconds of the response."
+    },
+    {
+      "name": "holdingIdentity",
+      "type": "net.corda.data.identity.HoldingIdentity",
+      "doc": "Holding identity of the member for which the request was made."
+    }
+  ]
+}

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/response/query/MemberInfoQueryResponse.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/response/query/MemberInfoQueryResponse.avsc
@@ -1,0 +1,16 @@
+{
+  "type": "record",
+  "name": "MemberInfoQueryResponse",
+  "namespace": "net.corda.data.membership.db.response.query",
+  "doc": "Response to a query for one or more member infos",
+  "fields": [
+    {
+      "name": "members",
+      "doc": "Member Infos representing members found for a given query.",
+      "type": {
+        "type": "array",
+        "items": "net.corda.data.membership.PersistentMemberInfo"
+      }
+    }
+  ]
+}

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/response/query/QueryFailedResponse.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/response/query/QueryFailedResponse.avsc
@@ -1,0 +1,13 @@
+{
+  "type": "record",
+  "name": "QueryFailedResponse",
+  "namespace": "net.corda.data.membership.db.response.query",
+  "doc": "Response for when a query failed.",
+  "fields": [
+    {
+      "name": "errorMessage",
+      "type": "string",
+      "doc": "Error message provided in the case of failure."
+    }
+  ]
+}

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/response/query/RegistrationRequestQueryResponse.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/response/query/RegistrationRequestQueryResponse.avsc
@@ -1,0 +1,16 @@
+{
+  "type": "record",
+  "name": "RegistrationRequestQueryResponse",
+  "namespace": "net.corda.data.membership.db.response.query",
+  "doc": "Response to a query for a registration request",
+  "fields": [
+    {
+      "name": "registrationRequest",
+      "type": [
+        "net.corda.data.membership.p2p.MembershipRegistrationRequest",
+        "null"
+      ],
+      "doc": "The registration request queried for or null if the query executed correctly but there were no matches."
+    }
+  ]
+}

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/event/MembershipEvent.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/event/MembershipEvent.avsc
@@ -1,0 +1,16 @@
+{
+  "type": "record",
+  "name": "MembershipEvent",
+  "namespace": "net.corda.data.membership.event",
+  "doc": "Wrapper schema around the various types of membership events available for consumption throughout the system.",
+  "fields": [
+    {
+      "name" : "event",
+      "description": "The member event that occurred.",
+      "type" : [
+        "net.corda.data.membership.event.registration.MemberRegistrationApproved",
+        "net.corda.data.membership.event.registration.MemberRegistrationDeclined"
+      ]
+    }
+  ]
+}

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/event/registration/MemberRegistrationApproved.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/event/registration/MemberRegistrationApproved.avsc
@@ -1,0 +1,13 @@
+{
+  "type": "record",
+  "name": "MemberRegistrationApproved",
+  "namespace": "net.corda.data.membership.event.registration",
+  "doc": "Event for when processing of a registration has finished. Could be for either acceptance or denial.",
+  "fields": [
+    {
+      "name": "approvedMember",
+      "doc": "Holding identity of the member who was approved.",
+      "type": "net.corda.data.identity.HoldingIdentity"
+    }
+  ]
+}

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/event/registration/MemberRegistrationDeclined.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/event/registration/MemberRegistrationDeclined.avsc
@@ -1,0 +1,13 @@
+{
+  "type": "record",
+  "name": "MemberRegistrationDeclined",
+  "namespace": "net.corda.data.membership.event.registration",
+  "doc": "Event for when processing of a registration has finished and the member has been denied access in the group.",
+  "fields": [
+    {
+      "name": "declinedMember",
+      "doc": "Holding identity of the member who was declined. Note: Holding identity was provided by member and maybe not be valid.",
+      "type": "net.corda.data.identity.HoldingIdentity"
+    }
+  ]
+}

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/p2p/CpiVersionEntries.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/p2p/CpiVersionEntries.avsc
@@ -1,7 +1,7 @@
 {
   "type": "record",
   "name": "CpiVersionEntries",
-  "namespace": "net.corda.data.membership",
+  "namespace": "net.corda.data.membership.p2p",
   "doc": "Avro representation of a list of WireCpiVersion.",
   "fields": [
     {

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/p2p/DistributionMetaData.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/p2p/DistributionMetaData.avsc
@@ -1,7 +1,7 @@
 {
   "type": "record",
   "name": "DistributionMetaData",
-  "namespace": "net.corda.data.membership",
+  "namespace": "net.corda.data.membership.p2p",
   "doc": "Basic information regarding a data distribution package which will be sent over the wire, wrapped into the MembershipPackage and the MembershipSyncRequest.",
   "fields": [
     {

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/p2p/MembershipPackage.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/p2p/MembershipPackage.avsc
@@ -1,7 +1,7 @@
 {
   "type": "record",
   "name": "MembershipPackage",
-  "namespace": "net.corda.data.membership",
+  "namespace": "net.corda.data.membership.p2p",
   "doc": "Membership data package which will be distributed on the wire across members.",
   "fields": [
     {

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/p2p/MembershipRegistrationRequest.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/p2p/MembershipRegistrationRequest.avsc
@@ -1,0 +1,23 @@
+{
+  "type": "record",
+  "name": "MembershipRegistrationRequest",
+  "namespace": "net.corda.data.membership.p2p",
+  "doc": "Request to register with an MGM.",
+  "fields": [
+    {
+      "name": "registrationId",
+      "doc": "UUID identifying this registration request",
+      "type": "string"
+    },
+    {
+      "name": "memberContext",
+      "doc": "Member provided data in MemberInfo serialised as byte array by using KeyValuePairList.",
+      "type": "bytes"
+    },
+    {
+      "name": "memberSignature",
+      "doc": "Signature of the member over the memberContext.",
+      "type": "net.corda.data.crypto.wire.CryptoSignatureWithKey"
+    }
+  ]
+}

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/p2p/MembershipRegistrationRequest.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/p2p/MembershipRegistrationRequest.avsc
@@ -7,7 +7,10 @@
     {
       "name": "registrationId",
       "doc": "UUID identifying this registration request",
-      "type": "string"
+      "type": {
+        "type": "string",
+        "logicalType": "uuid"
+      }
     },
     {
       "name": "memberContext",

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/p2p/MembershipSyncRequest.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/p2p/MembershipSyncRequest.avsc
@@ -1,7 +1,7 @@
 {
   "type": "record",
   "name": "MembershipSyncRequest",
-  "namespace": "net.corda.data.membership",
+  "namespace": "net.corda.data.membership.p2p",
   "doc": "Membership data synchronization request which will be processed by the MGM.",
   "fields": [
     {

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/p2p/SignedMemberships.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/p2p/SignedMemberships.avsc
@@ -1,7 +1,7 @@
 {
   "type": "record",
   "name": "SignedMemberships",
-  "namespace": "net.corda.data.membership",
+  "namespace": "net.corda.data.membership.p2p",
   "doc": "Avro representation of the membership data part, which will be sent over the wire, wrapped into the MembershipPackage.",
   "fields": [
     {
@@ -14,7 +14,7 @@
       "doc": "List of signed membership updates.",
       "type": {
         "type": "array",
-        "items": "SignedMemberInfo"
+        "items": "net.corda.data.membership.SignedMemberInfo"
       }
     }
   ]

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/p2p/WireCpiVersion.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/p2p/WireCpiVersion.avsc
@@ -1,7 +1,7 @@
 {
   "type": "record",
   "name": "WireCpiVersion",
-  "namespace": "net.corda.data.membership",
+  "namespace": "net.corda.data.membership.p2p",
   "doc": "Avro representation of CpiVersion.",
   "fields": [
     {

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/p2p/WireCpiWhitelist.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/p2p/WireCpiWhitelist.avsc
@@ -1,7 +1,7 @@
 {
   "type": "record",
   "name": "WireCpiWhitelist",
-  "namespace": "net.corda.data.membership",
+  "namespace": "net.corda.data.membership.p2p",
   "doc": "Avro representation of the CpiWhitelist data part, which will be sent over the wire, wrapped into the MembershipPackage.",
   "fields": [
     {

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/p2p/WireGroupParameters.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/p2p/WireGroupParameters.avsc
@@ -1,7 +1,7 @@
 {
   "type": "record",
   "name": "WireGroupParameters",
-  "namespace": "net.corda.data.membership",
+  "namespace": "net.corda.data.membership.p2p",
   "doc": "Avro representation of GroupParameters data part, which will be sent over the wire, wrapped into the MembershipPackage.",
   "fields": [
     {

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/rpc/request/MembershipRpcRequest.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/rpc/request/MembershipRpcRequest.avsc
@@ -13,8 +13,8 @@
       "name": "request",
       "doc": "Request's payload, depends on the requested operation.",
       "type": [
-        "RegistrationRequest",
-        "RegistrationStatusRequest"
+        "RegistrationRpcRequest",
+        "RegistrationStatusRpcRequest"
       ]
     }
   ]

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/rpc/request/MembershipRpcRequestContext.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/rpc/request/MembershipRpcRequestContext.avsc
@@ -7,7 +7,10 @@
     {
       "name": "requestId",
       "doc": "ID of the request.",
-      "type": "string"
+      "type": {
+        "type": "string",
+        "logicalType": "uuid"
+      }
     },
     {
       "name": "requestTimestamp",

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/rpc/request/RegistrationRpcRequest.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/rpc/request/RegistrationRpcRequest.avsc
@@ -1,6 +1,6 @@
 {
   "type": "record",
-  "name": "RegistrationRequest",
+  "name": "RegistrationRpcRequest",
   "namespace": "net.corda.data.membership.rpc.request",
   "doc": "Request to start the registration process.",
   "fields": [
@@ -14,9 +14,14 @@
       "doc": "The action to take during registration.",
       "type": {
         "type": "enum",
-        "name": "RegistrationAction",
+        "name": "RegistrationRpcAction",
         "symbols": ["REQUEST_JOIN"]
       }
+    },
+    {
+      "name": "context",
+      "doc": "The member or MGM context required for on-boarding within a group.",
+      "type": "net.corda.data.KeyValuePairList"
     }
   ]
 }

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/rpc/request/RegistrationStatusRpcRequest.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/rpc/request/RegistrationStatusRpcRequest.avsc
@@ -1,6 +1,6 @@
 {
   "type": "record",
-  "name": "RegistrationStatusRequest",
+  "name": "RegistrationStatusRpcRequest",
   "namespace": "net.corda.data.membership.rpc.request",
   "doc": "Request to check the status of the registration process.",
   "fields": [

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/rpc/response/MembershipRpcResponse.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/rpc/response/MembershipRpcResponse.avsc
@@ -13,7 +13,7 @@
       "name": "response",
       "doc": "Response's payload, depends on the requested operation.",
       "type": [
-        "RegistrationResponse"
+        "RegistrationRpcResponse"
       ]
     }
   ]

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/rpc/response/MembershipRpcResponseContext.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/rpc/response/MembershipRpcResponseContext.avsc
@@ -7,7 +7,10 @@
     {
       "name": "requestId",
       "doc": "ID of the request.",
-      "type": "string"
+      "type": {
+        "type": "string",
+        "logicalType": "uuid"
+      }
     },
     {
       "name": "requestTimestamp",

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/rpc/response/RegistrationRpcResponse.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/rpc/response/RegistrationRpcResponse.avsc
@@ -1,6 +1,6 @@
 {
   "type": "record",
-  "name": "RegistrationResponse",
+  "name": "RegistrationRpcResponse",
   "namespace": "net.corda.data.membership.rpc.response",
   "doc": "Registration response to submitting the registration request.",
   "fields": [
@@ -17,7 +17,7 @@
       "doc": "Status of the registration request.",
       "type": {
         "type": "enum",
-        "name": "RegistrationStatus",
+        "name": "RegistrationRpcStatus",
         "symbols": ["SUBMITTED", "NOT_SUBMITTED"]
       }
     },

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/state/RegistrationState.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/state/RegistrationState.avsc
@@ -7,7 +7,10 @@
     {
       "name": "registrationId",
       "doc": "UUID identifying this registration request",
-      "type": "string"
+      "type": {
+        "type": "string",
+        "logicalType": "uuid"
+      }
     },
     {
       "name": "registeringMember",

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/state/RegistrationState.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/state/RegistrationState.avsc
@@ -1,0 +1,18 @@
+{
+  "type": "record",
+  "name": "RegistrationState",
+  "namespace": "net.corda.data.membership.state",
+  "doc": "State for a registration.",
+  "fields": [
+    {
+      "name": "registrationId",
+      "doc": "UUID identifying this registration request",
+      "type": "string"
+    },
+    {
+      "name": "registeringMember",
+      "doc": "Holding identity of the registering member as provided during P2P communication. Used to verify the registration request.",
+      "type": "net.corda.data.identity.HoldingIdentity"
+    }
+  ]
+}

--- a/data/db-schema/src/main/kotlin/net/corda/db/schema/DbSchema.kt
+++ b/data/db-schema/src/main/kotlin/net/corda/db/schema/DbSchema.kt
@@ -25,6 +25,8 @@ object DbSchema {
     const val VNODE_VAULT_DB_TABLE = "vnode_vault"
     const val VNODE_KEY_DB_TABLE = "vnode_key"
     const val VNODE_CERTIFICATE_DB_TABLE = "vnode_certificate"
+    const val VNODE_GROUP_REGISTRATION_TABLE = "vnode_registration_request"
+    const val VNODE_MEMBER_INFO = "vnode_member_info"
 
     const val CERTIFICATES_SCHEME = "CERTIFICATES"
     const val CLUSTER_CERTIFICATES_DB_TABLE = "cluster_certificates"

--- a/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/vnode-vault-creation-v1.0.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/vnode-vault-creation-v1.0.xml
@@ -21,5 +21,56 @@
             </column>
         </createTable>
         <addPrimaryKey columnNames="alias" constraintName="vnode_certificate_pk" tableName="vnode_certificate"/>
+
+        <createTable tableName="vnode_registration_request">
+            <column name="registration_id" type="NVARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="holding_identity_id" type="VARCHAR(12)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="status" type="VARCHAR(64)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created" type="TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="last_modified" type="TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="context" type="VARBINARY(1048576)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+        <addPrimaryKey columnNames="registration_id"
+                       constraintName="vnode_registration_request_pk"
+                       tableName="vnode_registration_request"/>
+
+        <createTable tableName="vnode_member_info">
+            <column name="group_id" type="NVARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="member_name" type="NVARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="status" type="NVARCHAR(64)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="modified_time" type="TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="member_context" type="VARBINARY(1048576)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="mgm_context" type="VARBINARY(1048576)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="serial_number" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+        <addPrimaryKey columnNames="group_id, member_name"
+                       constraintName="vnode_member_info_pkey"
+                       tableName="vnode_member_info"/>
     </changeSet>
 </databaseChangeLog>

--- a/data/topic-schema/src/main/kotlin/net/corda/schema/Schemas.kt
+++ b/data/topic-schema/src/main/kotlin/net/corda/schema/Schemas.kt
@@ -90,19 +90,19 @@ class Schemas {
      */
     class Membership {
         companion object {
-            // Member persistence topics
             const val MEMBER_LIST_TOPIC = "membership.members"
             const val GROUP_PARAMETERS_TOPIC = "membership.group.params"
             const val CPI_WHITELIST_TOPIC = "membership.group.cpi.whitelists"
-            const val PROPOSAL_TOPIC = "membership.proposals"
             const val MEMBERSHIP_RPC_TOPIC = "membership.rpc.ops"
             const val MEMBERSHIP_RPC_RESPONSE_TOPIC = "membership.rpc.ops.resp"
-            const val MEMBERSHIP_OPS_RPC_TOPIC = "membership.ops.rpc"
-            const val MEMBERSHIP_OPS_RPC_RESPONSE_TOPIC = "membership.ops.rpc.resp"
+            const val MEMBERSHIP_DB_RPC_TOPIC = "membership.db.rpc.ops"
+            const val MEMBERSHIP_DB_RPC_RESPONSE_TOPIC = "membership.db.rpc.ops.resp"
 
-            // Member messaging topics
             const val UPDATE_TOPIC = "membership.update"
             const val EVENT_TOPIC = "membership.event"
+
+            const val REGISTRATION_COMMAND_TOPIC = "membership.registration"
+            const val REGISTRATION_STATE_TOPIC = "membership.registration.state"
         }
     }
 

--- a/data/topic-schema/src/main/resources/net/corda/schema/Membership.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/Membership.yaml
@@ -4,29 +4,40 @@ topics:
     consumers:
     producers:
     config:
+  MembershipGroupCPIWhitelistTopic:
+    name: membership.group.cpi.whitelists
+    consumers:
+    producers:
+    config:
       cleanup.policy: compact
       segment.ms: 300000
       delete.retention.ms: 300000
       min.compaction.lag.ms: 60000
       max.compaction.lag.ms: 300000
       min.cleanable.dirty.ratio: 0.5
-  MembershipGroupCPIWhitelistTopic:
-    name: membership.group.cpi.whitelists
-    consumers:
-    producers:
-    config:
   MembershipGroupParamsTopic:
     name: membership.group.params
     consumers:
     producers:
     config:
-  MembershipProposalsTopic:
-    name: membership.proposals
+      cleanup.policy: compact
+      segment.ms: 300000
+      delete.retention.ms: 300000
+      min.compaction.lag.ms: 60000
+      max.compaction.lag.ms: 300000
+      min.cleanable.dirty.ratio: 0.5
+  MembershipUpdateTopic:
+    name: membership.update
     consumers:
     producers:
     config:
-  MembershipUpdateTopic:
-    name: membership.update
+  MembershipRegistrationTopic:
+    name: membership.registration
+    consumers:
+    producers:
+    config:
+  MembershipRegistrationStateTopic:
+    name: membership.registration.state
     consumers:
     producers:
     config:
@@ -45,17 +56,17 @@ topics:
     name: membership.rpc.ops
     consumers:
     producers:
-  MembershipRpcOpsRespTopic:
+  MembershipRpcOpsResponseTopic:
     name: membership.rpc.ops.resp
     consumers:
     producers:
-    config:
-  MembershipOpsRpcTopic:
-    name: membership.ops.rpc
+  MembershipDBRpcOpsTopic:
+    name: membership.db.rpc.ops
     consumers:
     producers:
-  MembershipOpsRpcRespTopic:
-    name: membership.ops.rpc.resp
+    config:
+  MembershipDBRpcOpsResponseTopic:
+    name: membership.db.rpc.ops.resp
     consumers:
     producers:
     config:

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 123
+cordaApiRevision = 124
 
 # Main
 kotlinVersion = 1.7.0

--- a/membership/detekt-baseline.xml
+++ b/membership/detekt-baseline.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" ?>
-<SmellBaseline>
-    <ManuallySuppressedIssues></ManuallySuppressedIssues>
-    <CurrentIssues></CurrentIssues>
-</SmellBaseline>

--- a/membership/src/main/kotlin/net/corda/v5/membership/MemberInfo.kt
+++ b/membership/src/main/kotlin/net/corda/v5/membership/MemberInfo.kt
@@ -8,12 +8,21 @@ import java.security.PublicKey
  * The member info consist of two parts:
  * Member provided context: Parameters added and signed by member as part of the initial MemberInfo proposal.
  * MGM provided context: Parameters added by MGM as a part of member acceptance.
+ * Internally visible properties are accessible via extension properties.
  */
 @CordaSerializable
 interface MemberInfo {
 
+    /**
+     * Context representing the member set data regarding this members information.
+     * Required data from this context is parsed and returned via other class properties.
+     */
     val memberProvidedContext: MemberContext
 
+    /**
+     * Context representing the MGM set data regarding this members information.
+     * Required data from this context is parsed and returned via other class properties.
+     */
     val mgmProvidedContext: MGMContext
 
     /**


### PR DESCRIPTION
API changes for [CORE-4562](https://r3-cev.atlassian.net/browse/CORE-4562) and [CORE-3689](https://r3-cev.atlassian.net/browse/CORE-3689). Both combined under CORE-3689.

Changes:
* Switched member/mgm contexts in persistence member info to KeyValuePairLists
  - They were only bytes before to supported signing which has been removed.
* Added registration commands
  - starting a new registration
  - verifying a pending member (e.g. check endpoints)
  - process member verification (after receiving response from member during verification)
  - approving or declining a registration
  - Note: Many of these are placeholder. Only start has been implemented so far.
* Added avro schemas for persistence over RPC
  - Persist member infos
  - Persist registration request
  - Query member info
  - Wrappers for requests/responses.
* Moved and renamed schemas to better group between p2p schemas, and internal rpc schemas
* Added DB schemas for persisting registration requests, and member infos.
* Removed topic schema `membership.ops.rpc` since it looked like a duplicate of `membership.rpc.ops` and was unused.
* Tidied topic schema definitions