### PR TITLE
CORE-4868 - change PK of cpk_metadata to be the name, version and signer hash

### DIFF
--- a/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/cpx-creation-v1.0.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/cpx-creation-v1.0.xml
@@ -95,15 +95,6 @@
                              schemaName="${schema.name}"/>
 
         <createTable tableName="cpk_file" schemaName="${schema.name}">
-            <column name="cpk_name" type="VARCHAR(255)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="cpk_version" type="VARCHAR(255)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="cpk_signer_summary_hash" type="VARCHAR(255)">
-                <constraints nullable="false"/>
-            </column>
             <column name="file_checksum" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
@@ -123,28 +114,16 @@
             </column>
         </createTable>
 
-        <addPrimaryKey tableName="cpk_file" columnNames="cpk_name, cpk_version, cpk_signer_summary_hash" constraintName="cpk_file_pk"
+        <addPrimaryKey tableName="cpk_file" columnNames="file_checksum" constraintName="cpk_file_pk"
                        schemaName="${schema.name}"/>
 
-        <addForeignKeyConstraint baseTableName="cpk_file" baseColumnNames="cpk_name, cpk_version, cpk_signer_summary_hash"
-                                 referencedTableName="cpk_metadata" referencedColumnNames="cpk_name, cpk_version, cpk_signer_summary_hash"
+        <addForeignKeyConstraint baseTableName="cpk_file" baseColumnNames="file_checksum"
+                                 referencedTableName="cpk_metadata" referencedColumnNames="file_checksum"
                                  constraintName="FK_cpk_file_cpk_metadata"
                                  baseTableSchemaName="${schema.name}"
                                  referencedTableSchemaName="${schema.name}"/>
 
-        <addUniqueConstraint tableName="cpk_file" columnNames="file_checksum" constraintName="db_cpk_file_uc1"
-                             schemaName="${schema.name}"/>
-
         <createTable tableName="cpk_db_change_log" schemaName="${schema.name}">
-            <column name="cpk_name" type="VARCHAR(255)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="cpk_version" type="VARCHAR(255)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="cpk_signer_summary_hash" type="VARCHAR(255)">
-                <constraints nullable="false"/>
-            </column>
             <column name="cpk_file_checksum" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
@@ -167,17 +146,14 @@
             </column>
         </createTable>
 
-        <addPrimaryKey tableName="cpk_db_change_log" columnNames="cpk_name, cpk_version, cpk_signer_summary_hash, file_path"
-                       constraintName="cpk_db_change_log_pk" schemaName="${schema.name}"/>
+        <addPrimaryKey tableName="cpk_db_change_log" columnNames="cpk_file_checksum, file_path" constraintName="cpk_db_change_log_pk"
+                       schemaName="${schema.name}"/>
 
-        <addForeignKeyConstraint baseTableName="cpk_db_change_log" baseColumnNames="cpk_name, cpk_version, cpk_signer_summary_hash"
-                                 referencedTableName="cpk_metadata" referencedColumnNames="cpk_name, cpk_version, cpk_signer_summary_hash"
+        <addForeignKeyConstraint baseTableName="cpk_db_change_log" baseColumnNames="cpk_file_checksum"
+                                 referencedTableName="cpk_metadata" referencedColumnNames="file_checksum"
                                  constraintName="FK_cpk_db_change_log_cpk_metadata"
                                  baseTableSchemaName="${schema.name}"
                                  referencedTableSchemaName="${schema.name}"/>
-
-        <addUniqueConstraint tableName="cpk_db_change_log" columnNames="cpk_file_checksum" constraintName="db_cpk_db_change_log_uc1"
-                             schemaName="${schema.name}"/>
 
         <createTable tableName="cpi_cpk" schemaName="${schema.name}">
             <column name="cpi_name" type="VARCHAR(255)">
@@ -187,15 +163,6 @@
                 <constraints nullable="false"/>
             </column>
             <column name="cpi_signer_summary_hash" type="VARCHAR(255)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="cpk_name" type="VARCHAR(255)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="cpk_version" type="VARCHAR(255)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="cpk_signer_summary_hash" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
             <column name="cpk_file_checksum" type="VARCHAR(255)">
