### PR TITLE
CORE-5483 - add source configuration data

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/config/Configuration.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/config/Configuration.avsc
@@ -5,7 +5,13 @@
   "fields": [
     {
       "name": "value",
-      "type": "string"
+      "type": "string",
+      "doc": "Configuration values, as a JSON/HCON structure, with defaults applied."
+    },
+    {
+      "name": "source",
+      "type": "string",
+      "doc": "Configuration values, as a JSON/HCON structure, before defaults applied."
     },
     {
       "name": "version",

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 135
+cordaApiRevision = 136
 
 # Main
 kotlinVersion = 1.7.0


### PR DESCRIPTION
Add source attribute to Configuration schema to store pre-defaulted configuration data.

This is a prereq. to being able to return the pre-defaulted configuration to a HTTP client.