### PR TITLE
CORE-5105 Crypto + Flow integration - Signing

### DIFF
--- a/application/src/main/kotlin/net/corda/v5/application/crypto/SigningService.kt
+++ b/application/src/main/kotlin/net/corda/v5/application/crypto/SigningService.kt
@@ -5,7 +5,6 @@ import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.crypto.CompositeKey
 import net.corda.v5.crypto.DigitalSignature
 import net.corda.v5.crypto.SignatureSpec
-import net.corda.v5.crypto.exceptions.CryptoServiceLibraryException
 import java.security.KeyPair
 import java.security.PrivateKey
 import java.security.PublicKey
@@ -42,7 +41,8 @@ interface SigningService {
     *
     * Decodes public key from PEM encoded string.
     *
-    * @throws [CryptoServiceLibraryException] for general cryptographic exceptions.
+    * @throws IllegalArgumentException if the key scheme is not supported.
+    * @throws net.corda.v5.crypto.failures.CryptoException for general cryptographic exceptions.
     */
     @Suspendable
     fun decodePublicKey(encodedKey: String): PublicKey

--- a/application/src/main/kotlin/net/corda/v5/application/crypto/SigningService.kt
+++ b/application/src/main/kotlin/net/corda/v5/application/crypto/SigningService.kt
@@ -5,6 +5,7 @@ import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.crypto.CompositeKey
 import net.corda.v5.crypto.DigitalSignature
 import net.corda.v5.crypto.SignatureSpec
+import net.corda.v5.crypto.exceptions.CryptoServiceLibraryException
 import java.security.KeyPair
 import java.security.PrivateKey
 import java.security.PublicKey
@@ -35,4 +36,14 @@ interface SigningService {
      */
     @Suspendable
     fun sign(bytes: ByteArray, publicKey: PublicKey, signatureSpec: SignatureSpec): DigitalSignature.WithKey
+
+    /**
+    * TODO Remove this API from C5. Added as a temporary API for testing until MGM code is fully integrated.
+    *
+    * Decodes public key from PEM encoded string.
+    *
+    * @throws [CryptoServiceLibraryException] for general cryptographic exceptions.
+    */
+    @Suspendable
+    fun decodePublicKey(encodedKey: String): PublicKey
 }

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/ops/flow/FlowOpsResponse.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/ops/flow/FlowOpsResponse.avsc
@@ -14,7 +14,8 @@
       "type": [
         "net.corda.data.crypto.wire.CryptoPublicKey",
         "net.corda.data.crypto.wire.CryptoSigningKeys",
-        "net.corda.data.crypto.wire.CryptoSignatureWithKey"
+        "net.corda.data.crypto.wire.CryptoSignatureWithKey",
+        "net.corda.data.crypto.wire.CryptoNoContentValue"
       ],
       "doc": "Response's payload, depends on the requested operation"
     }

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/ops/flow/FlowOpsResponse.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/ops/flow/FlowOpsResponse.avsc
@@ -18,6 +18,11 @@
         "net.corda.data.crypto.wire.CryptoNoContentValue"
       ],
       "doc": "Response's payload, depends on the requested operation"
+    },
+    {
+      "name": "exception",
+      "doc": "Exception information",
+      "type": ["null", "net.corda.data.ExceptionEnvelope"]
     }
   ]
 }

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/flow/event/FlowEvent.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/flow/event/FlowEvent.avsc
@@ -14,7 +14,8 @@
         "net.corda.data.flow.event.Wakeup",
         "net.corda.data.flow.output.FlowStatus",
         "net.corda.data.flow.event.SessionEvent",
