### PR TITLE
CORE-6302 Update KDocs for cipher-suite API

### DIFF
--- a/application/src/main/kotlin/net/corda/v5/application/crypto/SigningService.kt
+++ b/application/src/main/kotlin/net/corda/v5/application/crypto/SigningService.kt
@@ -42,7 +42,7 @@ interface SigningService {
     * Decodes public key from PEM encoded string.
     *
     * @throws IllegalArgumentException if the key scheme is not supported.
-    * @throws net.corda.v5.crypto.failures.CryptoException for general cryptographic exceptions.
+    * @throws net.corda.v5.crypto.exceptions.CryptoException for general cryptographic exceptions.
     */
     @Suspendable
     fun decodePublicKey(encodedKey: String): PublicKey

--- a/cipher-suite/src/main/kotlin/net/corda/v5/cipher/suite/AlgorithmParameterSpecEncodingService.kt
+++ b/cipher-suite/src/main/kotlin/net/corda/v5/cipher/suite/AlgorithmParameterSpecEncodingService.kt
@@ -5,6 +5,7 @@ import java.security.spec.AlgorithmParameterSpec
 
 /**
  * Encoding service which can encode and decode signature parameters.
+ * The service is required as almost all [AlgorithmParameterSpec] implementations are not serializable.
  */
 interface AlgorithmParameterSpecEncodingService {
     /**

--- a/cipher-suite/src/main/kotlin/net/corda/v5/cipher/suite/CipherSchemeMetadata.kt
+++ b/cipher-suite/src/main/kotlin/net/corda/v5/cipher/suite/CipherSchemeMetadata.kt
@@ -13,12 +13,12 @@ import java.util.Collections
 
 /**
  * Service which provides metadata about cipher suite, such as available key schemes,
- * digests, security providers, key factories, and [SecureRandom] instance.
+ * digests, security providers, key factories, and [SecureRandom] instance as well as some utility methods.
  */
 interface CipherSchemeMetadata : KeyEncodingService, AlgorithmParameterSpecEncodingService {
     companion object {
         /**
-         * List of digest algorithms that must not be used due their vulnerabilities.
+         * List of digest algorithms that must not be used nor implemented due their vulnerabilities.
          */
         @JvmField
         val BANNED_DIGESTS: Set<String> = Collections.unmodifiableSet(setOf(
@@ -32,7 +32,7 @@ interface CipherSchemeMetadata : KeyEncodingService, AlgorithmParameterSpecEncod
     }
 
     /**
-     * The map of initialized security providers where the key is the provider name.
+     * The map of initialized security providers used by the cipher suite where the key is the provider name.
      */
     val providers: Map<String, Provider>
 
@@ -42,11 +42,13 @@ interface CipherSchemeMetadata : KeyEncodingService, AlgorithmParameterSpecEncod
     val schemes: List<KeyScheme>
 
     /**
-     * The list of all available digest algorithms for the cipher suite with the provider name which implements it.
+     * The list of all available digest algorithms for the cipher suite.
      */
     val digests: List<DigestScheme>
 
-    /** Get an instance of [SecureRandom] */
+    /**
+     * Returns an instance of [SecureRandom] which should be used to generate cryptographically secure random value.
+     */
     val secureRandom: SecureRandom
 
     /**
@@ -57,29 +59,30 @@ interface CipherSchemeMetadata : KeyEncodingService, AlgorithmParameterSpecEncod
     fun findKeyScheme(algorithm: AlgorithmIdentifier): KeyScheme
 
     /**
-     * Find the corresponding [KeyScheme] based on the type of the input [PublicKey].
+     * Find the corresponding [KeyScheme] based on the type of the [PublicKey].
      *
-     * @throws CryptoKeySchemeUnsupportedException if the requested key type is not supported.
+     * @throws IllegalArgumentException if the key type is not supported.
      */
     fun findKeyScheme(key: PublicKey): KeyScheme
 
     /**
      * Find the corresponding [KeyScheme] based on the code name.
      *
-     * @throws CryptoKeySchemeUnsupportedException if the requested key type is not supported.
+     * @throws IllegalArgumentException if the scheme is not supported.
      */
     fun findKeyScheme(codeName: String): KeyScheme
 
     /**
      * Find the corresponding [KeyFactory] based on the [KeyScheme].
      *
-     * @throws CryptoKeySchemeUnsupportedException if the requested key type is not supported.
+     * @throws IllegalArgumentException if the scheme is not supported.
      */
     fun findKeyFactory(scheme: KeyScheme): KeyFactory
 
     /**
-     * Infers the signature spec from the [PublicKey] and [DigestAlgorithmName]. If the [publicKey] is 'EdDSA'
-     * then the [digest] is ignored and signatureName is set to "EdDSA".
+     * Infers the signature spec from the [PublicKey] and [DigestAlgorithmName]. The [digest] may be ignored for some
+     * public key types as the digest is integral part of the signing/verification, e.g. if the [publicKey] is 'EdDSA'
+     * hen the [digest] is set to "EdDSA" by the platform's default implementation.
      *
      * @return [SignatureSpec] with the signatureName formatted like "SHA256withECDSA" if that can be inferred or
      * otherwise null.

--- a/cipher-suite/src/main/kotlin/net/corda/v5/cipher/suite/ConfigurationSecrets.kt
+++ b/cipher-suite/src/main/kotlin/net/corda/v5/cipher/suite/ConfigurationSecrets.kt
@@ -1,9 +1,17 @@
 package net.corda.v5.cipher.suite
 
 /**
- * Provides ways of getting the secret's value as that is encrypted in the configuration.
- * The secret value have to be declared as Map<String, Any> (or Map<String, Object>) for that to work.
+ * Provides ways of getting the secret value for the [CryptoServiceProvider] from the service configuration.
+ * The secret value have to be declared as Map<String, Any> (or Map<String, Object>) in the service
+ * configuration class for that to work.
  */
 interface ConfigurationSecrets {
+    /**
+     * @param secret encrypted secret
+     *
+     * @return the plain text secret's value.
+     *
+     * @see CryptoServiceProvider.getInstance
+     */
     fun getSecret(secret: Map<String, Any>): String
 }

--- a/cipher-suite/src/main/kotlin/net/corda/v5/cipher/suite/CryptoServiceProvider.kt
+++ b/cipher-suite/src/main/kotlin/net/corda/v5/cipher/suite/CryptoServiceProvider.kt
@@ -16,24 +16,29 @@ interface CryptoServiceProvider<T : Any> {
     val configType: Class<T>
 
     /**
-     * Returns an instance of the [CryptoService].
      * @param config crypto service configuration
-     * @param secrets provides access to decrypting the secrets
+     * @param secrets provides access to decrypting the configuration secrets
      *
      * The secrets have to be declared as Map<String, Any> in the corresponding POJO, the JSON will look like
      * in the example bellow for the property called 'passphrase'
      *
      * POJO (Kotlin):
+     *```
      *  val passphrase: Map<String, Any>
+     *```
      *
      * JSON:
+     *```
      *  "passphrase": {
      *      "configSecret": {
      *          "encryptedSecret": "<encrypted-value>"
      *      }
      *  }
+     *```
      *
-     * @throws [net.corda.v5.crypto.failures.CryptoException] for general cryptographic exceptions.
+     * @return An instance of the [CryptoService].
+     *
+     * @throws [net.corda.v5.crypto.exceptions.CryptoException] for general cryptographic exceptions.
      */
     fun getInstance(config: T, secrets: ConfigurationSecrets): CryptoService
 }

--- a/cipher-suite/src/main/kotlin/net/corda/v5/cipher/suite/CustomSignatureSpec.kt
+++ b/cipher-suite/src/main/kotlin/net/corda/v5/cipher/suite/CustomSignatureSpec.kt
@@ -9,19 +9,17 @@ import java.security.spec.AlgorithmParameterSpec
  * signing operation, it may have additional the additional algorithm parameters, such as RSASSA-PSS
  *
  * @property signatureName a signature-scheme name as required to create [java.security.Signature]
- * objects (e.g. "SHA256withECDSA")
- * @property customDigestName an optional digest algorithm name, set to non-null value if the hash should be precalculated
- * before passing to the provider (e.g. "SHA512"), note that the signatureName should not contain the digest
- * (e.g. "NONEwithECDSA").
+ * objects, note that the signatureName should not contain the digest (e.g. "NONEwithECDSA").
+ * @property customDigestName digest algorithm name (e.g. "SHA512")
  * @property params optional signature parameters, like if RSASSA-PSS is being used then in order to avoid
- * using the default SHA1 you must specify the signature parameters explicitly.
+ * using the default SHA1 you can specify the signature parameters explicitly.
  *
  * When used for signing the [signatureName] must match the corresponding key scheme, e.g. you cannot use
- * "SHA256withECDSA" with "RSA" keys.
+ * "NONEwithECDSA" with "RSA" keys.
  *
  * Note as the Bouncy Castle library doesn't support NONEwithRSA scheme, you would have to set the [signatureName] to
- * "RSA/NONE/PKCS1Padding" and the [customDigestName] to likes of "SHA512", the implementation will calculate hash by
- * using the RSA encryption on the private key and the decryption using the public key.
+ * "RSA/NONE/PKCS1Padding", the implementation will calculate hash by using the RSA encryption on the private key
+ * and the decryption using the public key.
  */
 class CustomSignatureSpec(
     signatureName: String,

--- a/cipher-suite/src/main/kotlin/net/corda/v5/cipher/suite/DigestService.kt
+++ b/cipher-suite/src/main/kotlin/net/corda/v5/cipher/suite/DigestService.kt
@@ -5,7 +5,7 @@ import net.corda.v5.crypto.SecureHash
 import java.io.InputStream
 
 /**
- * Basic hashing service, handling hashing of bytes.
+ * Digital digest calculation service.
  */
 interface DigestService {
 
@@ -15,7 +15,7 @@ interface DigestService {
      * @param bytes The [ByteArray] to hash.
      * @param digestAlgorithmName The digest algorithm to be used for hashing.
      *
-     * @throws [CryptoDigestUnsupportedException] if the digest algorithm is not supported.
+     * @throws [IllegalArgumentException] if the digest algorithm is not supported.
      */
     fun hash(bytes: ByteArray, digestAlgorithmName: DigestAlgorithmName): SecureHash
 
@@ -25,7 +25,7 @@ interface DigestService {
      * @param inputStream The [InputStream] to hash.
      * @param digestAlgorithmName The digest algorithm to be used for hashing.
      *
-     * @throws [CryptoDigestUnsupportedException] if the digest algorithm is not supported.
+     * @throws [IllegalArgumentException] if the digest algorithm is not supported.
      */
     fun hash(inputStream : InputStream, digestAlgorithmName: DigestAlgorithmName): SecureHash
 
@@ -34,7 +34,7 @@ interface DigestService {
      *
      * @param digestAlgorithmName The digest algorithm to get the digest length for.
      *
-     * @throws [CryptoDigestUnsupportedException] if the digest algorithm is not supported.
+     * @throws [IllegalArgumentException] if the digest algorithm is not supported.
      */
     fun digestLength(digestAlgorithmName: DigestAlgorithmName): Int
 }

--- a/cipher-suite/src/main/kotlin/net/corda/v5/cipher/suite/GeneratedPublicKey.kt
+++ b/cipher-suite/src/main/kotlin/net/corda/v5/cipher/suite/GeneratedPublicKey.kt
@@ -8,7 +8,7 @@ import java.security.PublicKey
  * @property publicKey The public key of the pair.
  * @property hsmAlias The alias which was used to persist the key pair in the HSM.
  *
- * Note about key aliases. Corda always uses single alias to identify a key pair however some HSMs need separate
+ * The Corda Platform always uses single alias to identify a key pair however some HSMs need separate
  * aliases for public and private keys, in such cases their names have to be derived from the single key pair alias.
  * It could be suffixes or whatever internal naming scheme is used.
  */

--- a/cipher-suite/src/main/kotlin/net/corda/v5/cipher/suite/KeyEncodingService.kt
+++ b/cipher-suite/src/main/kotlin/net/corda/v5/cipher/suite/KeyEncodingService.kt
@@ -3,15 +3,14 @@ package net.corda.v5.cipher.suite
 import java.security.PublicKey
 
 /**
- * Encoding service which can encode and decode keys to or from byte arrays
- * or strings using PEM encoding format.
+ * Encoding service which can encode and decode keys to or from byte arrays or strings using PEM encoding format.
  */
 interface KeyEncodingService {
     /**
      * Decodes public key from byte array.
      *
      * @throws IllegalArgumentException if the key scheme is not supported.
-     * @throws net.corda.v5.crypto.failures.CryptoException for general cryptographic exceptions.
+     * @throws net.corda.v5.crypto.exceptions.CryptoException for general cryptographic exceptions.
      */
     fun decodePublicKey(encodedKey: ByteArray): PublicKey
 
@@ -19,7 +18,7 @@ interface KeyEncodingService {
      * Decodes public key from PEM encoded string.
      *
      * @throws IllegalArgumentException if the key scheme is not supported.
-     * @throws net.corda.v5.crypto.failures.CryptoException for general cryptographic exceptions.
+     * @throws net.corda.v5.crypto.exceptions.CryptoException for general cryptographic exceptions.
      */
     fun decodePublicKey(encodedKey: String): PublicKey
 
@@ -28,7 +27,7 @@ interface KeyEncodingService {
      * The default implementation returns the [PublicKey.getEncoded]
      *
      * @throws IllegalArgumentException if the key scheme is not supported.
-     * @throws net.corda.v5.crypto.failures.CryptoException for general cryptographic exceptions.
+     * @throws net.corda.v5.crypto.exceptions.CryptoException for general cryptographic exceptions.
      */
     fun encodeAsByteArray(publicKey: PublicKey): ByteArray = publicKey.encoded
 
@@ -36,7 +35,7 @@ interface KeyEncodingService {
      * Encodes public key to PEM encoded string.
      *
      * @throws IllegalArgumentException if the key scheme is not supported.
-     * @throws net.corda.v5.crypto.failures.CryptoException for general cryptographic exceptions.
+     * @throws net.corda.v5.crypto.exceptions.CryptoException for general cryptographic exceptions.
      */
     fun encodeAsString(publicKey: PublicKey): String
 
@@ -44,7 +43,7 @@ interface KeyEncodingService {
      * Convert a public key to a supported implementation. This can be used to convert a SUN's EC key to an BC key.
      *
      * @throws IllegalArgumentException if the key scheme is not supported.
-     * @throws net.corda.v5.crypto.failures.CryptoException for general cryptographic exceptions.
+     * @throws net.corda.v5.crypto.exceptions.CryptoException for general cryptographic exceptions.
      */
     fun toSupportedPublicKey(key: PublicKey): PublicKey
 }

--- a/cipher-suite/src/main/kotlin/net/corda/v5/cipher/suite/KeyGenerationSpec.kt
+++ b/cipher-suite/src/main/kotlin/net/corda/v5/cipher/suite/KeyGenerationSpec.kt
@@ -15,7 +15,7 @@ import net.corda.v5.cipher.suite.schemes.KeyScheme
  * @property masterKeyAlias The wrapping key alias which can be used when generating the wrapped keys, the value
  * could be null for HSMs which use built-in wrapping keys.
  *
- * Note about key aliases. Corda always uses single alias to identify a key pair however some HSMs need separate
+ * The Corda Platform always uses single alias to identify a key pair however some HSMs need separate
  * aliases for public and private keys, in such cases their names have to be derived from the single key pair alias.
  * It could be suffixes or whatever internal naming scheme is used.
  */

--- a/cipher-suite/src/main/kotlin/net/corda/v5/cipher/suite/SignatureSpecEquality.kt
+++ b/cipher-suite/src/main/kotlin/net/corda/v5/cipher/suite/SignatureSpecEquality.kt
@@ -26,6 +26,11 @@ private val comparators = mapOf<Class<*>, BiPredicate<Any, Any>>(
     }
 )
 
+/**
+ * Compares two instances of the [SignatureSpec]
+ *
+ * @return true if the instances are describing the same specification or of both values are null.
+ */
 @Suppress("ComplexMethod")
 fun SignatureSpec?.equal(right: SignatureSpec?): Boolean =
     if (this == null) {

--- a/cipher-suite/src/main/kotlin/net/corda/v5/cipher/suite/SignatureSpecUtils.kt
+++ b/cipher-suite/src/main/kotlin/net/corda/v5/cipher/suite/SignatureSpecUtils.kt
@@ -6,6 +6,10 @@ import net.corda.v5.crypto.ParameterizedSignatureSpec
 import net.corda.v5.crypto.SignatureSpec
 import java.security.spec.AlgorithmParameterSpec
 
+/**
+ * @return the contained [AlgorithmParameterSpec] of [CustomSignatureSpec.params] or [ParameterizedSignatureSpec.params]
+ * or null otherwise.
+ */
 fun SignatureSpec.getParamsSafely(): AlgorithmParameterSpec? =
     when(this) {
         is CustomSignatureSpec -> params

--- a/cipher-suite/src/main/kotlin/net/corda/v5/cipher/suite/SignatureVerificationService.kt
+++ b/cipher-suite/src/main/kotlin/net/corda/v5/cipher/suite/SignatureVerificationService.kt
@@ -16,7 +16,7 @@ interface SignatureVerificationService {
      * @param signatureSpec the signature spec.
      * @param clearData the clear data/message that was signed (usually the Merkle root).
      *
-     * @throws net.corda.v5.crypto.failures.CryptoSignatureException if verification fails.
+     * @throws net.corda.v5.crypto.exceptions.CryptoSignatureException if verification fails.
      * @throws IllegalArgumentException if any of the clear or signature data is empty, key is invalid,
      * the signature scheme is not supported or in general arguments are wrong
      */
@@ -31,7 +31,7 @@ interface SignatureVerificationService {
      * @param digest is used together with the [PublicKey] to infer the [SignatureSpec] to use when verifying this signature.
      * @param clearData the clear data/message that was signed (usually the Merkle root).
      *
-     * @throws net.corda.v5.crypto.failures.CryptoSignatureException if verification fails.
+     * @throws net.corda.v5.crypto.exceptions.CryptoSignatureException if verification fails.
      * @throws IllegalArgumentException if any of the clear or signature data is empty, key is invalid,
      * the signature scheme is not supported, the [SignatureSpec] cannot
      * be inferred from the parameters - e.g. EdDSA supports only 'NONEwithEdDSA' signatures so if the SHA-256 will

--- a/cipher-suite/src/main/kotlin/net/corda/v5/cipher/suite/SigningSpec.kt
+++ b/cipher-suite/src/main/kotlin/net/corda/v5/cipher/suite/SigningSpec.kt
@@ -9,8 +9,9 @@ import java.security.PublicKey
  *
  * @property publicKey The public key of the pair.
  * @property keyScheme The scheme for the key used for signing operation.
- * @property signatureSpec The [SignatureSpec] (or one of derived classes such as [ParameterizedSignatureSpec] or
- * [CustomSignatureSpec]) to use for signing, such as SHA256withECDSA, etc.
+ * @property signatureSpec The [SignatureSpec] (or one of derived classes such as
+ * [net.corda.v5.crypto.ParameterizedSignatureSpec] or [CustomSignatureSpec]) to use for signing,
+ * such as SHA256withECDSA, etc.
  */
 interface SigningSpec {
     val publicKey: PublicKey

--- a/cipher-suite/src/main/kotlin/net/corda/v5/cipher/suite/SoftKeyWrappingService.kt
+++ b/cipher-suite/src/main/kotlin/net/corda/v5/cipher/suite/SoftKeyWrappingService.kt
@@ -1,9 +1,10 @@
 package net.corda.v5.cipher.suite
 
 /**
- * Crypto service which can encrypt and decrypt data. The key will have to be created outside the scope of the service.
+ * Crypto service which can encrypt and decrypt key used by SOFT HSM.
+ * The key will have to be created outside the scope of the service.
  */
-interface EncryptionService {
+interface SoftKeyWrappingService {
     /**
      * Encrypts a byte array using the key identified by the alias.
      *
@@ -15,9 +16,9 @@ interface EncryptionService {
      * @return the encrypted data.
      *
      * @throws IllegalArgumentException if the key is not found or in general the input parameters are wrong
-     * @throws net.corda.v5.crypto.failures.CryptoException, non-recoverable
+     * @throws net.corda.v5.crypto.exceptions.CryptoException, non-recoverable
      */
-    fun encrypt(alias: String, clearText: ByteArray, context: Map<String, String>): ByteArray
+    fun wrap(alias: String, clearText: ByteArray, context: Map<String, String>): ByteArray
 
     /**
      * Decrypt a byte array using the key identified by the alias.
@@ -30,7 +31,7 @@ interface EncryptionService {
      * @return the clear text data.
      *
      * @throws IllegalArgumentException if the key is not found or in general the input parameters are wrong
-     * @throws net.corda.v5.crypto.failures.CryptoException, non-recoverable
+     * @throws net.corda.v5.crypto.exceptions.CryptoException, non-recoverable
      */
-    fun decrypt(alias: String, cipherText: ByteArray, context: Map<String, String>): ByteArray
+    fun unwrap(alias: String, cipherText: ByteArray, context: Map<String, String>): ByteArray
 }

--- a/cipher-suite/src/main/kotlin/net/corda/v5/cipher/suite/SoftKeyWrappingServiceProvider.kt
+++ b/cipher-suite/src/main/kotlin/net/corda/v5/cipher/suite/SoftKeyWrappingServiceProvider.kt
@@ -1,9 +1,9 @@
 package net.corda.v5.cipher.suite
 
 /**
- * Factory to create new instances of the [EncryptionService].
+ * Factory to create new instances of the [SoftKeyWrappingService].
  */
-interface EncryptionServiceProvider<T : Any> {
+interface SoftKeyWrappingServiceProvider<T : Any> {
     /**
      * The name used to resolve current provider by crypto service factory.
      */
@@ -16,7 +16,7 @@ interface EncryptionServiceProvider<T : Any> {
     val configType: Class<T>
 
     /**
-     * Returns an instance of the [EncryptionService].
+     * Returns an instance of the [SoftKeyWrappingService].
      * @param config crypto service configuration
      * @param secrets provides access to decrypting the secrets
      *
@@ -24,16 +24,18 @@ interface EncryptionServiceProvider<T : Any> {
      * in the example bellow for the property called 'passphrase'
      *
      * POJO (Kotlin):
+     *```
      *  val passphrase: Map<String, Any>
-     *
+     *```
      * JSON:
+     *```
      *  "passphrase": {
      *      "configSecret": {
      *          "encryptedSecret": "<encrypted-value>"
      *      }
      *  }
-     *
-     * @throws [net.corda.v5.crypto.failures.CryptoException] for general cryptographic exceptions.
+     *```
+     * @throws [net.corda.v5.crypto.exceptions.CryptoException] for general cryptographic exceptions.
      */
     fun getInstance(config: T, secrets: ConfigurationSecrets): CryptoService
 }

--- a/cipher-suite/src/main/kotlin/net/corda/v5/cipher/suite/schemes/AlgorithmParameterSpecSerializer.kt
+++ b/cipher-suite/src/main/kotlin/net/corda/v5/cipher/suite/schemes/AlgorithmParameterSpecSerializer.kt
@@ -5,6 +5,7 @@ import java.security.spec.AlgorithmParameterSpec
 /**
  * Custom serializer for [AlgorithmParameterSpec] as most of the implementations are not serializable and throw
  * an exception when trying to use default constructors so the JSON cannot be used as well.
+ * Te implementations are used by [net.corda.v5.cipher.suite.AlgorithmParameterSpecEncodingService].
  */
 interface AlgorithmParameterSpecSerializer<T : AlgorithmParameterSpec> {
     /**

--- a/cipher-suite/src/main/kotlin/net/corda/v5/cipher/suite/schemes/DigestScheme.kt
+++ b/cipher-suite/src/main/kotlin/net/corda/v5/cipher/suite/schemes/DigestScheme.kt
@@ -3,7 +3,7 @@ package net.corda.v5.cipher.suite.schemes
 /**
  * This class is used to define a digital digest scheme.
  * @property algorithmName digest's algorithm name (e.g. SHA-256, SHA-512, etc.).
- * @property providerName the provider's name (e.g. "BC").
+ * @property providerName the provider's name (e.g. "BC") which supports the scheme.
  */
 data class DigestScheme(val algorithmName: String, val providerName: String) {
     init {

--- a/cipher-suite/src/main/kotlin/net/corda/v5/cipher/suite/schemes/SerializedAlgorithmParameterSpec.kt
+++ b/cipher-suite/src/main/kotlin/net/corda/v5/cipher/suite/schemes/SerializedAlgorithmParameterSpec.kt
@@ -1,7 +1,7 @@
 package net.corda.v5.cipher.suite.schemes
 
 /**
- * Represents the result of [AlgorithmParameterSpec] serialization.
+ * Represents the result of [java.security.spec.AlgorithmParameterSpec] serialization.
  *
  * @property clazz the fully qualified name of the parameters class which was serialized
  * @property bytes the byte array containing the result of the serialization


### PR DESCRIPTION
Also `EncryptionService/Provider` was renamed to `SoftKeyWrappingService/Provider`, it's not a breaking change as the interface is not being used yet