### PR TITLE
CORE-5165 Uniqueness DB schema

### DIFF
--- a/data/db-schema/src/main/kotlin/net/corda/db/schema/CordaDb.kt
+++ b/data/db-schema/src/main/kotlin/net/corda/db/schema/CordaDb.kt
@@ -8,6 +8,7 @@ package net.corda.db.schema
 enum class CordaDb(val persistenceUnitName: String) {
     CordaCluster("corda-cluster"),
     RBAC("corda-rbac"),
+    Uniqueness("corda-uniqueness"),
     Vault("corda-vault"),
     Crypto("corda-crypto"),
 }

--- a/data/db-schema/src/main/kotlin/net/corda/db/schema/DbSchema.kt
+++ b/data/db-schema/src/main/kotlin/net/corda/db/schema/DbSchema.kt
@@ -42,4 +42,9 @@ object DbSchema {
     const val CRYPTO_HSM_CATEGORY_MAP_TABLE = "crypto_hsm_category_map"
     const val CRYPTO_HSM_ASSOCIATION_TABLE = "crypto_hsm_association"
     const val CRYPTO_HSM_CATEGORY_ASSOCIATION_TABLE = "crypto_hsm_category_association"
+
+    const val UNIQUENESS = "UNIQUENESS"
+    const val UNIQUENESS_STATE_DETAILS_TABLE = "uniqueness_state_details"
+    const val UNIQUENESS_TX_DETAILS_TABLE = "uniqueness_tx_details"
+    const val UNIQUENESS_REJECTED_TX_TABLE = "uniqueness_rejected_txs"
 }

--- a/data/db-schema/src/main/resources/net/corda/db/schema/uniqueness/db.changelog-master.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/uniqueness/db.changelog-master.xml
@@ -1,0 +1,6 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <include file="net/corda/db/schema/uniqueness/migration/uniqueness-creation-v1.0.xml"/>
+</databaseChangeLog>

