### PR TITLE
CORE-5521 fix Avro generation issue 

### DIFF
--- a/data/avro-schema/build.gradle
+++ b/data/avro-schema/build.gradle
@@ -67,7 +67,6 @@ avro {
 def generateOSGiPackageInfo = tasks.register("generateOSGiPackageInfo", Task) {
     outputs.cacheIf { false }
     group = "codeGeneration"
-
     def packages = [] as Set<String>
     def classes = [] as Set<String>
 

--- a/data/avro-schema/build.gradle
+++ b/data/avro-schema/build.gradle
@@ -43,14 +43,9 @@ sourceSets {
     }
 }
 
-def cleanAvro = tasks.register("cleanAvro", Delete) {
-    group = "codeGeneration"
-    delete generatedAvroDir
-}
-
 def generateAvro = tasks.register("generateAvro", GenerateAvroJavaTask) {
-    dependsOn cleanAvro
     outputs.cacheIf { false }
+    outputs.upToDateWhen { false }
     group = "codeGeneration"
     source("src/main/resources/avro")
     outputDir = generatedAvroDir

--- a/data/avro-schema/build.gradle
+++ b/data/avro-schema/build.gradle
@@ -43,7 +43,14 @@ sourceSets {
     }
 }
 
+def cleanAvero = tasks.register("cleanAvero", Delete) {
+    group = "codeGeneration"
+    delete generatedAvroDir
+}
+
 def generateAvro = tasks.register("generateAvro", GenerateAvroJavaTask) {
+    dependsOn cleanAvero
+    outputs.cacheIf { false }
     group = "codeGeneration"
     source("src/main/resources/avro")
     outputDir = generatedAvroDir
@@ -58,7 +65,9 @@ avro {
 // generate through Avro
 
 def generateOSGiPackageInfo = tasks.register("generateOSGiPackageInfo", Task) {
+    outputs.cacheIf { false }
     group = "codeGeneration"
+
     def packages = [] as Set<String>
     def classes = [] as Set<String>
 

--- a/data/avro-schema/build.gradle
+++ b/data/avro-schema/build.gradle
@@ -43,13 +43,13 @@ sourceSets {
     }
 }
 
-def cleanAvero = tasks.register("cleanAvero", Delete) {
+def cleanAvro = tasks.register("cleanAvro", Delete) {
     group = "codeGeneration"
     delete generatedAvroDir
 }
 
 def generateAvro = tasks.register("generateAvro", GenerateAvroJavaTask) {
-    dependsOn cleanAvero
+    dependsOn cleanAvro
     outputs.cacheIf { false }
     group = "codeGeneration"
     source("src/main/resources/avro")


### PR DESCRIPTION
Fix Avro Generation issue where the Build does not realize the avro schema has changed. 

- This also removes the need to manually call data:avro-schema:clean as a work around by introducing a new cleanAvro task which is always triggered.
- disable build caching for existing avro related tasks ( Delete tasks not catchable by default so not needed in for mentioned item)
  