### PR TITLE
NOTICK - Make trace ID an optional field

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/app/AuthenticatedMessageHeader.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/app/AuthenticatedMessageHeader.avsc
@@ -27,7 +27,7 @@
     {
       "doc": "A trace identifier. The semantics of this field can vary based on the use-case of the upstream user, but it can be used to trace together multiple instances of the same message (e.g. in cases where the upstream user also performs replays, it can assign the same trace ID to all the instances of the same replayed message).",
       "name": "traceId",
-      "type": "string"
+      "type": ["null", "string"]
     },
     {
       "doc": "This value identifies the upstream user of the p2p layer that this message is sent from and should be received by. It can be used to filter incoming messages from the p2p layer and process only the ones destined for a specific system.",


### PR DESCRIPTION
Making trace ID optional, since there can be use cases where it's not needed at all (e.g. if the user does not specify TTL and will not perform replays on its side).