### PR TITLE
CORE-4557: Refactor member key properties based on key design

### DIFF
--- a/application/src/main/kotlin/net/corda/v5/application/membership/MemberLookup.kt
+++ b/application/src/main/kotlin/net/corda/v5/application/membership/MemberLookup.kt
@@ -7,7 +7,7 @@ import net.corda.v5.membership.MemberInfo
 import java.security.PublicKey
 
 /**
- * Group Manager Service contains list of identities in Membership Management Group along with information about their identity keys,
+ * Group Manager Service contains list of identities in Membership Management Group along with information about their ledger keys,
  * services they provide and host names or IP addresses where they can be connected to. The cache wraps around a list fetched from the
  * manager, and adds easy lookup of the data stored within it. Generally it would be initialised with a specific Group Manager,
  * which it fetches data from and then subscribes to updates of.

--- a/base/src/main/kotlin/net/corda/v5/base/types/LayeredPropertyMap.kt
+++ b/base/src/main/kotlin/net/corda/v5/base/types/LayeredPropertyMap.kt
@@ -83,10 +83,10 @@ interface LayeredPropertyMap {
      * the [T] is different from it was called for the first time.
      *
      * Here is an example of what a set will look like
-     * (the [itemKeyPrefix] has to be "corda.identityKeyHashes" or "corda.identityKeyHashes."):
-     *  corda.identityKeyHashes.1 = <hash value of identity key 1>
-     *  corda.identityKeyHashes.2 = <hash value of identity key 2>
-     *  corda.identityKeyHashes.3 = <hash value of identity key 3>
+     * (the [itemKeyPrefix] has to be "corda.ledgerKeyHashes" or "corda.ledgerKeyHashes."):
+     *  corda.ledgerKeyHashes.1 = <hash value of ledger key 1>
+     *  corda.ledgerKeyHashes.2 = <hash value of ledger key 2>
+     *  corda.ledgerKeyHashes.3 = <hash value of ledger key 3>
      */
     fun <T> parseSet(itemKeyPrefix: String, clazz: Class<out T>): Set<T>
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 110
+cordaApiRevision = 111
 
 # Main
 kotlinVersion = 1.6.21

--- a/ledger/src/main/kotlin/net/corda/v5/ledger/services/TransactionService.kt
+++ b/ledger/src/main/kotlin/net/corda/v5/ledger/services/TransactionService.kt
@@ -96,8 +96,8 @@ interface TransactionService : TransactionStorage, TransactionMappingService, Tr
     fun sign(builder: TransactionBuilder, publicKey: PublicKey): SignedTransaction
 
     /**
-     * Constructs an initial partially signed transaction from a [TransactionBuilder] using the default identity key contained in the node.
-     * The legal identity key is used to sign.
+     * Constructs an initial partially signed transaction from a [TransactionBuilder] using the default ledger key contained in the node.
+     * The ledger key is used to sign.
      *
      * @param builder The [TransactionBuilder] to seal with the node's signature. Any existing signatures on the builder will be preserved.
      *
@@ -140,8 +140,8 @@ interface TransactionService : TransactionStorage, TransactionMappingService, Tr
     fun createSignature(signedTransaction: SignedTransaction, publicKey: PublicKey): DigitalSignatureAndMetadata
 
     /**
-     * Creates a signature for an existing (partially) [SignedTransaction] using the default identity signing key of the node. The legal
-     * identity key is used to sign. Additional [DigitalSignatureMetadata], including the platform version used during signing and the
+     * Creates a signature for an existing (partially) [SignedTransaction] using the default identity signing key of the node. The
+     * ledger key is used to sign. Additional [DigitalSignatureMetadata], including the platform version used during signing and the
      * cryptographic signature scheme use, is added to the signature.
      *
      * @param signedTransaction The [SignedTransaction] to which the signature will apply.
@@ -164,7 +164,7 @@ interface TransactionService : TransactionStorage, TransactionMappingService, Tr
     fun createSignature(filteredTransaction: FilteredTransaction, publicKey: PublicKey): DigitalSignatureAndMetadata
 
     /**
-     * Creates a signature for a [FilteredTransaction] using the default identity signing key of the node. The legal identity key is used to
+     * Creates a signature for a [FilteredTransaction] using the default ledger signing key of the node. The ledger key is used to
      * sign. Additional [DigitalSignatureMetadata], including the platform version used during signing and the cryptographic signature scheme use,
      * is added to the signature.
      *

--- a/ledger/src/main/kotlin/net/corda/v5/ledger/transactions/TransactionBuilder.kt
+++ b/ledger/src/main/kotlin/net/corda/v5/ledger/transactions/TransactionBuilder.kt
@@ -100,8 +100,8 @@ interface TransactionBuilder {
     fun sign(publicKey: PublicKey): SignedTransaction
 
     /**
-     * Constructs an initial partially signed transaction from a [TransactionBuilder] using the default identity key contained in the node.
-     * The legal identity key is used to sign.
+     * Constructs an initial partially signed transaction from a [TransactionBuilder] using the default ledger key contained in the node.
+     * The ledger key is used to sign.
      *
      * @return Returns a [SignedTransaction] with the new node signature attached.
      *

--- a/membership/src/main/kotlin/net/corda/v5/membership/MemberInfo.kt
+++ b/membership/src/main/kotlin/net/corda/v5/membership/MemberInfo.kt
@@ -23,12 +23,12 @@ interface MemberInfo {
     val name: MemberX500Name
 
     /**
-     * Member's identity key.
+     * Member's session initiation key.
      */