--- a/data/db-schema/src/main/resources/net/corda/db/schema/uniqueness/migration/uniqueness-creation-v1.0.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/uniqueness/migration/uniqueness-creation-v1.0.xml
@@ -1,0 +1,121 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <!--This changelog represents the initial state of the database schema used by the JPA
+        backing store as part of the uniqueness checker. As one of our main supported DBs is
+        CockroachDB, we follow the guidance regarding doing each change individually where
+        possible, and not running in transactions. See
+        (https://www.cockroachlabs.com/docs/v21.1/liquibase.html#liquibase-and-transactions)-->
+
+    <changeSet author="R3.Corda" id="uniqueness-creation-v1.0-1" runInTransaction="false">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <primaryKeyExists primaryKeyName="primary" tableName="DATABASECHANGELOG"/>
+            </not>
+        </preConditions>
+        <addPrimaryKey columnNames="id"
+                       constraintName="primary"
+                       tableName="DATABASECHANGELOG"/>
+    </changeSet>
+
+    <changeSet author="R3.Corda" id="uniqueness-creation-v1.0-2" runInTransaction="false">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="uniqueness_state_details"/>
+            </not>
+        </preConditions>
+        <createTable tableName="uniqueness_state_details">
+            <column name="issue_tx_id_algo" type="VARCHAR(8)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="issue_tx_id" type="VARBINARY(64)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="issue_tx_output_idx" type="bigint">
+                <constraints nullable="false"/>
+            </column>
+            <column name="consuming_tx_id_algo" type="VARCHAR(8)">
+                <constraints nullable="true"/>
+            </column>
+            <column name="consuming_tx_id" type="VARBINARY(64)">
+                <constraints nullable="true"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+    <changeSet author="R3.Corda" id="uniqueness-creation-v1.0-3" runInTransaction="false">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <primaryKeyExists primaryKeyName="uniqueness_state_details_pkey" tableName="uniqueness_state_details"/>
+            </not>
+        </preConditions>
+        <addPrimaryKey columnNames="issue_tx_id_algo, issue_tx_id, issue_tx_output_idx"
+                       constraintName="uniqueness_state_details_pkey"
+                       tableName="uniqueness_state_details"/>
+    </changeSet>
+
+    <changeSet author="R3.Corda" id="uniqueness-creation-v1.0-4" runInTransaction="false">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="uniqueness_tx_details"/>
+            </not>
+        </preConditions>
+        <createTable tableName="uniqueness_tx_details">
+            <column name="tx_id_algo" type="VARCHAR(8)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="tx_id" type="VARBINARY(64)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="expiry_datetime" type="TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="result" type="CHAR">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+    <changeSet author="R3.Corda" id="uniqueness-creation-v1.0-5" runInTransaction="false">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <primaryKeyExists primaryKeyName="uniqueness_tx_details_pkey" tableName="uniqueness_tx_details"/>
+            </not>
+        </preConditions>
+        <addPrimaryKey columnNames="tx_id_algo, tx_id"
+                       constraintName="uniqueness_tx_details_pkey"
+                       tableName="uniqueness_tx_details"/>
+    </changeSet>
+
+    <changeSet author="R3.Corda" id="uniqueness-creation-v1.0-6" runInTransaction="false">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <tableExists tableName="uniqueness_rejected_txs"/>
+            </not>
+        </preConditions>
+        <createTable tableName="uniqueness_rejected_txs">
+            <column name="tx_id_algo" type="VARCHAR(8)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="tx_id" type="VARBINARY(64)">
+                <constraints nullable="false"/>
+            </column>
+            <!-- TODO Using VARBINARY instead of BLOB is a temporary solution, should be investigated as part of NAAS-458 -->
+            <column name="error_details" type="VARBINARY(1024)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+    </changeSet>
+
+    <changeSet author="R3.Corda" id="uniqueness-creation-v1.0-7" runInTransaction="false">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <primaryKeyExists primaryKeyName="uniqueness_rejected_txs_pkey" tableName="uniqueness_rejected_txs"/>
+            </not>
+        </preConditions>
+        <addPrimaryKey columnNames="tx_id_algo, tx_id"
+                       constraintName="uniqueness_rejected_txs_pkey"
+                       tableName="uniqueness_rejected_txs"/>
+    </changeSet>
+</databaseChangeLog>

--- a/data/db-schema/src/main/resources/net/corda/db/schema/uniqueness/migration/uniqueness-creation-v1.0.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/uniqueness/migration/uniqueness-creation-v1.0.xml
@@ -7,19 +7,7 @@
         CockroachDB, we follow the guidance regarding doing each change individually where
         possible, and not running in transactions. See
         (https://www.cockroachlabs.com/docs/v21.1/liquibase.html#liquibase-and-transactions)-->
-
     <changeSet author="R3.Corda" id="uniqueness-creation-v1.0-1" runInTransaction="false">
-        <preConditions onFail="MARK_RAN">
-            <not>
-                <primaryKeyExists primaryKeyName="primary" tableName="DATABASECHANGELOG"/>
-            </not>
-        </preConditions>
-        <addPrimaryKey columnNames="id"
-                       constraintName="primary"
-                       tableName="DATABASECHANGELOG"/>
-    </changeSet>
-
-    <changeSet author="R3.Corda" id="uniqueness-creation-v1.0-2" runInTransaction="false">
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="uniqueness_state_details"/>
@@ -44,7 +32,7 @@
         </createTable>
     </changeSet>
 
-    <changeSet author="R3.Corda" id="uniqueness-creation-v1.0-3" runInTransaction="false">
+    <changeSet author="R3.Corda" id="uniqueness-creation-v1.0-2" runInTransaction="false">
         <preConditions onFail="MARK_RAN">
             <not>
                 <primaryKeyExists primaryKeyName="uniqueness_state_details_pkey" tableName="uniqueness_state_details"/>
@@ -55,7 +43,7 @@
                        tableName="uniqueness_state_details"/>
     </changeSet>
 
-    <changeSet author="R3.Corda" id="uniqueness-creation-v1.0-4" runInTransaction="false">
+    <changeSet author="R3.Corda" id="uniqueness-creation-v1.0-3" runInTransaction="false">
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="uniqueness_tx_details"/>
@@ -66,9 +54,12 @@
                 <constraints nullable="false"/>
             </column>
             <column name="tx_id" type="VARBINARY(64)">
-                <constraints nullable="false"/>
+                <constraints nullable="false"/>s
             </column>
             <column name="expiry_datetime" type="TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="commit_timestamp" type="TIMESTAMP">
                 <constraints nullable="false"/>
             </column>
             <column name="result" type="CHAR">
@@ -77,7 +68,7 @@
         </createTable>
     </changeSet>
 
-    <changeSet author="R3.Corda" id="uniqueness-creation-v1.0-5" runInTransaction="false">
+    <changeSet author="R3.Corda" id="uniqueness-creation-v1.0-4" runInTransaction="false">
         <preConditions onFail="MARK_RAN">
             <not>
                 <primaryKeyExists primaryKeyName="uniqueness_tx_details_pkey" tableName="uniqueness_tx_details"/>
@@ -88,7 +79,7 @@
                        tableName="uniqueness_tx_details"/>
     </changeSet>
 
-    <changeSet author="R3.Corda" id="uniqueness-creation-v1.0-6" runInTransaction="false">
+    <changeSet author="R3.Corda" id="uniqueness-creation-v1.0-5" runInTransaction="false">
         <preConditions onFail="MARK_RAN">
             <not>
                 <tableExists tableName="uniqueness_rejected_txs"/>
@@ -108,7 +99,7 @@
         </createTable>
     </changeSet>
 
-    <changeSet author="R3.Corda" id="uniqueness-creation-v1.0-7" runInTransaction="false">
+    <changeSet author="R3.Corda" id="uniqueness-creation-v1.0-6" runInTransaction="false">
         <preConditions onFail="MARK_RAN">
             <not>
                 <primaryKeyExists primaryKeyName="uniqueness_rejected_txs_pkey" tableName="uniqueness_rejected_txs"/>


### PR DESCRIPTION
This change introduces the database schema required for the uniqueness checker component. See https://github.com/corda/corda-runtime-os/pull/1826 for the changes that utilise this schema.

This change must be merged prior to https://github.com/corda/corda-runtime-os/pull/1826