### PR TITLE
CORE-3989 vnode audit columns + reconciliation values

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/virtualnode/VirtualNodeInfo.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/virtualnode/VirtualNodeInfo.avsc
@@ -35,6 +35,18 @@
       "name": "hsmConnectionId",
       "type": ["null", "string"],
       "doc": "ID of HSM connection. Null value means that HSM is not used."
+    },
+    {
+      "name": "version",
+      "type": "int"
+    },
+    {
+      "name": "timestamp",
+      "type": {
+        "type": "long",
+        "logicalType": "timestamp-millis"
+      },
+      "doc": "Time ([Instant]) in milliseconds when the record was updated or added."
     }
   ]
 }

--- a/data/config-schema/src/main/kotlin/net/corda/schema/configuration/ReconciliationConfig.kt
+++ b/data/config-schema/src/main/kotlin/net/corda/schema/configuration/ReconciliationConfig.kt
@@ -6,4 +6,5 @@ object ReconciliationConfig {
         const val RECONCILIATION_CPK_WRITE_INTERVAL_MS = "cpkWriteIntervalMs"
         const val RECONCILIATION_CPI_INFO_INTERVAL_MS = "cpiInfoIntervalMs"
         const val RECONCILIATION_CONFIG_INTERVAL_MS = "configIntervalMs"
+        const val RECONCILIATION_VNODE_INFO_INTERVAL_MS ="vnodeInfoIntervalMs"
 }

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/reconciliation/1.0/corda.reconciliation.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/reconciliation/1.0/corda.reconciliation.json
@@ -24,6 +24,12 @@
       "minimum": 5000,
       "default": 30000
     },
+    "vnodeInfoIntervalMs": {
+      "description": "",
+      "type": "integer",
+      "minimum": 5000,
+      "default": 30000
+    },
     "configIntervalMs": {
       "description": "",
       "type": "integer",

--- a/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/config-creation-v1.0.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/config-creation-v1.0.xml
@@ -230,6 +230,16 @@
             <column name="cpi_signer_summary_hash" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
+            <!-- audit -->
+            <column name="entity_version" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="is_deleted" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="insert_ts" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
         </createTable>
         <addPrimaryKey columnNames="holding_identity_id, cpi_name, cpi_version, cpi_signer_summary_hash"
                        constraintName="vnode_instance_pk" tableName="vnode_instance" schemaName="${schema.name}"/>

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 119
+cordaApiRevision = 120
 
 # Main
 kotlinVersion = 1.7.0


### PR DESCRIPTION
(draft, but still needs a final rebase,  see also https://github.com/corda/corda-runtime-os/pull/1454)

Added audit columns to the virtual node table.

Added reconciliation configuration settings.

