### PR TITLE
CORE-5550: Only allow integers for max message size

### DIFF
--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/messaging/1.0/corda.messaging.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/messaging/1.0/corda.messaging.json
@@ -102,7 +102,7 @@
     },
     "maxAllowedMessageSize": {
       "description": "Maximum allowed size, in bytes, for publishing Messages. This configuration is used by the platform as a guide and does _not_ change the underlying bus settings.",
-      "type": "number",
+      "type": "integer",
       "default": 972800,
       "minimum": 512000,
       "maximum": 8388608


### PR DESCRIPTION
The max message size field was allowing floating point values through. This PR changes the schema to only allow integer values.