### PR TITLE
NOTICK: Remove superfluous inline UntrustworthyData.unwrap() method.

### DIFF
--- a/application/src/main/kotlin/net/corda/v5/application/messaging/UntrustworthyData.kt
+++ b/application/src/main/kotlin/net/corda/v5/application/messaging/UntrustworthyData.kt
@@ -14,15 +14,13 @@ import java.io.Serializable
  * - Are any objects *reachable* from this object mismatched or not what you expected?
  * - Is it suspiciously large or small?
  */
-class UntrustworthyData<out T>(@PublishedApi internal val fromUntrustedWorld: T) {
+class UntrustworthyData<out T>(private val fromUntrustedWorld: T) {
     @Suspendable
     fun <R> unwrap(validator: Validator<T, R>) = validator.validate(fromUntrustedWorld)
 
     @FunctionalInterface
-    interface Validator<in T, out R> : Serializable {
+    fun interface Validator<in T, out R> : Serializable {
         @Suspendable
         fun validate(data: T): R
     }
 }
-
-inline fun <T, R> UntrustworthyData<T>.unwrap(validator: (T) -> R): R = validator(fromUntrustedWorld)

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 162
+cordaApiRevision = 163
 
 # Main
 kotlinVersion = 1.7.10


### PR DESCRIPTION
Declare `UntrustworthyData.Validator` to be a Kotlin functional interface so that Kotlin can use it to generate lambdas. This allows us to remove the inline extension method, and hence make `UntrustworthyData.fromUntrustedWorld` private too.