### PR TITLE
CORE-5141 Set topic configurations to Confluent Cloud minimum

### DIFF
--- a/data/topic-schema/src/main/resources/net/corda/schema/Config.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/Config.yaml
@@ -20,7 +20,7 @@ topics:
     producers:
     config:
       cleanup.policy: compact
-      segment.ms: 300000
+      segment.ms: 600000
       delete.retention.ms: 300000
       min.compaction.lag.ms: 60000
       max.compaction.lag.ms: 300000

--- a/data/topic-schema/src/main/resources/net/corda/schema/Config.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/Config.yaml
@@ -23,5 +23,5 @@ topics:
       segment.ms: 600000
       delete.retention.ms: 300000
       min.compaction.lag.ms: 60000
-      max.compaction.lag.ms: 300000
+      max.compaction.lag.ms: 604800000
       min.cleanable.dirty.ratio: 0.5

--- a/data/topic-schema/src/main/resources/net/corda/schema/Flow.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/Flow.yaml
@@ -10,7 +10,7 @@ topics:
     producers:
     config:
       cleanup.policy: compact
-      segment.ms: 300000
+      segment.ms: 600000
       delete.retention.ms: 300000
       min.compaction.lag.ms: 60000
       max.compaction.lag.ms: 300000
@@ -31,7 +31,7 @@ topics:
     producers:
     config:
       cleanup.policy: compact
-      segment.ms: 300000
+      segment.ms: 600000
       delete.retention.ms: 300000
       min.compaction.lag.ms: 60000
       max.compaction.lag.ms: 300000
@@ -47,7 +47,7 @@ topics:
     producers:
     config:
       cleanup.policy: compact
-      segment.ms: 300000
+      segment.ms: 600000
       delete.retention.ms: 300000
       min.compaction.lag.ms: 60000
       max.compaction.lag.ms: 300000

--- a/data/topic-schema/src/main/resources/net/corda/schema/Flow.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/Flow.yaml
@@ -13,7 +13,7 @@ topics:
       segment.ms: 600000
       delete.retention.ms: 300000
       min.compaction.lag.ms: 60000
-      max.compaction.lag.ms: 300000
+      max.compaction.lag.ms: 604800000
       min.cleanable.dirty.ratio: 0.5
   FlowEventDLQTopic:
     name: flow.event.dlq
@@ -34,7 +34,7 @@ topics:
       segment.ms: 600000
       delete.retention.ms: 300000
       min.compaction.lag.ms: 60000
-      max.compaction.lag.ms: 300000
+      max.compaction.lag.ms: 604800000
       min.cleanable.dirty.ratio: 0.5
   FlowMapperEventDLQTopic:
     name: flow.mapper.event.dlq
@@ -50,5 +50,5 @@ topics:
       segment.ms: 600000
       delete.retention.ms: 300000
       min.compaction.lag.ms: 60000
-      max.compaction.lag.ms: 300000
+      max.compaction.lag.ms: 604800000
       min.cleanable.dirty.ratio: 0.5

--- a/data/topic-schema/src/main/resources/net/corda/schema/Membership.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/Membership.yaml
@@ -13,7 +13,7 @@ topics:
       segment.ms: 600000
       delete.retention.ms: 300000
       min.compaction.lag.ms: 60000
-      max.compaction.lag.ms: 300000
+      max.compaction.lag.ms: 604800000
       min.cleanable.dirty.ratio: 0.5
   MembershipGroupParamsTopic:
     name: membership.group.params
@@ -24,7 +24,7 @@ topics:
       segment.ms: 600000
       delete.retention.ms: 300000
       min.compaction.lag.ms: 60000
-      max.compaction.lag.ms: 300000
+      max.compaction.lag.ms: 604800000
       min.cleanable.dirty.ratio: 0.5
   MembershipUpdateTopic:
     name: membership.update
@@ -50,7 +50,7 @@ topics:
       segment.ms: 600000
       delete.retention.ms: 300000
       min.compaction.lag.ms: 60000
-      max.compaction.lag.ms: 300000
+      max.compaction.lag.ms: 604800000
       min.cleanable.dirty.ratio: 0.5
   MembershipRpcOpsTopic:
     name: membership.rpc.ops

--- a/data/topic-schema/src/main/resources/net/corda/schema/Membership.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/Membership.yaml
@@ -10,7 +10,7 @@ topics:
     producers:
     config:
       cleanup.policy: compact