-    val owningKey: PublicKey
+    val sessionInitiationKey: PublicKey
 
-    /** List of current and previous (rotated) identity keys, which member can still use to sign unspent transactions on ledger. */
-    val identityKeys: List<PublicKey>
+    /** List of current and previous (rotated) ledger keys, which member can still use to sign unspent transactions on ledger. */
+    val ledgerKeys: List<PublicKey>
 
     /** Corda platform version */
     val platformVersion: Int

--- a/membership/src/test/java/net/corda/v5/membership/MemberInfoJavaApiTest.java
+++ b/membership/src/test/java/net/corda/v5/membership/MemberInfoJavaApiTest.java
@@ -55,17 +55,17 @@ public class MemberInfoJavaApiTest {
     }
 
     @Test
-    public void getIdentityKeys() {
+    public void getLedgerKeys() {
         PublicKey testPublicKey = mock(PublicKey.class);
         List<PublicKey> mockList = List.of(testPublicKey);
-        when(memberInfo.getIdentityKeys()).thenReturn(mockList);
+        when(memberInfo.getLedgerKeys()).thenReturn(mockList);
 
-        List<PublicKey> result = memberInfo.getIdentityKeys();
+        List<PublicKey> result = memberInfo.getLedgerKeys();
 
         Assertions.assertThat(result).isNotNull();
         Assertions.assertThat(result).isEqualTo(mockList);
 
-        verify(memberInfo, times(1)).getIdentityKeys();
+        verify(memberInfo, times(1)).getLedgerKeys();
     }
 
     @Test

--- a/membership/src/test/java/net/corda/v5/membership/MemberInfoJavaApiTest.java
+++ b/membership/src/test/java/net/corda/v5/membership/MemberInfoJavaApiTest.java
@@ -69,6 +69,19 @@ public class MemberInfoJavaApiTest {
     }
 
     @Test
+    public void getSessionKey() {
+        PublicKey testPublicKey = mock(PublicKey.class);
+        when(memberInfo.getSessionInitiationKey()).thenReturn(testPublicKey);
+
+        PublicKey result = memberInfo.getSessionInitiationKey();
+
+        Assertions.assertThat(result).isNotNull();
+        Assertions.assertThat(result).isEqualTo(testPublicKey);
+
+        verify(memberInfo, times(1)).getSessionInitiationKey();
+    }
+
+    @Test
     public void getPlatformVersion() {
         int test = 5;
         when(memberInfo.getPlatformVersion()).thenReturn(test);


### PR DESCRIPTION
https://r3-cev.atlassian.net/browse/CORE-4557
The following key properties exposed by the `MemberInfo` interface have changed -
- `owningKey` changed to `sessionInitiationKey`
- `identityKeys` changed to `ledgerKeys`

Updates Corda API version to 111