### PR TITLE
CORE-5145 Merkle tree doc tweaks

### DIFF
--- a/crypto/src/main/kotlin/net/corda/v5/crypto/merkle/MerkleTreeFactory.kt
+++ b/crypto/src/main/kotlin/net/corda/v5/crypto/merkle/MerkleTreeFactory.kt
@@ -10,7 +10,7 @@ import net.corda.v5.base.annotations.Suspendable
 const val HASH_DIGEST_PROVIDER_DEFAULT_NAME = "DefaultHashDigestProvider"
 
 /**
- * A merkle tree digest that one-way derives a set of per-leaf nonces from a 16-byte entropy input. The nonces are
+ * A merkle tree digest that one-way derives a set of per-leaf nonces from a 32-byte entropy input. The nonces are
  * pre-hashed with the leaf data before forming a standard merkle tree.
  * This allows low entropy inputs to be used in the merkle tree.
  * Requires [HASH_DIGEST_PROVIDER_ENTROPY_OPTION]

--- a/crypto/src/main/kotlin/net/corda/v5/crypto/merkle/MerkleTreeFactory.kt
+++ b/crypto/src/main/kotlin/net/corda/v5/crypto/merkle/MerkleTreeFactory.kt
@@ -40,17 +40,17 @@ const val HASH_DIGEST_PROVIDER_NONCE_SIZE_ONLY_VERIFY_NAME = "NonceHashDigestPro
 const val HASH_DIGEST_PROVIDER_TWEAKABLE_NAME = "TweakableHashDigestProvider"
 
 /**
- * Tweakable hash digest providers require a ByteArray leaf prefix option.
+ * Tweakable hash digest providers require a non-empty ByteArray leaf prefix option.
  */
 const val HASH_DIGEST_PROVIDER_LEAF_PREFIX_OPTION = "leafPrefix"
 
 /**
- * Tweakable hash digest providers require a ByteArray node prefix option.
+ * Tweakable hash digest providers require a non-empty ByteArray node prefix option.
  */
 const val HASH_DIGEST_PROVIDER_NODE_PREFIX_OPTION = "nodePrefix"
 
 /**
- * Nonce hash digest providers require a ByteArray entropy option.
+ * Nonce hash digest providers require a 32 bytes long ByteArray entropy option.
  */
 const val HASH_DIGEST_PROVIDER_ENTROPY_OPTION = "entropy"
 


### PR DESCRIPTION
 * Update Nonce Hash Digest Provider's expected entropy length.
 * Clarify Merkle Tree factory expected options length

Implementation: https://github.com/corda/corda-runtime-os/pull/1683