### PR TITLE
CORE-5146: Upgrade to Bnd 6.3.1 and Corda Gradle plugins 6.0.0-BETA17.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ kotlinVersion = 1.7.0
 kotlin.stdlib.default.dependency = false
 
 # at the moment, required for packaging to build test cpks for unit tests
-gradlePluginsVersion = 6.0.0-BETA16
+gradlePluginsVersion = 6.0.0-BETA17
 
 # License
 ## TODO: Change to correct name and URL
@@ -53,7 +53,7 @@ mockitoVersion = 4.1.0
 mockitoKotlinVersion = 4.0.0
 
 # OSGi
-bndVersion = 6.3.0
+bndVersion = 6.3.1
 osgiVersion = 8.0.0
 osgiScrAnnotationVersion = 1.4.0
 


### PR DESCRIPTION
Upgrade to Bnd 6.3.1 to fix potential `ClassCastException` introduced in Bnd 6.3.0. 