### PR TITLE
CORE-5593: Explicitly constrain config `integer` values

### DIFF
--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/flow/1.0/corda.flow.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/flow/1.0/corda.flow.json
@@ -12,27 +12,31 @@
       "default": {},
       "properties": {
         "maxRetryAttempts": {
-          "description": "The maximum number of retry attempts a transient error will be retried before failing the flow. a value of zero disables retries.",
+          "description": "The maximum number of retry attempts a transient error will be retried before failing the flow. A value of zero disables retries.",
           "type": "integer",
           "minimum": 0,
+          "maximum": 1000,
           "default": 5
         },
         "maxRetryDelay": {
           "description": "The maximum delay before a retry is scheduled, in milliseconds",
           "type": "integer",
           "minimum": 1000,
+          "maximum": 2147483647,
           "default": 16000
         },
         "maxFlowSleepDuration": {
           "description": "The maximum delay before a periodic WakeUp is scheduled, in milliseconds",
           "type": "integer",
           "minimum": 1000,
+          "maximum": 2147483647,
           "default": 60000
         },
         "maxFlowExecutionDuration": {
           "description": "The maximum amount of time in milliseconds a Flow can execute between suspends before it is considered faulty and a candidate for forced failure",
           "type": "integer",
           "minimum": 5000,
+          "maximum": 2147483647,
           "default": 60000
         }
       }
@@ -46,18 +50,21 @@
           "description": "Length of time to wait before resending unacknowledged flow session messages, in milliseconds",
           "type": "integer",
           "minimum": 1000,
+          "maximum": 2147483647,
           "default": 120000
         },
         "heartbeatTimeout": {
           "description": "Length of time to wait when no message has been received from a counterparty before causing the session to error, in milliseconds",
           "type": "integer",
           "minimum": 600000,
+          "maximum": 2147483647,
           "default": 3600000
         },
         "p2pTTL": {
           "description": "TTL set on on messages passed to the P2P layer to be sent to a counterparty.",
           "type": "integer",
           "minimum": 10000,
+          "maximum": 2147483647,
           "default": 240000
         }
       }
@@ -71,12 +78,14 @@
           "description": "Length of time to wait before resending unacknowledged query messages, in milliseconds",
           "type": "integer",
           "minimum": 100,
+          "maximum": 2147483647,
           "default": 5000
         },
         "maxRetries": {
           "description": "The maximum amount of times to retry a request before returning an exception to the user code.",
           "type": "integer",
           "minimum": 0,
+          "maximum": 2147483647,
           "default": 5
         }
       }
@@ -90,12 +99,14 @@
           "description": "Length of time to wait before resending unacknowledged crypto events, in milliseconds",
           "type": "integer",
           "minimum": 100,
+          "maximum": 2147483647,
           "default": 5000
         },
         "maxRetries": {
           "description": "The maximum amount of times to retry a request before returning an exception to the user code.",
           "type": "integer",
           "minimum": 0,
+          "maximum": 2147483647,
           "default": 5
         }
       }

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/messaging/1.0/corda.messaging.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/messaging/1.0/corda.messaging.json
@@ -58,7 +58,7 @@
                         "type": "integer",
                         "minimum": 1,
                         "maximum": 100000,
-                        "default": 5
+                        "default": 100
                       }
                     },
                     "additionalProperties": false

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/messaging/1.0/corda.messaging.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/messaging/1.0/corda.messaging.json
@@ -55,7 +55,10 @@
                     "properties": {
                       "maxPollRecords": {
                         "description": "Max records to poll from db in a single poll.",
-                        "type": "integer"
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 100000,
+                        "default": 5
                       }
                     },
                     "additionalProperties": false

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/messaging/1.0/publisher.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/messaging/1.0/publisher.json
@@ -9,6 +9,7 @@
       "description": "Time in ms to wait when closing underlying bus objects on close.",
       "type": "integer",
       "minimum": 100,
