### PR TITLE
NOTICK: Update Avro to 1.11.1 and remove constraints that are no longer required

### DIFF
--- a/data/avro-schema/build.gradle
+++ b/data/avro-schema/build.gradle
@@ -12,14 +12,6 @@ plugins {
 
 dependencies {
     api "org.apache.avro:avro:$avroVersion"
-    // Transitive dependency bump to eliminate critical violation in NexusIQ report - see nexus iq report.
-    // Constraints block can be removed when Avro is upgraded to v1.11
-    // For more details, please see: https://issues.apache.org/jira/browse/AVRO-3215
-    constraints {
-        implementation('org.apache.commons:commons-compress:1.21') {
-            because 'CVE-2021-35515, CVE-2021-35516, CVE-2021-35517, CVE-2021-36090'
-        }
-    }
 
     implementation platform(project(':corda-api'))
     implementation project(":base")

--- a/gradle.properties
+++ b/gradle.properties
@@ -38,7 +38,7 @@ slf4jVersion = 1.7.36
 
 # Main implementation dependencies
 avroGradlePluginVersion=1.3.0
-avroVersion = 1.11.0
+avroVersion = 1.11.1
 bouncycastleVersion = 1.70
 grgitPluginVersion = 4.0.2
 taskTreePluginVersion = 2.1.0


### PR DESCRIPTION
Update the Avro version to 1.11.1 from 1.11.0. The `commons-compress` dependency was updated in 1.11.0, so a constraints block we were previously using to force this dependency version can also be removed.
