### PR TITLE
CORE-5040 Config DB/Kafka reconciliation integration

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/config/Configuration.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/config/Configuration.avsc
@@ -9,7 +9,7 @@
     },
     {
       "name": "version",
-      "type": "string"
+      "type": "int"
     },
     {
       "name": "schemaVersion",

--- a/data/config-schema/src/main/kotlin/net/corda/schema/configuration/BootConfig.kt
+++ b/data/config-schema/src/main/kotlin/net/corda/schema/configuration/BootConfig.kt
@@ -1,10 +1,5 @@
 package net.corda.schema.configuration
 
-import net.corda.schema.configuration.ReconciliationConfig.RECONCILIATION_CPI_INFO_INTERVAL_MS
-import net.corda.schema.configuration.ReconciliationConfig.RECONCILIATION_CPK_WRITE_INTERVAL_MS
-import net.corda.schema.configuration.ReconciliationConfig.RECONCILIATION_PERMISSION_SUMMARY_INTERVAL_MS
-
-
 /**
  * Configuration paths for values used to bootstrap the worker
  */
@@ -25,10 +20,4 @@ object BootConfig {
     const val BOOT_DIR = "dir"
     const val BOOT_WORKSPACE_DIR = "$BOOT_DIR.workspace"
     const val BOOT_TMP_DIR = "$BOOT_DIR.tmp"
-
-    const val BOOT_RPC = "rpc"
-    const val BOOT_RECONCILIATION = "reconciliation"
-    const val BOOT_PERMISSION_SUMMARY_INTERVAL = "$BOOT_RECONCILIATION.$RECONCILIATION_PERMISSION_SUMMARY_INTERVAL_MS"
-    const val BOOT_CPK_WRITE_INTERVAL = "$BOOT_RECONCILIATION.$RECONCILIATION_CPK_WRITE_INTERVAL_MS"
-    const val BOOT_CPI_INFO_INTERVAL = "$BOOT_RECONCILIATION.$RECONCILIATION_CPI_INFO_INTERVAL_MS"
 }

--- a/data/config-schema/src/main/kotlin/net/corda/schema/configuration/ConfigDefaults.kt
+++ b/data/config-schema/src/main/kotlin/net/corda/schema/configuration/ConfigDefaults.kt
@@ -13,9 +13,6 @@ package net.corda.schema.configuration
 object ConfigDefaults {
     const val JDBC_DRIVER = "org.postgresql.Driver"
     const val DB_POOL_MAX_SIZE = 10
-    const val RECONCILIATION_PERMISSION_SUMMARY_INTERVAL_MS_DEFAULT: Long = 60000L
-    const val RECONCILIATION_CPK_WRITE_INTERVAL_MS_DEFAULT: Long = 10000L
-    const val RECONCILIATION_CPI_INFO_INTERVAL_MS_DEFAULT: Long = 10000L
 
     val WORKSPACE_DIR = "${System.getProperty("java.io.tmpdir")}/corda/workspace"
     val TEMP_DIR = "${System.getProperty("java.io.tmpdir")}/corda/tmp"

--- a/data/config-schema/src/main/kotlin/net/corda/schema/configuration/ReconciliationConfig.kt
+++ b/data/config-schema/src/main/kotlin/net/corda/schema/configuration/ReconciliationConfig.kt
@@ -5,4 +5,5 @@ object ReconciliationConfig {
         const val RECONCILIATION_PERMISSION_SUMMARY_INTERVAL_MS = "permissionSummaryIntervalMs"
         const val RECONCILIATION_CPK_WRITE_INTERVAL_MS = "cpkWriteIntervalMs"
         const val RECONCILIATION_CPI_INFO_INTERVAL_MS = "cpiInfoIntervalMs"
+        const val RECONCILIATION_CONFIG_INTERVAL_MS = "configIntervalMs"
 }

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/reconciliation/1.0/corda.reconciliation.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/reconciliation/1.0/corda.reconciliation.json
@@ -4,5 +4,31 @@
   "title": "Corda Reconciliation Configuration Schema",
   "description": "Configuration schema for the reconciliation subsection.",
   "type": "object",
-  "properties": {}
+  "default": {},
+  "properties": {
+    "permissionSummaryIntervalMs": {
+      "description": "",
+      "type": "integer",
+      "minimum": 5000,
+      "default": 30000
+    },
+    "cpkWriteIntervalMs": {
+      "description": "",
+      "type": "integer",
+      "minimum": 5000,
+      "default": 30000
+    },
+    "cpiInfoIntervalMs": {
+      "description": "",
+      "type": "integer",
+      "minimum": 5000,
+      "default": 30000
+    },
+    "configIntervalMs": {
+      "description": "",
+      "type": "integer",
+      "minimum": 5000,
+      "default": 30000
+    }
+  }
 }

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/rpc/1.0/corda.rpc.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/rpc/1.0/corda.rpc.json
@@ -4,5 +4,46 @@
   "title": "Corda RPC Configuration Schema",
   "description": "Configuration schema for the RPC subsection.",
   "type": "object",
-  "properties": {}
+  "default": {},
+  "properties": {
+    "address": {
+      "description": "",
+      "type": "string",
+      "default": "0.0.0.0:8888"
+    },
+    "context": {
+      "description": "",
+      "type": "object",
+      "default": {},
+      "properties": {
+        "description": {
+          "description": "",
+          "type": "string",
+          "default": "Exposing RPCOps interfaces as OpenAPI WebServices"
+        },
+        "title": {
+          "description": "",
+          "type": "string",
+          "default": "HTTP RPC"
+        }
+      }
+    },
+    "maxContentLength": {
+      "description": "",
+      "type": "integer",
+      "default": 2000000000
+    },
+    "endpoint": {
+      "description": "",
+      "type": "object",
+      "default": {},
+      "properties": {
+        "timeoutMs": {
+          "description": "",
+          "type": "integer",
+          "default": 12000
+        }
+      }
+    }
+  }
 }

