### PR TITLE
CORE-5050 fix failing tests in corda-api for Jenkins windows builds

### DIFF
--- a/data/topic-schema/src/test/kotlin/net/corda/schema/SchemaTests.kt
+++ b/data/topic-schema/src/test/kotlin/net/corda/schema/SchemaTests.kt
@@ -27,35 +27,6 @@ class SchemaTests {
     @Suppress("UNCHECKED_CAST")
     private val yamlFileData: Map<String, Map<String, Map<String, Map<String, *>>>> by lazy {
         // Scan resources in classpath to find all the yaml files to scan
-        //        val sep = File.pathSeparatorChar
-        println(this::class.java.classLoader.getResources("net/corda/schema")
-            .toList()
-            .filterNotNull()
-            .map { File(it.file) }
-            .filter { it.isDirectory }
-            .flatMap { it.listFiles()!!.toList() })
-        println(this::class.java.classLoader.getResources("net/corda/schema")
-            .toList()
-            .filterNotNull()
-            .map { File(it.file) }
-            .filter { it.isDirectory }
-            .flatMap { it.listFiles()!!.toList() }
-            .map{ it.exists() })
-        println(this::class.java.classLoader.getResources("net/corda/schema")
-            .toList()
-            .filterNotNull()
-            .map { File(it.file) }
-            .filter { it.isDirectory }
-            .flatMap { it.listFiles()!!.toList() }
-            .filter { it.name.endsWith("yaml") || it.endsWith("yml") })
-        println(this::class.java.classLoader.getResources("net/corda/schema")
-            .toList()
-            .filterNotNull()
-            .map { File(it.file) }
-            .filter { it.isDirectory }
-            .flatMap { it.listFiles()!!.toList() }
-            .filter { it.name.endsWith("yaml") || it.endsWith("yml") }
-            .map{ it.exists() })
         this::class.java.classLoader.getResources("net/corda/schema")
             .toList()
             .filterNotNull()

--- a/data/topic-schema/src/test/kotlin/net/corda/schema/SchemaTests.kt
+++ b/data/topic-schema/src/test/kotlin/net/corda/schema/SchemaTests.kt
@@ -30,7 +30,7 @@ class SchemaTests {
         this::class.java.classLoader.getResources("net/corda/schema")
             .toList()
             .filterNotNull()
-            .map { File(it.toURI() ) }
+            .map { File(it.toURI()) }
             .filter { it.isDirectory }
             .flatMap { it.listFiles()!!.toList() }
             .filter { it.name.endsWith("yaml") || it.endsWith("yml") }

--- a/data/topic-schema/src/test/kotlin/net/corda/schema/SchemaTests.kt
+++ b/data/topic-schema/src/test/kotlin/net/corda/schema/SchemaTests.kt
@@ -27,7 +27,8 @@ class SchemaTests {
     @Suppress("UNCHECKED_CAST")
     private val yamlFileData: Map<String, Map<String, Map<String, Map<String, *>>>> by lazy {
         // Scan resources in classpath to find all the yaml files to scan
-        this::class.java.classLoader.getResources("net/corda/schema")
+        val sep = File.pathSeparator
+        this::class.java.classLoader.getResources("net${sep}corda${sep}schema")
             .toList()
             .filterNotNull()
             .map { File(it.file) }

--- a/data/topic-schema/src/test/kotlin/net/corda/schema/SchemaTests.kt
+++ b/data/topic-schema/src/test/kotlin/net/corda/schema/SchemaTests.kt
@@ -27,7 +27,8 @@ class SchemaTests {
     @Suppress("UNCHECKED_CAST")
     private val yamlFileData: Map<String, Map<String, Map<String, Map<String, *>>>> by lazy {
         // Scan resources in classpath to find all the yaml files to scan
-        val sep = File.pathSeparator
+        val sep = File.separator
+        println("net${sep}corda${sep}schema")
         this::class.java.classLoader.getResources("net${sep}corda${sep}schema")
             .toList()
             .filterNotNull()

--- a/data/topic-schema/src/test/kotlin/net/corda/schema/SchemaTests.kt
+++ b/data/topic-schema/src/test/kotlin/net/corda/schema/SchemaTests.kt
@@ -11,7 +11,6 @@ import java.io.File
 import kotlin.reflect.KCallable
 import kotlin.reflect.full.companionObject
 
-
 class SchemaTests {
     // Setup jackson mapper to support yaml with null values
     private val mapper = ObjectMapper(YAMLFactory()).registerModule(

--- a/data/topic-schema/src/test/kotlin/net/corda/schema/SchemaTests.kt
+++ b/data/topic-schema/src/test/kotlin/net/corda/schema/SchemaTests.kt
@@ -11,6 +11,7 @@ import java.io.File
 import kotlin.reflect.KCallable
 import kotlin.reflect.full.companionObject
 
+
 class SchemaTests {
     // Setup jackson mapper to support yaml with null values
     private val mapper = ObjectMapper(YAMLFactory()).registerModule(
@@ -30,7 +31,7 @@ class SchemaTests {
         this::class.java.classLoader.getResources("net/corda/schema")
             .toList()
             .filterNotNull()
-            .map { File(it.file) }
+            .map { File(it.toURI() ) }
             .filter { it.isDirectory }
             .flatMap { it.listFiles()!!.toList() }
             .filter { it.name.endsWith("yaml") || it.endsWith("yml") }

--- a/data/topic-schema/src/test/kotlin/net/corda/schema/SchemaTests.kt
+++ b/data/topic-schema/src/test/kotlin/net/corda/schema/SchemaTests.kt
@@ -27,9 +27,36 @@ class SchemaTests {
     @Suppress("UNCHECKED_CAST")
     private val yamlFileData: Map<String, Map<String, Map<String, Map<String, *>>>> by lazy {
         // Scan resources in classpath to find all the yaml files to scan
-        val sep = File.separator
-        println("net${sep}corda${sep}schema")
-        this::class.java.classLoader.getResources("net${sep}corda${sep}schema")
+        //        val sep = File.pathSeparatorChar
+        println(this::class.java.classLoader.getResources("net/corda/schema")
+            .toList()
+            .filterNotNull()
+            .map { File(it.file) }
+            .filter { it.isDirectory }
+            .flatMap { it.listFiles()!!.toList() })
+        println(this::class.java.classLoader.getResources("net/corda/schema")
+            .toList()
+            .filterNotNull()
+            .map { File(it.file) }
+            .filter { it.isDirectory }
+            .flatMap { it.listFiles()!!.toList() }
+            .map{ it.exists() })
+        println(this::class.java.classLoader.getResources("net/corda/schema")
+            .toList()
+            .filterNotNull()
+            .map { File(it.file) }
+            .filter { it.isDirectory }
+            .flatMap { it.listFiles()!!.toList() }
+            .filter { it.name.endsWith("yaml") || it.endsWith("yml") })
+        println(this::class.java.classLoader.getResources("net/corda/schema")
+            .toList()
+            .filterNotNull()
+            .map { File(it.file) }
+            .filter { it.isDirectory }
+            .flatMap { it.listFiles()!!.toList() }
+            .filter { it.name.endsWith("yaml") || it.endsWith("yml") }
+            .map{ it.exists() })
+        this::class.java.classLoader.getResources("net/corda/schema")
             .toList()
             .filterNotNull()
             .map { File(it.file) }


### PR DESCRIPTION
On windows server Jenkins environments these tests were evaluating this code as no directory existing for the classloader resources in question ( Despite the files actually existing and passing locally on any OS) 

Windows build which was failing [here ] now verified as passing with this change (https://ci02.dev.r3.com/job/Corda5/view/Corda%205%20Nightly%20Jobs/job/Nightlys/job/Corda-API/job/Windows/job/ronnb%252Ffix-windows-tests-api/)

Using URI rather then file which seems to play nicer on windows server and allows these to pass on any OS 