@@ -217,8 +184,8 @@
             </column>
         </createTable>
 
-        <addPrimaryKey tableName="cpi_cpk" columnNames="cpi_name, cpi_version, cpi_signer_summary_hash, cpk_file_checksum"
-                       constraintName="cpi_cpk_pk" schemaName="${schema.name}"/>
+        <addPrimaryKey tableName="cpi_cpk" columnNames="cpi_name, cpi_version, cpi_signer_summary_hash, cpk_file_checksum" constraintName="cpi_cpk_pk"
+                       schemaName="${schema.name}"/>
 
         <addForeignKeyConstraint baseTableName="cpi_cpk" baseColumnNames="cpi_name, cpi_version, cpi_signer_summary_hash"
                                  referencedTableName="cpi" referencedColumnNames="name, version, signer_summary_hash"
@@ -226,8 +193,8 @@
                                  baseTableSchemaName="${schema.name}"
                                  referencedTableSchemaName="${schema.name}"/>
 
-        <addForeignKeyConstraint baseTableName="cpi_cpk" baseColumnNames="cpk_name, cpk_version, cpk_signer_summary_hash"
-                                 referencedTableName="cpk_metadata" referencedColumnNames="cpk_name, cpk_version, cpk_signer_summary_hash"
+        <addForeignKeyConstraint baseTableName="cpi_cpk" baseColumnNames="cpk_file_checksum"
+                                 referencedTableName="cpk_metadata" referencedColumnNames="file_checksum"
                                  constraintName="FK_cpi_cpk_cpk_metadata"
                                  baseTableSchemaName="${schema.name}"
                                  referencedTableSchemaName="${schema.name}"/>

--- a/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/cpx-creation-v1.0.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/cpx-creation-v1.0.xml
@@ -91,6 +91,9 @@
         <addPrimaryKey tableName="cpk_metadata" columnNames="cpk_name, cpk_version, cpk_signer_summary_hash" constraintName="cpk_metadata_pk"
                        schemaName="${schema.name}"/>
 
+        <addUniqueConstraint tableName="cpk_metadata" columnNames="file_checksum" constraintName="db_cpk_metadata_uc1"
+                             schemaName="${schema.name}"/>
+
         <createTable tableName="cpk_file" schemaName="${schema.name}">
             <column name="cpk_name" type="VARCHAR(255)">
                 <constraints nullable="false"/>
@@ -128,6 +131,9 @@
                                  constraintName="FK_cpk_file_cpk_metadata"
                                  baseTableSchemaName="${schema.name}"
                                  referencedTableSchemaName="${schema.name}"/>
+
+        <addUniqueConstraint tableName="cpk_file" columnNames="file_checksum" constraintName="db_cpk_file_uc1"
+                             schemaName="${schema.name}"/>
 
         <createTable tableName="cpk_db_change_log" schemaName="${schema.name}">
             <column name="cpk_name" type="VARCHAR(255)">
@@ -170,6 +176,9 @@
                                  baseTableSchemaName="${schema.name}"
                                  referencedTableSchemaName="${schema.name}"/>
 
+        <addUniqueConstraint tableName="cpk_db_change_log" columnNames="cpk_file_checksum" constraintName="db_cpk_db_change_log_uc1"
+                             schemaName="${schema.name}"/>
+
         <createTable tableName="cpi_cpk" schemaName="${schema.name}">
             <column name="cpi_name" type="VARCHAR(255)">
                 <constraints nullable="false"/>
@@ -208,8 +217,8 @@
             </column>
         </createTable>
 
-        <addPrimaryKey tableName="cpi_cpk" columnNames="cpi_name, cpi_version, cpi_signer_summary_hash, cpk_file_checksum" constraintName="cpi_cpk_pk"
-                       schemaName="${schema.name}"/>
+        <addPrimaryKey tableName="cpi_cpk" columnNames="cpi_name, cpi_version, cpi_signer_summary_hash, cpk_file_checksum"
+                       constraintName="cpi_cpk_pk" schemaName="${schema.name}"/>
 
         <addForeignKeyConstraint baseTableName="cpi_cpk" baseColumnNames="cpi_name, cpi_version, cpi_signer_summary_hash"
                                  referencedTableName="cpi" referencedColumnNames="name, version, signer_summary_hash"