-      segment.ms: 300000
+      segment.ms: 600000
       delete.retention.ms: 300000
       min.compaction.lag.ms: 60000
       max.compaction.lag.ms: 300000
@@ -21,7 +21,7 @@ topics:
     producers:
     config:
       cleanup.policy: compact
-      segment.ms: 300000
+      segment.ms: 600000
       delete.retention.ms: 300000
       min.compaction.lag.ms: 60000
       max.compaction.lag.ms: 300000
@@ -47,7 +47,7 @@ topics:
     producers:
     config:
       cleanup.policy: compact
-      segment.ms: 300000
+      segment.ms: 600000
       delete.retention.ms: 300000
       min.compaction.lag.ms: 60000
       max.compaction.lag.ms: 300000

--- a/data/topic-schema/src/main/resources/net/corda/schema/P2P.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/P2P.yaml
@@ -20,7 +20,7 @@ topics:
     producers:
     config:
       cleanup.policy: compact
-      segment.ms: 300000
+      segment.ms: 600000
       delete.retention.ms: 300000
       min.compaction.lag.ms: 60000
       max.compaction.lag.ms: 300000
@@ -36,7 +36,7 @@ topics:
     producers:
     config:
       cleanup.policy: compact
-      segment.ms: 300000
+      segment.ms: 600000
       delete.retention.ms: 300000
       min.compaction.lag.ms: 60000
       max.compaction.lag.ms: 300000
@@ -57,7 +57,7 @@ topics:
     producers:
     config:
       cleanup.policy: compact
-      segment.ms: 300000
+      segment.ms: 600000
       delete.retention.ms: 300000
       min.compaction.lag.ms: 60000
       max.compaction.lag.ms: 300000
@@ -68,7 +68,7 @@ topics:
     producers:
     config:
       cleanup.policy: compact
-      segment.ms: 300000
+      segment.ms: 600000
       delete.retention.ms: 300000
       min.compaction.lag.ms: 60000
       max.compaction.lag.ms: 300000
@@ -79,7 +79,7 @@ topics:
     producers:
     config:
       cleanup.policy: compact
-      segment.ms: 300000
+      segment.ms: 600000
       delete.retention.ms: 300000
       min.compaction.lag.ms: 60000
       max.compaction.lag.ms: 300000
@@ -91,7 +91,7 @@ topics:
     producers:
     config:
       cleanup.policy: compact
-      segment.ms: 300000
+      segment.ms: 600000
       delete.retention.ms: 300000
       min.compaction.lag.ms: 60000
       max.compaction.lag.ms: 300000
@@ -102,7 +102,7 @@ topics:
     producers:
     config:
       cleanup.policy: compact
-      segment.ms: 300000
+      segment.ms: 600000
       delete.retention.ms: 300000
       min.compaction.lag.ms: 60000
       max.compaction.lag.ms: 300000
@@ -113,7 +113,7 @@ topics:
     producers:
     config:
       cleanup.policy: compact
-      segment.ms: 300000
+      segment.ms: 600000
       delete.retention.ms: 300000
       min.compaction.lag.ms: 60000
       max.compaction.lag.ms: 300000

--- a/data/topic-schema/src/main/resources/net/corda/schema/P2P.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/P2P.yaml
@@ -23,7 +23,7 @@ topics:
       segment.ms: 600000
       delete.retention.ms: 300000
       min.compaction.lag.ms: 60000
-      max.compaction.lag.ms: 300000
+      max.compaction.lag.ms: 604800000
       min.cleanable.dirty.ratio: 0.5
   P2POutMarkersDlqTopic:
     name: p2p.out.markers.dlq
@@ -39,7 +39,7 @@ topics:
       segment.ms: 600000
       delete.retention.ms: 300000
       min.compaction.lag.ms: 60000
-      max.compaction.lag.ms: 300000
+      max.compaction.lag.ms: 604800000
       min.cleanable.dirty.ratio: 0.5
   LinkInTopic:
     name: link.in
@@ -60,7 +60,7 @@ topics:
       segment.ms: 600000
       delete.retention.ms: 300000
       min.compaction.lag.ms: 60000
-      max.compaction.lag.ms: 300000
+      max.compaction.lag.ms: 604800000
       min.cleanable.dirty.ratio: 0.5
   GatewayTLSTruststoresTopic:
     name: gateway.tls.truststores
