### PR TITLE
CORE-6415: Remove Kotlin-specific references from our API signatures.

### DIFF
--- a/application/src/main/kotlin/net/corda/v5/application/flows/FlowContextProperties.kt
+++ b/application/src/main/kotlin/net/corda/v5/application/flows/FlowContextProperties.kt
@@ -1,3 +1,4 @@
+@file:JvmName("FlowUtils")
 package net.corda.v5.application.flows
 
 /**

--- a/application/src/main/kotlin/net/corda/v5/application/flows/RPCRequestData.kt
+++ b/application/src/main/kotlin/net/corda/v5/application/flows/RPCRequestData.kt
@@ -1,3 +1,4 @@
+@file:JvmName("RPCRequestUtils")
 package net.corda.v5.application.flows
 
 import net.corda.v5.application.marshalling.MarshallingService

--- a/application/src/main/kotlin/net/corda/v5/application/marshalling/MarshallingService.kt
+++ b/application/src/main/kotlin/net/corda/v5/application/marshalling/MarshallingService.kt
@@ -1,3 +1,4 @@
+@file:JvmName("MarshallingUtils")
 package net.corda.v5.application.marshalling
 
 import net.corda.v5.base.annotations.DoNotImplement

--- a/application/src/main/kotlin/net/corda/v5/application/messaging/FlowSession.kt
+++ b/application/src/main/kotlin/net/corda/v5/application/messaging/FlowSession.kt
@@ -1,3 +1,4 @@
+@file:JvmName("FlowSessionUtils")
 package net.corda.v5.application.messaging
 
 import net.corda.v5.base.annotations.DoNotImplement

--- a/application/src/main/kotlin/net/corda/v5/application/persistence/PersistenceService.kt
+++ b/application/src/main/kotlin/net/corda/v5/application/persistence/PersistenceService.kt
@@ -1,3 +1,4 @@
+@file:JvmName("PersistenceUtils")
 package net.corda.v5.application.persistence
 
 import net.corda.v5.base.annotations.DoNotImplement

--- a/application/src/main/kotlin/net/corda/v5/application/serialization/SerializationService.kt
+++ b/application/src/main/kotlin/net/corda/v5/application/serialization/SerializationService.kt
@@ -1,3 +1,4 @@
+@file:JvmName("SerializationUtils")
 package net.corda.v5.application.serialization
 
 import net.corda.v5.base.annotations.DoNotImplement

--- a/base/src/main/kotlin/net/corda/v5/base/annotations/Suspendable.kt
+++ b/base/src/main/kotlin/net/corda/v5/base/annotations/Suspendable.kt
@@ -6,13 +6,13 @@ package net.corda.v5.base.annotations
  * This annotation is required to allow a fiber (a special lightweight thread used by flows in Corda) to suspend and release the underlying
  * thread to another fiber.
  */
