### PR TITLE
NOTICK Shorten CPK write reconciliations interval

### DIFF
--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/reconciliation/1.0/corda.reconciliation.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/reconciliation/1.0/corda.reconciliation.json
@@ -16,7 +16,7 @@
       "description": "",
       "type": "integer",
       "minimum": 5000,
-      "default": 30000
+      "default": 10000
     },
     "cpiInfoIntervalMs": {
       "description": "",


### PR DESCRIPTION
Shortens CPK write reconciliation default interval from 30 seconds to 10 seconds.  