@@ -71,7 +71,7 @@ topics:
       segment.ms: 600000
       delete.retention.ms: 300000
       min.compaction.lag.ms: 60000
-      max.compaction.lag.ms: 300000
+      max.compaction.lag.ms: 604800000
       min.cleanable.dirty.ratio: 0.5
   SessionOutPartitionsTopic:
     name: session.out.partitions
@@ -82,7 +82,7 @@ topics:
       segment.ms: 600000
       delete.retention.ms: 300000
       min.compaction.lag.ms: 60000
-      max.compaction.lag.ms: 300000
+      max.compaction.lag.ms: 604800000
       min.cleanable.dirty.ratio: 0.5
   # Below are topics for stub components that will be removed after full integration with MGM/membership/crypto components
   P2PMembersInfoTopic:
@@ -94,7 +94,7 @@ topics:
       segment.ms: 600000
       delete.retention.ms: 300000
       min.compaction.lag.ms: 60000
-      max.compaction.lag.ms: 300000
+      max.compaction.lag.ms: 604800000
       min.cleanable.dirty.ratio: 0.5
   P2PGroupPoliciesTopic:
     name: p2p.group.policies
@@ -105,7 +105,7 @@ topics:
       segment.ms: 600000
       delete.retention.ms: 300000
       min.compaction.lag.ms: 60000
-      max.compaction.lag.ms: 300000
+      max.compaction.lag.ms: 604800000
       min.cleanable.dirty.ratio: 0.5
   P2PCryptoKeyTopic:
     name: p2p.crypto.keys
@@ -116,5 +116,5 @@ topics:
       segment.ms: 600000
       delete.retention.ms: 300000
       min.compaction.lag.ms: 60000
-      max.compaction.lag.ms: 300000
+      max.compaction.lag.ms: 604800000
       min.cleanable.dirty.ratio: 0.5

--- a/data/topic-schema/src/main/resources/net/corda/schema/Permissions.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/Permissions.yaml
@@ -13,5 +13,5 @@ topics:
       segment.ms: 600000
       delete.retention.ms: 300000
       min.compaction.lag.ms: 60000
-      max.compaction.lag.ms: 300000
+      max.compaction.lag.ms: 604800000
       min.cleanable.dirty.ratio: 0.5

--- a/data/topic-schema/src/main/resources/net/corda/schema/Permissions.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/Permissions.yaml
@@ -10,7 +10,7 @@ topics:
     producers:
     config:
       cleanup.policy: compact
-      segment.ms: 300000
+      segment.ms: 600000
       delete.retention.ms: 300000
       min.compaction.lag.ms: 60000
       max.compaction.lag.ms: 300000

--- a/data/topic-schema/src/main/resources/net/corda/schema/RPC.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/RPC.yaml
@@ -18,7 +18,7 @@ topics:
       segment.ms: 600000
       delete.retention.ms: 300000
       min.compaction.lag.ms: 60000
-      max.compaction.lag.ms: 300000
+      max.compaction.lag.ms: 604800000
       min.cleanable.dirty.ratio: 0.5
   RPCPermissionsPermissionTopic:
     name: rpc.permissions.permission
@@ -29,7 +29,7 @@ topics:
       segment.ms: 600000
       delete.retention.ms: 300000
       min.compaction.lag.ms: 60000
-      max.compaction.lag.ms: 300000
+      max.compaction.lag.ms: 604800000
       min.cleanable.dirty.ratio: 0.5
   RPCPermissionsUserTopic:
     name: rpc.permissions.user
@@ -40,7 +40,7 @@ topics:
       segment.ms: 600000
       delete.retention.ms: 300000
       min.compaction.lag.ms: 60000
-      max.compaction.lag.ms: 300000
+      max.compaction.lag.ms: 604800000
       min.cleanable.dirty.ratio: 0.5
   RPCPermissionsRoleTopic:
     name: rpc.permissions.role
@@ -51,5 +51,5 @@ topics:
       segment.ms: 600000
       delete.retention.ms: 300000
       min.compaction.lag.ms: 60000
-      max.compaction.lag.ms: 300000
+      max.compaction.lag.ms: 604800000
       min.cleanable.dirty.ratio: 0.5

