### PR TITLE
CORE-5389: add offset and limit to FindAll

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/persistence/FindAll.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/persistence/FindAll.avsc
@@ -8,6 +8,16 @@
       "name": "entityClassName",
       "type": "string",
       "doc": "the fully qualified entity class name"
+    },
+    {
+      "name": "offset",
+      "type" : "int",
+      "doc": "The index of the first result in the query output that should be returned."
+    },
+    {
+      "name": "limit",
+      "type": "int",
+      "doc": "Limit number of rows in the output query results, after applying the offset. Use the maximum int value if you do not want a lower limit."
     }
   ]
 }

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/persistence/FindWithNamedQuery.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/persistence/FindWithNamedQuery.avsc
@@ -1,7 +1,7 @@
 {
   "type": "record",
   "name": "FindWithNamedQuery",
-  "doc": "Find entities matched by a named query. Parameters for the query may be specified. Pagination is supported, but there's no guarantee of consistency if the underlying data changes or is unsorted.  Replies with {@link EntityResponse}",
+  "doc": "Find entities matched by a named query. Parameters for the query may be specified. Pagination is supported, but there's no guarantee of consistency if the underlying data changes. The data will not be sorted in Corda; if the database returns an unpredictable order that must be handled by the caller. FindWithNamedQuery can be used to enforce ordering if required. Replies with {@link EntityResponse}",
   "namespace": "net.corda.data.persistence",
   "fields": [
     {

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 153
+cordaApiRevision = 154
 
 # Main
 kotlinVersion = 1.7.10


### PR DESCRIPTION
For now we are not supporting sorting. Pagination will be most useful in situations where the database
returns consistent order without us having to specify an ordering.