--- a/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/config-creation-v1.0.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/config-creation-v1.0.xml
@@ -5,6 +5,8 @@
 
     <property name="schema.name" value="CONFIG"/>
 
+    <property name="now" value="now()" dbms="postgresql"/>
+
     <changeSet author="R3.Corda" id="config-creation-v1.0">
 
         <sql>
@@ -39,6 +41,28 @@
         </createTable>
         <addPrimaryKey columnNames="section" constraintName="config_pk" tableName="config"
                        schemaName="${schema.name}"/>
+
+        <insert tableName="config" schemaName="${schema.name}">
+            <column name="section" value="corda.reconciliation"/>
+            <column name="config" value=""/>
+            <column name="schema_version_major" value="1"/>
+            <column name="schema_version_minor" value="0"/>
+            <column name="version" value="0"/>
+            <column name="is_deleted" value="false"/>
+            <column name="update_ts" value="${now}"/>
+            <column name="update_actor" value="admin"/>
+        </insert>
+
+        <insert tableName="config" schemaName="${schema.name}">
+            <column name="section" value="corda.rpc"/>
+            <column name="config" value=""/>
+            <column name="schema_version_major" value="1"/>
+            <column name="schema_version_minor" value="0"/>
+            <column name="version" value="0"/>
+            <column name="is_deleted" value="false"/>
+            <column name="update_ts" value="${now}"/>
+            <column name="update_actor" value="admin"/>
+        </insert>
 
         <createTable tableName="config_audit" schemaName="${schema.name}">
             <column name="change_number" type="SERIAL">

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 116
+cordaApiRevision = 117
 
 # Main
 kotlinVersion = 1.7.0


### PR DESCRIPTION
- updates `Configuration.version` type to int.
- defines JSON schema for Reconciliation and RPC config.
- inserts into `config` table empty sections for Reconciliation and RPC configurations to be defaulted by schema.

Please note: Crypto configuration is still outstanding JIRA: [CORE-5086](https://r3-cev.atlassian.net/browse/CORE-5086).

Complement corda-runtime-os PR: [#1405](https://github.com/corda/corda-runtime-os/pull/1405)