### PR TITLE
CORE-5087 - added platform exception reporting in the flow checkpoint

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/flow/state/Checkpoint.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/flow/state/Checkpoint.avsc
@@ -50,6 +50,12 @@
       "name": "maxFlowSleepDuration",
       "type": "int",
       "doc": "The maximum time a flow can sleep, before a Wakeup event is generated (milliseconds)"
+    },
+    {
+      "name": "pendingPlatformError",
+      "type": ["null", "net.corda.data.ExceptionEnvelope"],
+      "default": null,
+      "doc": "Used for platform generated errors reported back to user code."
     }
   ]
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 125
+cordaApiRevision = 126
 
 # Main
 kotlinVersion = 1.7.0


### PR DESCRIPTION
Adds a new field to the flow checkpoint to enable platform exceptions to be sent back to user code.