-        "net.corda.data.persistence.EntityResponse"
+        "net.corda.data.persistence.EntityResponse",
+        "net.corda.data.crypto.wire.ops.flow.FlowOpsResponse"
       ]
     }
   ]

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/flow/state/Checkpoint.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/flow/state/Checkpoint.avsc
@@ -31,6 +31,12 @@
       "doc": "Active persistence query. Null if there is no query in progress."
     },
     {
+      "name": "CryptoState",
+      "type": ["null", "net.corda.data.flow.state.crypto.CryptoState"],
+      "default": null,
+      "doc": "Active crypto request. Null if there are no requests in progress."
+    },
+    {
       "name": "sessions",
       "type": {
         "type": "array",

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/flow/state/crypto/CryptoState.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/flow/state/crypto/CryptoState.avsc
@@ -1,0 +1,39 @@
+{
+  "type": "record",
+  "name": "CryptoState",
+  "namespace": "net.corda.data.flow.state.crypto",
+  "fields": [
+    {
+      "name": "requestId",
+      "type": "string",
+      "doc": "Unique ID of a single crypto request. The Id remains the same for each resend."
+    },
+    {
+      "name": "sendTimestamp",
+      "type": {
+        "type": "long",
+        "logicalType": "timestamp-millis"
+      },
+      "doc": "Timestamp of when to send a message. If this time is in the past, then the message needs to be (re)sent."
+    },
+    {
+      "name": "request",
+      "doc": "The 'request' that we wish to make to the crypto API.",
+      "type": "net.corda.data.crypto.wire.ops.flow.FlowOpsRequest"
+    },
+    {
+      "name": "retries",
+      "doc": "The amount of times the request has been sent.",
+      "type": "int",
+      "default": 0
+    },
+    {
+      "name": "response",
+      "doc": "The response we receive from the crypto API. Null if the response has not been returned yet.",
+      "type": [
+        "null",
+        "net.corda.data.crypto.wire.ops.flow.FlowOpsResponse"
+      ]
+    }
+  ]
+}

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/flow/state/waiting/SignedBytes.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/flow/state/waiting/SignedBytes.avsc
@@ -1,0 +1,12 @@
+{
+  "type": "record",
+  "name": "SignedBytes",
+  "namespace": "net.corda.data.flow.state.waiting",
+  "fields": [
+    {
+      "name": "requestId",
+      "type": "string",
+      "doc": "The ID of the request to the Crypto Worker"
+    }
+  ]
+}

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/flow/state/waiting/WaitingFor.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/flow/state/waiting/WaitingFor.avsc
@@ -9,7 +9,8 @@
         "net.corda.data.flow.state.waiting.Wakeup",
         "net.corda.data.flow.state.waiting.SessionConfirmation",
         "net.corda.data.flow.state.waiting.SessionData",
-        "net.corda.data.flow.state.waiting.EntityResponse"
+        "net.corda.data.flow.state.waiting.EntityResponse",
+        "net.corda.data.flow.state.waiting.SignedBytes"
       ]
     }
   ]

--- a/data/config-schema/src/main/kotlin/net/corda/schema/configuration/FlowConfig.kt
+++ b/data/config-schema/src/main/kotlin/net/corda/schema/configuration/FlowConfig.kt
@@ -1,6 +1,9 @@
 package net.corda.schema.configuration
 
 object FlowConfig {
+        const val CRYPTO_RESEND_BUFFER = "crypto.messageResendWindowBuffer"
+        const val CRYPTO_MESSAGE_RESEND_WINDOW = "crypto.messageResendWindow"
+        const val CRYPTO_MAX_RETRIES = "crypto.maxRetries"
         const val PERSISTENCE_RESEND_BUFFER = "persistence.messageResendWindowBuffer"
         const val PERSISTENCE_MESSAGE_RESEND_WINDOW = "persistence.messageResendWindow"
         const val PERSISTENCE_MAX_RETRIES = "persistence.maxRetries"

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/flow/1.0/corda.flow.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/flow/1.0/corda.flow.json
@@ -74,6 +74,25 @@
           "default": 5
         }
       }
+    },
+    "crypto": {
+      "description": "Settings for crypto interactions within a flow",
+      "type": "object",
+      "default": {},
+      "properties": {
+        "messageResendWindow": {
+          "description": "Length of time to wait before resending unacknowledged crypto events, in milliseconds",
+          "type": "integer",
+          "minimum": 100,
+          "default": 5000
+        },
+        "maxRetries": {
+          "description": "The maximum amount of times to retry a request before returning an exception to the user code.",
+          "type": "integer",
+          "minimum": 0,
+          "default": 5
+        }
+      }
     }
   }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 133
+cordaApiRevision = 134
 
 # Main
 kotlinVersion = 1.7.0


### PR DESCRIPTION
Add a property to the `Checkpoint` schema to keep track of what the current crypto request is.

Temporarily add `decodePublicKey` to the public API to assist in testing until MGM code catches up.

Update `FlowOpsResponse` schema to include a schema that was not referenced but was used inside the `corda-runtime-os` code.