### PR TITLE
CORE-6380: activate publishing to S3 bucket for corda-api

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,5 +7,7 @@ cordaPipeline(
     javadocJar: true,
     // always use -beta-9999999999999 for local publication as this is used for the version compatibility checks,
     //  This is a PR gate, so we want to check the "post merge" state before publication for real.
-    localPublishVersionSuffixOverride: '-beta-9999999999999'
+    localPublishVersionSuffixOverride: '-beta-9999999999999',
+    // allow publishing artifacts to S3 bucket
+    publishToMavenS3Repository: true,
     )

--- a/build.gradle
+++ b/build.gradle
@@ -106,14 +106,11 @@ subprojects {
             toolchain {
                 languageVersion = of(javaVersion.majorVersion.toInteger())
             }
-
-            if (releaseType != 'GA' && releaseType != 'RC') {
-                withSourcesJar()
-            }
+            withSourcesJar()
         }
     }
 
-    apply plugin: "org.gradle.test-retry" 
+    apply plugin: "org.gradle.test-retry"
 
     pluginManager.withPlugin('org.jetbrains.kotlin.jvm') {
         apply plugin: 'io.gitlab.arturbosch.detekt'


### PR DESCRIPTION
* use newly introduced functionality of shared pipeline and set
  `publishToMavenS3Repository`
* removed obsolete conditional activation of source jar, always create
  them