-@kotlin.annotation.Target(
+@Target(
     AnnotationTarget.CLASS,
     AnnotationTarget.FUNCTION,
     AnnotationTarget.PROPERTY_GETTER,
     AnnotationTarget.PROPERTY_SETTER,
     AnnotationTarget.PROPERTY,
 )
-@kotlin.annotation.Retention
+@Retention
 @MustBeDocumented
 annotation class Suspendable

--- a/base/src/main/kotlin/net/corda/v5/base/concurrent/ConcurrencyUtils.kt
+++ b/base/src/main/kotlin/net/corda/v5/base/concurrent/ConcurrencyUtils.kt
@@ -28,7 +28,7 @@ import java.util.concurrent.TimeoutException
 fun <V> Future<V>.getOrThrow(timeout: Duration?): V = try {
     if (timeout == null) get() else get(timeout.toNanos(), TimeUnit.NANOSECONDS)
 } catch (e: ExecutionException) {
-    throw e.cause!!
+    throw e.cause ?: IllegalStateException("ExecutionException without cause", e)
 }
 
 /**

--- a/base/src/main/kotlin/net/corda/v5/base/stream/Method.kt
+++ b/base/src/main/kotlin/net/corda/v5/base/stream/Method.kt
@@ -1,3 +1,4 @@
+@file:JvmName("MethodUtils")
 package net.corda.v5.base.stream
 
 import java.lang.reflect.Method

--- a/base/src/main/kotlin/net/corda/v5/base/versioning/Version.kt
+++ b/base/src/main/kotlin/net/corda/v5/base/versioning/Version.kt
@@ -12,6 +12,7 @@ data class Version(val major: Int, val minor: Int) {
     }
 
     companion object {
+        @JvmStatic
         fun fromString(versionString: String): Version {
             val regex = Regex("(\\d+)\\.(\\d+)")
             val match = regex.matchEntire(versionString)

--- a/crypto/src/main/kotlin/net/corda/v5/crypto/PublicKeyHash.kt
+++ b/crypto/src/main/kotlin/net/corda/v5/crypto/PublicKeyHash.kt
@@ -1,3 +1,4 @@
+@file:JvmName("PublicKeyUtils")
 package net.corda.v5.crypto
 
 import net.corda.v5.base.types.toHexString

--- a/crypto/src/main/kotlin/net/corda/v5/crypto/merkle/MerkleTreeFactory.kt
+++ b/crypto/src/main/kotlin/net/corda/v5/crypto/merkle/MerkleTreeFactory.kt
@@ -1,3 +1,4 @@
+@file:JvmName("HashDigestConstants")
 package net.corda.v5.crypto.merkle
 
 import net.corda.v5.crypto.DigestAlgorithmName

--- a/data/avro-schema/src/main/kotlin/net/corda/data/CordaAvroSerializationFactory.kt
+++ b/data/avro-schema/src/main/kotlin/net/corda/data/CordaAvroSerializationFactory.kt
@@ -1,5 +1,7 @@
 package net.corda.data
 
+import java.util.function.Consumer
+
 /**
  * Defines the interface for Message Bus deserialization.  The underlying mechanism may differ.
  */
@@ -7,13 +9,13 @@ interface CordaAvroSerializationFactory {
     /**
      * Create the [CordaAvroSerializer] for use in Avro/Message bus serialization
      */
-    fun <T : Any> createAvroSerializer(onError: (ByteArray) -> Unit): CordaAvroSerializer<T>
+    fun <T : Any> createAvroSerializer(onError: Consumer<ByteArray>): CordaAvroSerializer<T>
 
     /**
      * Create the [CordaAvroDeserializer] for use in Avro/Message bus serialization
      */
     fun <T : Any> createAvroDeserializer(
-        onError: (ByteArray) -> Unit,
+        onError: Consumer<ByteArray>,
         expectedClass: Class<T>
     ): CordaAvroDeserializer<T>
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 164
+cordaApiRevision = 165
 
 # Main
 kotlinVersion = 1.7.10

--- a/membership/src/main/kotlin/net/corda/v5/membership/GroupParameters.kt
+++ b/membership/src/main/kotlin/net/corda/v5/membership/GroupParameters.kt
@@ -1,3 +1,4 @@
+@file:JvmName("GroupParametersUtils")
 package net.corda.v5.membership
 
 import net.corda.v5.base.annotations.CordaSerializable

--- a/membership/src/main/kotlin/net/corda/v5/membership/GroupParametersConstants.kt
+++ b/membership/src/main/kotlin/net/corda/v5/membership/GroupParametersConstants.kt
@@ -1,3 +1,4 @@
+@file:JvmName("GroupParametersConstants")
 package net.corda.v5.membership
 
 const val MAX_MESSAGE_SIZE: Int = 1048576


### PR DESCRIPTION
API signatures containing Kotlin classes cannot be invoked from Java, e.g. Kotlin lambda parameters. Replace these with standard Java functional interfaces instead.

Also apply `@JvmStatic` annotations to `companion object` functions, and assign non-default names to `*Kt` classes.