### PR TITLE
NOTICK - clean up depedency versions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -28,13 +28,13 @@ artifactoryContextUrl = https://software.r3.com/artifactory
 # dokka need more metaspace - https://github.com/Kotlin/dokka/issues/1405
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=2g
 internalPublishVersion = 1.+
-dokkaVersion = 1.6.+
-detektPluginVersion = 1.19.+
+dokkaVersion = 1.7.+
+detektPluginVersion = 1.20.+
 dependencyCheckVersion=0.42.+
 artifactoryPluginVersion = 4.28.2
 
 # Logging
-slf4jVersion = 1.7.32
+slf4jVersion = 1.7.36
 
 # Main implementation dependencies
 avroGradlePluginVersion=1.1.0
@@ -43,11 +43,11 @@ bouncycastleVersion = 1.70
 grgitPluginVersion = 4.0.2
 taskTreePluginVersion = 2.1.0
 javaxPersistenceApiVersion = 2.2
-hibernateVersion = 5.6.2.Final
+hibernateVersion = 5.6.9.Final
 jacksonVersion = 2.13.1
 
 # Testing
-assertjVersion = 3.12.2
+assertjVersion = 3.23.+
 junitVersion = 5.8.2
 mockitoVersion = 4.1.0
 mockitoKotlinVersion = 4.0.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -49,7 +49,7 @@ jacksonVersion = 2.13.1
 # Testing
 assertjVersion = 3.23.+
 junitVersion = 5.8.2
-mockitoVersion = 4.1.0
+mockitoVersion = 4.6.+
 mockitoKotlinVersion = 4.0.0
 
 # OSGi


### PR DESCRIPTION
Updated all the obvious ones.
Left Jackson as is for now.

```
The following dependencies have later milestone versions:
 - com.fasterxml.jackson.core:jackson-databind [2.13.1 -> 2.13.3]
     http://github.com/FasterXML/jackson
 - com.fasterxml.jackson.dataformat:jackson-dataformat-yaml [2.13.1 -> 2.13.3]
     https://github.com/FasterXML/jackson-dataformats-text
 - com.fasterxml.jackson.module:jackson-module-kotlin [2.13.1 -> 2.13.3]
     https://github.com/FasterXML/jackson-module-kotlin
 - com.github.davidmc24.gradle.plugin.avro-base:com.github.davidmc24.gradle.plugin.avro-base.gradle.plugin [1.1.0 -> 1.3.0]
     https://github.com/davidmc24/gradle-avro-plugin
 - org.ajoberstar.grgit:org.ajoberstar.grgit.gradle.plugin [4.0.2 -> 5.0.0]
     https://github.com/ajoberstar/grgit
 - org.gradle.test-retry:org.gradle.test-retry.gradle.plugin [1.3.2 -> 1.4.0]
```
