### PR TITLE
NOTICK - Add some docs for Avro schemas that are part of p2p public API

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/app/AppMessage.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/app/AppMessage.avsc
@@ -2,7 +2,7 @@
   "type": "record",
   "name": "AppMessage",
   "namespace": "net.corda.p2p.app",
-  "doc": "An application message to be transferred via the p2p layer.",
+  "doc": "An application message to be transferred via the p2p layer. This is a wrapper over the different types of messages that can be transferred via the p2p layer.",
   "fields": [
       {
         "name": "message",

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/app/AuthenticatedMessage.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/app/AuthenticatedMessage.avsc
@@ -2,7 +2,7 @@
   "type": "record",
   "name": "AuthenticatedMessage",
   "namespace": "net.corda.p2p.app",
-  "doc": "A message to be sent to the specified destination via an (authenticated) link session.",
+  "doc": "A message that will be delivered by the p2p layer over an end-to-end (authenticated and optionally encrypted) session.",
   "fields": [
     {
       "name": "header",

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/app/AuthenticatedMessageHeader.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/app/AuthenticatedMessageHeader.avsc
@@ -14,7 +14,7 @@
       "type": "net.corda.data.identity.HoldingIdentity"
     },
     {
-      "doc": "A (time-to-live) timestamp after which this message will be dropped from the p2p layer. If no ttl is specified, the p2p layer will continue replaying this message infinitely until it is delivered.",
+      "doc": "A (time-to-live) unix timestamp (in milliseconds) after which this message will be dropped from the p2p layer. If no ttl is specified, the p2p layer will continue replaying this message infinitely until it is delivered.",
       "name": "ttl",
       "type": ["null", "long"]
     },

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/app/AuthenticatedMessageHeader.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/app/AuthenticatedMessageHeader.avsc
@@ -1,31 +1,37 @@
 {
   "type": "record",
   "name": "AuthenticatedMessageHeader",
+  "doc": "A message that will be delivered by the p2p layer over an end-to-end (authenticated and optionally encrypted) session.",
   "namespace": "net.corda.p2p.app",
   "fields": [
     {
+      "doc": "The destination identity for this message.",
       "name": "destination",
       "type": "net.corda.data.identity.HoldingIdentity"
     },
     {
+      "doc": "The source identity of this message.",
       "name": "source",
       "type": "net.corda.data.identity.HoldingIdentity"
     },
     {
+      "doc": "A (time-to-live) timestamp after which this message will be dropped from the p2p layer.",
       "name": "ttl",
       "type": ["null", "long"]
     },
     {
+      "doc": "A unique identifier for this message. This will be used by the p2p layer to track the delivery of this specific message.",
       "name": "messageId",
       "type": "string"
     },
     {
+      "doc": "A trace identifier. The semantics of this field can vary based on the use-case of the upstream user, but it can be used to trace together multiple instances of the same message (e.g. in cases where the upstream user also performs replays, it can assign the same trace ID to all the instances of the same replayed message.)",
       "name": "traceId",
       "type": "string"
     },
     {
+      "doc": "This value identifies the upstream user of the p2p layer that this message is sent from and should be received by. It can be used to filter incoming messages from the p2p layer and process only the ones destined for a specific system.",
       "name": "subsystem",
-      "doc": "The subsystem that this message is sent from and should be received by.",
       "type": "string"
     }
   ]

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/app/AuthenticatedMessageHeader.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/app/AuthenticatedMessageHeader.avsc
@@ -25,7 +25,7 @@
       "type": "string"
     },
     {
-      "doc": "A trace identifier. The semantics of this field can vary based on the use-case of the upstream user, but it can be used to trace together multiple instances of the same message (e.g. in cases where the upstream user also performs replays, it can assign the same trace ID to all the instances of the same replayed message.)",
+      "doc": "A trace identifier. The semantics of this field can vary based on the use-case of the upstream user, but it can be used to trace together multiple instances of the same message (e.g. in cases where the upstream user also performs replays, it can assign the same trace ID to all the instances of the same replayed message).",
       "name": "traceId",
       "type": "string"
     },

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/app/AuthenticatedMessageHeader.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/app/AuthenticatedMessageHeader.avsc
@@ -1,7 +1,6 @@
 {
   "type": "record",
   "name": "AuthenticatedMessageHeader",
-  "doc": "A message that will be delivered by the p2p layer over an end-to-end (authenticated and optionally encrypted) session.",
   "namespace": "net.corda.p2p.app",
   "fields": [
     {
@@ -15,7 +14,7 @@
       "type": "net.corda.data.identity.HoldingIdentity"
     },
     {
-      "doc": "A (time-to-live) timestamp after which this message will be dropped from the p2p layer.",
+      "doc": "A (time-to-live) timestamp after which this message will be dropped from the p2p layer. If no ttl is specified, the p2p layer will continue replaying this message infinitely until it is delivered.",
       "name": "ttl",
       "type": ["null", "long"]
     },

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/app/AuthenticatedMessageHeader.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/app/AuthenticatedMessageHeader.avsc
@@ -16,6 +16,7 @@
     {
       "doc": "A (time-to-live) unix timestamp (in milliseconds) after which this message will be dropped from the p2p layer. If no ttl is specified, the p2p layer will continue replaying this message infinitely until it is delivered.",
       "name": "ttl",
+      "logicalType": "timestamp-millis",
       "type": ["null", "long"]
     },
     {

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/app/UnauthenticatedMessage.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/app/UnauthenticatedMessage.avsc
@@ -2,7 +2,7 @@
   "type": "record",
   "name": "UnauthenticatedMessage",
   "namespace": "net.corda.p2p.app",
-  "doc": "A message to be sent to the specified destination outside a link session. This means, for instance, that any authentication need to performed by the application layer",
+  "doc": "A message that will be delivered by the p2p layer directly (without using an end-to-end session). If there is a need for authentication, this has to be performed at the application layer.",
   "fields": [
     {
       "name": "header",

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/app/UnauthenticatedMessageHeader.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/app/UnauthenticatedMessageHeader.avsc
@@ -1,7 +1,6 @@
 {
   "type": "record",
   "name": "UnauthenticatedMessageHeader",
-  "doc": "A message that will be delivered by the p2p layer directly (without using an end-to-end session).",
   "namespace": "net.corda.p2p.app",
   "fields": [
     {

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/app/UnauthenticatedMessageHeader.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/app/UnauthenticatedMessageHeader.avsc
@@ -1,19 +1,22 @@
 {
   "type": "record",
   "name": "UnauthenticatedMessageHeader",
+  "doc": "A message that will be delivered by the p2p layer directly (without using an end-to-end session).",
   "namespace": "net.corda.p2p.app",
   "fields": [
     {
+      "doc": "The destination identity for this message.",
       "name": "destination",
       "type": "net.corda.data.identity.HoldingIdentity"
     },
     {
+      "doc": "The source identity of this message.",
       "name": "source",
       "type": "net.corda.data.identity.HoldingIdentity"
     },
     {
+      "doc": "This value identifies the upstream user of the p2p layer that this message is sent from and should be received by. It can be used to filter incoming messages from the p2p layer and process only the ones destined for a specific system.",
       "name": "subsystem",
-      "doc": "The subsystem that this message is sent from and should be received by.",
       "type": "string"
     }
   ]


### PR DESCRIPTION
After discussions with various people these days, I realised `docs` fields were missing from some Avro schemas that form the public API of the p2p layer. This adds those, so that people that use the p2p layer can understand the semantics of each field more easily.