--- a/data/topic-schema/src/main/resources/net/corda/schema/RPC.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/RPC.yaml
@@ -15,7 +15,7 @@ topics:
     producers:
     config:
       cleanup.policy: compact
-      segment.ms: 300000
+      segment.ms: 600000
       delete.retention.ms: 300000
       min.compaction.lag.ms: 60000
       max.compaction.lag.ms: 300000
@@ -26,7 +26,7 @@ topics:
     producers:
     config:
       cleanup.policy: compact
-      segment.ms: 300000
+      segment.ms: 600000
       delete.retention.ms: 300000
       min.compaction.lag.ms: 60000
       max.compaction.lag.ms: 300000
@@ -37,7 +37,7 @@ topics:
     producers:
     config:
       cleanup.policy: compact
-      segment.ms: 300000
+      segment.ms: 600000
       delete.retention.ms: 300000
       min.compaction.lag.ms: 60000
       max.compaction.lag.ms: 300000
@@ -48,7 +48,7 @@ topics:
     producers:
     config:
       cleanup.policy: compact
-      segment.ms: 300000
+      segment.ms: 600000
       delete.retention.ms: 300000
       min.compaction.lag.ms: 60000
       max.compaction.lag.ms: 300000

--- a/data/topic-schema/src/main/resources/net/corda/schema/VirtualNode.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/VirtualNode.yaml
@@ -5,7 +5,7 @@ topics:
     producers:
     config:
       cleanup.policy: compact
-      segment.ms: 300000
+      segment.ms: 600000
       delete.retention.ms: 300000
       min.compaction.lag.ms: 60000
       max.compaction.lag.ms: 300000
@@ -31,7 +31,7 @@ topics:
     producers:
     config:
       cleanup.policy: compact
-      segment.ms: 300000
+      segment.ms: 600000
       delete.retention.ms: 300000
       min.compaction.lag.ms: 60000
       max.compaction.lag.ms: 300000
@@ -67,7 +67,7 @@ topics:
     producers:
     config:
       cleanup.policy: compact
-      segment.ms: 300000
+      segment.ms: 600000
       delete.retention.ms: 300000
       min.compaction.lag.ms: 60000
       max.compaction.lag.ms: 300000

--- a/data/topic-schema/src/main/resources/net/corda/schema/VirtualNode.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/VirtualNode.yaml
@@ -8,7 +8,7 @@ topics:
       segment.ms: 600000
       delete.retention.ms: 300000
       min.compaction.lag.ms: 60000
-      max.compaction.lag.ms: 300000
+      max.compaction.lag.ms: 604800000
       min.cleanable.dirty.ratio: 0.5
   CPIUploadTopic:
     name: cpi.upload
@@ -34,7 +34,7 @@ topics:
       segment.ms: 600000
       delete.retention.ms: 300000
       min.compaction.lag.ms: 60000
-      max.compaction.lag.ms: 300000
+      max.compaction.lag.ms: 604800000
       min.cleanable.dirty.ratio: 0.5
   DatabaseEntityTopic:
     name: db.entity.processor
@@ -70,5 +70,5 @@ topics:
       segment.ms: 600000
       delete.retention.ms: 300000
       min.compaction.lag.ms: 60000
-      max.compaction.lag.ms: 300000
+      max.compaction.lag.ms: 604800000
       min.cleanable.dirty.ratio: 0.5

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 132
+cordaApiRevision = 133
 
 # Main
 kotlinVersion = 1.7.0


### PR DESCRIPTION
Confluent Cloud enforces a minimum `segment.ms` and `max.compaction.lag.ms` during topic creation which are higher than our current values. Bump our current default values to match.


# PR Checklist:

- [x] Have you run the unit, integration and smoke tests as described [here](https://docs.corda.net/head/testing.html)?
- [x] If you added public APIs, did you write the JavaDocs?
- [x] If the changes are of interest to application developers, have you added them to the [changelog](https://docs.corda.net/head/changelog.html) (`/docs/source/changelog.rst`), and potentially the [release notes](https://docs.corda.net/head/release-notes.html) (`/docs/source/release-notes.rst`)?
- [x] If you are contributing for the first time, please read the [contributor agreement](https://docs.corda.net/head/contributing.html) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://docs.corda.net/head/contributing.html#merging-the-changes-back-into-corda).

Thanks for your code, it's appreciated! :)