@@ -222,6 +231,9 @@
                                  constraintName="FK_cpi_cpk_cpk_metadata"
                                  baseTableSchemaName="${schema.name}"
                                  referencedTableSchemaName="${schema.name}"/>
+
+        <addUniqueConstraint tableName="cpi_cpk" columnNames="cpk_file_checksum" constraintName="db_cpi_cpk_uc1"
+                             schemaName="${schema.name}"/>
 
     </changeSet>
 </databaseChangeLog>

--- a/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/cpx-creation-v1.0.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/cpx-creation-v1.0.xml
@@ -56,9 +56,6 @@
                              schemaName="${schema.name}"/>
 
         <createTable tableName="cpk_metadata" schemaName="${schema.name}">
-            <column name="file_checksum" type="VARCHAR(255)">
-                <constraints nullable="false"/>
-            </column>
             <column name="cpk_name" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
@@ -66,6 +63,9 @@
                 <constraints nullable="false"/>
             </column>
             <column name="cpk_signer_summary_hash" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="file_checksum" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
             <column name="format_version" type="VARCHAR(12)">
@@ -88,10 +88,19 @@
             </column>
         </createTable>
 
-        <addPrimaryKey tableName="cpk_metadata" columnNames="file_checksum" constraintName="cpk_metadata_pk"
+        <addPrimaryKey tableName="cpk_metadata" columnNames="cpk_name, cpk_version, cpk_signer_summary_hash" constraintName="cpk_metadata_pk"
                        schemaName="${schema.name}"/>
 
         <createTable tableName="cpk_file" schemaName="${schema.name}">
+            <column name="cpk_name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="cpk_version" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="cpk_signer_summary_hash" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
             <column name="file_checksum" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
@@ -111,16 +120,25 @@
             </column>
         </createTable>
 
-        <addPrimaryKey tableName="cpk_file" columnNames="file_checksum" constraintName="cpk_file_pk"
+        <addPrimaryKey tableName="cpk_file" columnNames="cpk_name, cpk_version, cpk_signer_summary_hash" constraintName="cpk_file_pk"
                        schemaName="${schema.name}"/>
 
-        <addForeignKeyConstraint baseTableName="cpk_file" baseColumnNames="file_checksum"
-                                 referencedTableName="cpk_metadata" referencedColumnNames="file_checksum"
+        <addForeignKeyConstraint baseTableName="cpk_file" baseColumnNames="cpk_name, cpk_version, cpk_signer_summary_hash"
+                                 referencedTableName="cpk_metadata" referencedColumnNames="cpk_name, cpk_version, cpk_signer_summary_hash"
                                  constraintName="FK_cpk_file_cpk_metadata"
                                  baseTableSchemaName="${schema.name}"
                                  referencedTableSchemaName="${schema.name}"/>
 
         <createTable tableName="cpk_db_change_log" schemaName="${schema.name}">
+            <column name="cpk_name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="cpk_version" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="cpk_signer_summary_hash" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
             <column name="cpk_file_checksum" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
@@ -143,11 +161,11 @@
             </column>
         </createTable>
 
-        <addPrimaryKey tableName="cpk_db_change_log" columnNames="cpk_file_checksum, file_path" constraintName="cpk_db_change_log_pk"
-                       schemaName="${schema.name}"/>
+        <addPrimaryKey tableName="cpk_db_change_log" columnNames="cpk_name, cpk_version, cpk_signer_summary_hash, file_path"
+                       constraintName="cpk_db_change_log_pk" schemaName="${schema.name}"/>
 
-        <addForeignKeyConstraint baseTableName="cpk_db_change_log" baseColumnNames="cpk_file_checksum"
-                                 referencedTableName="cpk_metadata" referencedColumnNames="file_checksum"
+        <addForeignKeyConstraint baseTableName="cpk_db_change_log" baseColumnNames="cpk_name, cpk_version, cpk_signer_summary_hash"
+                                 referencedTableName="cpk_metadata" referencedColumnNames="cpk_name, cpk_version, cpk_signer_summary_hash"
                                  constraintName="FK_cpk_db_change_log_cpk_metadata"
                                  baseTableSchemaName="${schema.name}"
                                  referencedTableSchemaName="${schema.name}"/>
