### PR TITLE
CORE-3764 set flow and session related timeouts in a way that do not conflict with each other

### DIFF
--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/flow/1.0/corda.flow.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/flow/1.0/corda.flow.json
@@ -39,8 +39,8 @@
         "messageResendWindow": {
           "description": "Length of time to wait before resending unacknowledged flow session messages, in milliseconds",
           "type": "integer",
-          "minimum": 100,
-          "default": 5000
+          "minimum": 1000,
+          "default": 120000
         },
         "heartbeatTimeout": {
           "description": "Length of time to wait when no message has been received from a counterparty before causing the session to error, in milliseconds",
@@ -52,7 +52,7 @@
           "description": "TTL set on on messages passed to the P2P layer to be sent to a counterparty.",
           "type": "integer",
           "minimum": 10000,
-          "default": 60000
+          "default": 240000
         }
       }
     },


### PR DESCRIPTION
set session ttl such that it is not significantly longer than the amount of time a flow  will resend a message that has not received a reply. Theres no need for p2p to keep trying multiple messages if they are duplicates.  

Set resend window closer to the flow wakeup interval as being set significantly lower than this will have no effect on the flow and may cause confusion. 

Values will likely be changed over time depending on customer needs