### PR TITLE
NOTICK - Switch gonepostal infix to p2p-preview

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 88-gonepostal
+cordaApiRevision = 88-p2p-preview
 
 # Main
 kotlinVersion = 1.4.32


### PR DESCRIPTION
Switching from `gonepostal` to `p2p-preview` to prevent confusion.