@@ -160,6 +178,15 @@
                 <constraints nullable="false"/>
             </column>
             <column name="cpi_signer_summary_hash" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="cpk_name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="cpk_version" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="cpk_signer_summary_hash" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
             <column name="cpk_file_checksum" type="VARCHAR(255)">
@@ -190,8 +217,8 @@
                                  baseTableSchemaName="${schema.name}"
                                  referencedTableSchemaName="${schema.name}"/>
 
-        <addForeignKeyConstraint baseTableName="cpi_cpk" baseColumnNames="cpk_file_checksum"
-                                 referencedTableName="cpk_metadata" referencedColumnNames="file_checksum"
+        <addForeignKeyConstraint baseTableName="cpi_cpk" baseColumnNames="cpk_name, cpk_version, cpk_signer_summary_hash"
+                                 referencedTableName="cpk_metadata" referencedColumnNames="cpk_name, cpk_version, cpk_signer_summary_hash"
                                  constraintName="FK_cpi_cpk_cpk_metadata"
                                  baseTableSchemaName="${schema.name}"
                                  referencedTableSchemaName="${schema.name}"/>

--- a/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/cpx-creation-v1.0.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/cpx-creation-v1.0.xml
@@ -232,8 +232,5 @@
                                  baseTableSchemaName="${schema.name}"
                                  referencedTableSchemaName="${schema.name}"/>
 
-        <addUniqueConstraint tableName="cpi_cpk" columnNames="cpk_file_checksum" constraintName="db_cpi_cpk_uc1"
-                             schemaName="${schema.name}"/>
-
     </changeSet>
 </databaseChangeLog>

--- a/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/cpx-creation-v1.0.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/cpx-creation-v1.0.xml
@@ -95,6 +95,15 @@
                              schemaName="${schema.name}"/>
 
         <createTable tableName="cpk_file" schemaName="${schema.name}">
+            <column name="cpk_name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="cpk_version" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="cpk_signer_summary_hash" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
             <column name="file_checksum" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
@@ -114,16 +123,28 @@
             </column>
         </createTable>
 
-        <addPrimaryKey tableName="cpk_file" columnNames="file_checksum" constraintName="cpk_file_pk"
+        <addPrimaryKey tableName="cpk_file" columnNames="cpk_name, cpk_version, cpk_signer_summary_hash" constraintName="cpk_file_pk"
                        schemaName="${schema.name}"/>
 
-        <addForeignKeyConstraint baseTableName="cpk_file" baseColumnNames="file_checksum"
-                                 referencedTableName="cpk_metadata" referencedColumnNames="file_checksum"
+        <addForeignKeyConstraint baseTableName="cpk_file" baseColumnNames="cpk_name, cpk_version, cpk_signer_summary_hash"
+                                 referencedTableName="cpk_metadata" referencedColumnNames="cpk_name, cpk_version, cpk_signer_summary_hash"
                                  constraintName="FK_cpk_file_cpk_metadata"
                                  baseTableSchemaName="${schema.name}"
                                  referencedTableSchemaName="${schema.name}"/>
 
+        <addUniqueConstraint tableName="cpk_file" columnNames="file_checksum" constraintName="db_cpk_file_uc1"
+                             schemaName="${schema.name}"/>
+
         <createTable tableName="cpk_db_change_log" schemaName="${schema.name}">
+            <column name="cpk_name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="cpk_version" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="cpk_signer_summary_hash" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
             <column name="cpk_file_checksum" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
@@ -146,14 +167,17 @@
             </column>
         </createTable>
 
-        <addPrimaryKey tableName="cpk_db_change_log" columnNames="cpk_file_checksum, file_path" constraintName="cpk_db_change_log_pk"
-                       schemaName="${schema.name}"/>
+        <addPrimaryKey tableName="cpk_db_change_log" columnNames="cpk_name, cpk_version, cpk_signer_summary_hash, file_path"
+                       constraintName="cpk_db_change_log_pk" schemaName="${schema.name}"/>
 
