### PR TITLE
CORE-5052: Upgrade to Corda Gradle plugins 6.0.0-BETA16 and Bnd 6.3.0.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ kotlinVersion = 1.6.21
 kotlin.stdlib.default.dependency = false
 
 # at the moment, required for packaging to build test cpks for unit tests
-gradlePluginsVersion = 6.0.0-BETA15
+gradlePluginsVersion = 6.0.0-BETA16
 
 # License
 ## TODO: Change to correct name and URL
@@ -53,7 +53,7 @@ mockitoVersion = 4.1.0
 mockitoKotlinVersion = 4.0.0
 
 # OSGi
-bndVersion = 6.2.0
+bndVersion = 6.3.0
 osgiVersion = 8.0.0
 osgiScrAnnotationVersion = 1.4.0
 


### PR DESCRIPTION
[Bnd 6.3.0 has been released.](https://github.com/bndtools/bnd/wiki/Changes-in-6.3.0) Update Corda API to use it.