### PR TITLE
CORE-5521: bump avro plugin version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -37,7 +37,7 @@ artifactoryPluginVersion = 4.28.2
 slf4jVersion = 1.7.36
 
 # Main implementation dependencies
-avroGradlePluginVersion=1.1.0
+avroGradlePluginVersion=1.3.0
 avroVersion = 1.11.0
 bouncycastleVersion = 1.70
 grgitPluginVersion = 4.0.2


### PR DESCRIPTION
Take latest version of Avro Gradle plugin to attempt to fix issue where Gradle incorrectly does not re generate Avro schema after a change 