### PR TITLE
CORE-4868 - add entityVersion to CpkIdentifier.

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/packaging/CpkIdentifier.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/packaging/CpkIdentifier.avsc
@@ -14,6 +14,10 @@
     {
       "name": "signerSummaryHash",
       "type": ["null", "net.corda.data.crypto.SecureHash"]
+    },
+    {
+      "name": "entityVersion",
+      "type": ["null", "int"]
     }
   ]
 }

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/packaging/CpkIdentifier.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/packaging/CpkIdentifier.avsc
@@ -17,7 +17,7 @@
     },
     {
       "name": "entityVersion",
-      "type": ["null", "int"]
+      "type": "int"
     }
   ]
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 111
+cordaApiRevision = 112
 
 # Main
 kotlinVersion = 1.6.21


### PR DESCRIPTION
As part of https://github.com/corda/corda-runtime-os/pull/1385 we will add entityVersion to CpkIdentifier avro object so this field can be propagated across kafka and used in CpkIdentifier when accessing maps in the cache, etc.