### PR TITLE
NOTICK: Allow Gradle to run on Java 17, while still building for Java 11.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,8 +64,8 @@ def releaseType = System.getenv('RELEASE_TYPE') ?: "SNAPSHOT"
 def javaVersion = VERSION_11
 
 logger.quiet("********************** CORDA BUILD **********************")
-if (JavaVersion.current() != javaVersion) {
-    throw new GradleException("The java version used ${JavaVersion.current()} is not the expected version ${javaVersion}.")
+if (!JavaVersion.current().isCompatibleWith(javaVersion)) {
+    throw new GradleException("The java version used ${JavaVersion.current()} is not compatible with the expected version ${javaVersion}.")
 }
 logger.quiet("SDK version: {}", JavaVersion.current())
 logger.quiet("JAVA HOME {}", System.getProperty("java.home"))


### PR DESCRIPTION
We use Gradle toolchains to build and test Corda on Java 11, so allow Gradle _itself_ to run on Java 17.