-        <addForeignKeyConstraint baseTableName="cpk_db_change_log" baseColumnNames="cpk_file_checksum"
-                                 referencedTableName="cpk_metadata" referencedColumnNames="file_checksum"
+        <addForeignKeyConstraint baseTableName="cpk_db_change_log" baseColumnNames="cpk_name, cpk_version, cpk_signer_summary_hash"
+                                 referencedTableName="cpk_metadata" referencedColumnNames="cpk_name, cpk_version, cpk_signer_summary_hash"
                                  constraintName="FK_cpk_db_change_log_cpk_metadata"
                                  baseTableSchemaName="${schema.name}"
                                  referencedTableSchemaName="${schema.name}"/>
+
+        <addUniqueConstraint tableName="cpk_db_change_log" columnNames="cpk_file_checksum" constraintName="db_cpk_db_change_log_uc1"
+                             schemaName="${schema.name}"/>
 
         <createTable tableName="cpi_cpk" schemaName="${schema.name}">
             <column name="cpi_name" type="VARCHAR(255)">
@@ -163,6 +187,15 @@
                 <constraints nullable="false"/>
             </column>
             <column name="cpi_signer_summary_hash" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="cpk_name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="cpk_version" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="cpk_signer_summary_hash" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
             <column name="cpk_file_checksum" type="VARCHAR(255)">
@@ -184,8 +217,8 @@
             </column>
         </createTable>
 
-        <addPrimaryKey tableName="cpi_cpk" columnNames="cpi_name, cpi_version, cpi_signer_summary_hash, cpk_file_checksum" constraintName="cpi_cpk_pk"
-                       schemaName="${schema.name}"/>
+        <addPrimaryKey tableName="cpi_cpk" columnNames="cpi_name, cpi_version, cpi_signer_summary_hash, cpk_file_checksum"
+                       constraintName="cpi_cpk_pk" schemaName="${schema.name}"/>
 
         <addForeignKeyConstraint baseTableName="cpi_cpk" baseColumnNames="cpi_name, cpi_version, cpi_signer_summary_hash"
                                  referencedTableName="cpi" referencedColumnNames="name, version, signer_summary_hash"
@@ -193,8 +226,8 @@
                                  baseTableSchemaName="${schema.name}"
                                  referencedTableSchemaName="${schema.name}"/>
 
-        <addForeignKeyConstraint baseTableName="cpi_cpk" baseColumnNames="cpk_file_checksum"
-                                 referencedTableName="cpk_metadata" referencedColumnNames="file_checksum"
+        <addForeignKeyConstraint baseTableName="cpi_cpk" baseColumnNames="cpk_name, cpk_version, cpk_signer_summary_hash"
+                                 referencedTableName="cpk_metadata" referencedColumnNames="cpk_name, cpk_version, cpk_signer_summary_hash"
                                  constraintName="FK_cpi_cpk_cpk_metadata"
                                  baseTableSchemaName="${schema.name}"
                                  referencedTableSchemaName="${schema.name}"/>

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 117
+cordaApiRevision = 118
 
 # Main
 kotlinVersion = 1.7.0


### PR DESCRIPTION
This changes the PK for CPK_FILE and CPK_METADATA.

The tables still have the file_checksum as a unique key and can be continued to be used in queries by runtime-os.

Accompanying runtime-os change is here: https://github.com/corda/corda-runtime-os/pull/1429

**Background of this change:**
While working on [CORE-4868](https://github.com/corda/corda-runtime-os/pull/1385) we decided to add entityVersion to the CPK identifier, but when storing a CPK during force upload, it would result in new row with the same `cpkName`, `cpkVersion`, `cpkSignerSummaryHash` and a different `cpkFileChecksum`, and `entityVersion` would still be 0. This meant the cache in `FlowSandboxServiceImpl` would have multiple CPKs with the same name, version, signerSummaryHash, but different fileChecksums, and an entity version of 0. This meant we couldn't identify a CPK using the CpkIdentifer so the cache would have the incorrect CPKs.

Now when a CPK is force uploaded, we'll merge the new CPK with the existing, hibernate will increment the `entity_version` on the existing CPK and the CPK_File will be overwritten with the new data, thus overwriting the existing CPK.