+      "maximum": 2147483647,
       "default": 600
     },
     "transactional": {

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/messaging/1.0/subscription.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/messaging/1.0/subscription.json
@@ -9,36 +9,42 @@
       "description": "Time in ms to wait for a response from the bus when calling poll.",
       "type": "integer",
       "minimum": 100,
+      "maximum": 2147483647,
       "default": 500
     },
     "threadStopTimeout": {
       "description": "Time in ms to wait for the subscription processing thread to terminate on close",
       "type": "integer",
       "minimum": 100,
+      "maximum": 2147483647,
       "default": 10000
     },
     "processorRetries": {
       "description": "Number of times to retry internal intermittent failures before throwing back to the client",
       "type": "integer",
       "minimum": 0,
+      "maximum": 1000,
       "default": 3
     },
     "subscribeRetries": {
       "description": "Number of times to attempt to subscribe to the underlying bus before throwing back to the client",
       "type": "integer",
       "minimum": 0,
+      "maximum": 1000,
       "default": 3
     },
     "commitRetries": {
       "description": "Number of times to attempt to commit a transaction before throwing back to the client",
       "type": "integer",
       "minimum": 0,
+      "maximum": 1000,
       "default": 3
     },
     "processorTimeout": {
       "description": "Time in ms to wait for an individual event to process. This is applied if the subscription must also maintain state that needs to be periodically serviced.",
       "type": "integer",
       "minimum": 1000,
+      "maximum": 2147483647,
       "default": 15000
     }
   },

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/reconciliation/1.0/corda.reconciliation.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/reconciliation/1.0/corda.reconciliation.json
@@ -7,33 +7,38 @@
   "default": {},
   "properties": {
     "permissionSummaryIntervalMs": {
-      "description": "",
+      "description": "Interval in ms between permission summary reconciliation rounds.",
       "type": "integer",
       "minimum": 5000,
+      "maximum": 2147483647,
       "default": 30000
     },
     "cpkWriteIntervalMs": {
       "description": "",
       "type": "integer",
       "minimum": 5000,
+      "maximum": 2147483647,
       "default": 10000
     },
     "cpiInfoIntervalMs": {
       "description": "",
       "type": "integer",
       "minimum": 5000,
+      "maximum": 2147483647,
       "default": 30000
     },
     "vnodeInfoIntervalMs": {
       "description": "",
       "type": "integer",
       "minimum": 5000,
+      "maximum": 2147483647,
       "default": 30000
     },
     "configIntervalMs": {
       "description": "",
       "type": "integer",
       "minimum": 5000,
+      "maximum": 2147483647,
       "default": 30000
     }
   }

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/rpc/1.0/corda.rpc.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/rpc/1.0/corda.rpc.json
@@ -29,9 +29,11 @@
       }
     },
     "maxContentLength": {
-      "description": "",
+      "description": "Maximum length in bytes that can be sent over HTTP transport.",
       "type": "integer",
-      "default": 2000000000
+      "minimum": 1024,
+      "maximum": 2147483647,
+      "default": 200000000
     },
     "endpoint": {
       "description": "",
@@ -39,8 +41,10 @@
       "default": {},
       "properties": {
         "timeoutMs": {
-          "description": "",
+          "description": "Amount of time in milliseconds to wait for response on Kafka bus for a remote operation before timing out the HTTP RPC call.",
           "type": "integer",
+          "minimum": 100,
+          "maximum": 2147483647,
           "default": 12000
         }
       }

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 155
+cordaApiRevision = 156
 
 # Main
 kotlinVersion = 1.7.10

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 156
+cordaApiRevision = 155
 
 # Main
 kotlinVersion = 1.7.10


### PR DESCRIPTION
To prevent passing bogus values at config update time.
Looks like when no min/max values specified JSON schema does not do much of a validation in terms of range of the numbers as per: `com.networknt.schema.TypeValidator#isInteger`.