### PR TITLE
CORE-5684: Missing marker type in union of app message marker causing link manager to fail

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/markers/AppMessageMarker.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/markers/AppMessageMarker.avsc
@@ -11,6 +11,7 @@
         "net.corda.p2p.markers.ApplicationProcessedMarker",
         "net.corda.p2p.markers.ApplicationRejectedStaleMarker",
         "net.corda.p2p.markers.GatewaySentMarker",
+        "net.corda.p2p.markers.LinkManagerProcessedMarker",
         "net.corda.p2p.markers.TtlExpiredMarker"
       ]
     },

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 143
+cordaApiRevision = 144
 
 # Main
 kotlinVersion = 1.7.10

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 144
+cordaApiRevision = 143
 
 # Main
 kotlinVersion = 1.7.10


### PR DESCRIPTION
Add LinkManagerProcessedMarker to parent type AppMessageMarker
