### PR TITLE
CORE-5014 Add soft DB deletion flag at config table 

### DIFF
--- a/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/config-creation-v1.0.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/config-creation-v1.0.xml
@@ -15,12 +15,6 @@
             <column name="section" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="version" type="INT">
-                <constraints nullable="false"/>
-            </column>
-            <column name="is_deleted" type="BOOLEAN">
-                <constraints nullable="false"/>
-            </column>
             <column name="config" type="TEXT">
                 <constraints nullable="false"/>
             </column>
@@ -28,6 +22,12 @@
                 <constraints nullable="false"/>
             </column>
             <column name="schema_version_minor" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="version" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="is_deleted" type="BOOLEAN">
                 <constraints nullable="false"/>
             </column>
             <column name="update_ts" type="DATETIME">

--- a/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/config-creation-v1.0.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/config-creation-v1.0.xml
@@ -18,6 +18,9 @@
             <column name="version" type="INT">
                 <constraints nullable="false"/>
             </column>
+            <column name="is_deleted" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
             <column name="config" type="TEXT">
                 <constraints nullable="false"/>
             </column>

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 108
+cordaApiRevision = 109
 
 # Main
 kotlinVersion = 1.6.21


### PR DESCRIPTION
- adds `is_deleted` flag at `config` table to allow soft DB deletion.

Complement corda-runtime-os PR [#1395](https://github.com/corda/corda-runtime-os/pull/1395).