### PR TITLE
CORE-6384: Add capability to publish to a S3 Bucket 

### DIFF
--- a/corda-api/build.gradle
+++ b/corda-api/build.gradle
@@ -60,6 +60,7 @@ dependencies {
     }
 }
 
+
 publishing {
     publications {
         apiConfiguration(MavenPublication) {
@@ -88,6 +89,21 @@ publishing {
                         name = 'R3'
                         email = 'dev@corda.net'
                     }
+                }
+            }
+        }
+    }
+}
+
+if (project.hasProperty('maven.repo.s3')){
+    publishing {
+        repositories {
+            maven {
+                url = project.findProperty('maven.repo.s3')
+                credentials(AwsCredentials) {
+                    accessKey "${System.getenv('AWS_ACCESS_KEY_ID')}"
+                    secretKey "${System.getenv('AWS_SECRET_ACCESS_KEY')}"
+                    sessionToken "${System.getenv('AWS_SESSION_TOKEN')}"
                 }
             }
         }

--- a/corda-api/build.gradle
+++ b/corda-api/build.gradle
@@ -60,7 +60,6 @@ dependencies {
     }
 }
 
-
 publishing {
     publications {
         apiConfiguration(MavenPublication) {


### PR DESCRIPTION
Add capability to publish to a S3 Bucket to the corda-api submodule. 

Other submodules are already catered for by the logic in corda-gradle-internal plugin however this submodule uses custom publishing logic and does not consume the r3 publish plugin.

Longer term this should be refactored into corda-gradle-internal plugins, however this requires a larger re work of that logic .Tech debt Jira for this [here](https://r3-cev.atlassian.net/browse/CORE-6425)