### PR TITLE
NOTICK: Dependency version upgrade for Jackson, JUnit, Hibernate, Detekt and the retry plugin

### DIFF
--- a/detekt-config.yml
+++ b/detekt-config.yml
@@ -185,11 +185,11 @@ style:
   ForbiddenComment:
     active: true
     excludes: "**/buildSrc/**"
-    values: 'TODO:,FIXME:,STOPSHIP:'
+    values: ["TODO:","FIXME:","STOPSHIP:"]
   MagicNumber:
     active: false
     excludes: "**/test/**,**/integration-test/**,**/*Test.kt,**/*Tests.kt,**/buildSrc/**"
-    ignoreNumbers: '-1,0,1,2'
+    ignoreNumbers: ["-1","0","1","2"]
     ignoreHashCodeFunction: true
     ignorePropertyDeclaration: false
     ignoreConstantDeclaration: true
@@ -219,6 +219,6 @@ style:
   WildcardImport:
     active: true
     excludes: "**/buildSrc/**"
-    excludeImports: 'java.util.*,kotlinx.android.synthetic.*'
+    excludeImports: ["java.util.*","kotlinx.android.synthetic.*"]
   UnusedImports:
     active: true

--- a/gradle.properties
+++ b/gradle.properties
@@ -48,7 +48,7 @@ jacksonVersion = 2.13.3
 
 # Testing
 assertjVersion = 3.23.+
-junitVersion = 5.8.2
+junitVersion = 5.9.0
 mockitoVersion = 4.6.+
 mockitoKotlinVersion = 4.0.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -29,7 +29,7 @@ artifactoryContextUrl = https://software.r3.com/artifactory
 org.gradle.jvmargs=-XX:MaxMetaspaceSize=2g
 internalPublishVersion = 1.+
 dokkaVersion = 1.7.+
-detektPluginVersion = 1.20.+
+detektPluginVersion = 1.21.+
 dependencyCheckVersion=0.42.+
 artifactoryPluginVersion = 4.28.2
 
@@ -43,8 +43,8 @@ bouncycastleVersion = 1.70
 grgitPluginVersion = 4.0.2
 taskTreePluginVersion = 2.1.0
 javaxPersistenceApiVersion = 2.2
-hibernateVersion = 5.6.9.Final
-jacksonVersion = 2.13.1
+hibernateVersion = 5.6.10.Final
+jacksonVersion = 2.13.3
 
 # Testing
 assertjVersion = 3.23.+
@@ -61,7 +61,7 @@ gradleEnterpriseVersion = 3.8.1
 gradleDataPlugin = 1.6.2
 org.gradle.caching = true
 gradleEnterpriseUrl = https://gradle.dev.r3.com
-gradleTestRetryPluginVersion = 1.3.2
+gradleTestRetryPluginVersion = 1.4.0
 
 #snyk version
 snykVersion = 0.4

--- a/ledger-obsolete/src/main/kotlin/net/corda/v5/ledger/obsolete/contracts/Amount.kt
+++ b/ledger-obsolete/src/main/kotlin/net/corda/v5/ledger/obsolete/contracts/Amount.kt
@@ -35,6 +35,7 @@ interface TokenizableAssetInfo {
  * @param T the type of the token, for example [Currency]. T should implement [TokenizableAssetInfo] if automatic conversion to/from a display format is required.
  */
 @CordaSerializable
+@Suppress("ComplexMethod", "NestedBlockDepth")
 data class Amount<T : Any>(val quantity: Long, val displayTokenSize: BigDecimal, val token: T) : Comparable<Amount<T>> {
     // TODO Proper lookup of currencies in a locale and context sensitive fashion is not supported and is left to the application.
     companion object {
@@ -346,6 +347,7 @@ data class SourceAndAmount<T : Any, out P : Any>(val source: P, val amount: Amou
  * @property destination is the [Party], [CompositeKey], or other identifier of the token sink if quantityDelta is positive,
  * or the token source if quantityDelta is negative. The type P should support value equality.
  */
+@Suppress("ComplexMethod", "NestedBlockDepth")
 @CordaSerializable
 class AmountTransfer<T : Any, P : Any>(val quantityDelta: Long,
                                        val token: T,


### PR DESCRIPTION
This PR contains the following dependency version upgrades:
- Hibernate 5.6.9.FINAL -> 5.6.10.FINAL
- Jackson 2.13.1 -> 2.13.3
- JUnit 5.8.2 -> 5.9.0
- Detekt 1.20 -> 1.21
- Retry plugin 1.3.2 -> 1.4.0

The detekt plugin upgrade has resulted in some legacy code flagging up new warnings, as well as general warnings being reported for incorrectly declared detekt configuration. These have been addressed.
