### PR TITLE
CORE-6472 - add new event schema for successful mgm onboarding and fix docs

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/event/MembershipEvent.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/event/MembershipEvent.avsc
@@ -9,7 +9,8 @@
       "description": "The member event that occurred.",
       "type" : [
         "net.corda.data.membership.event.registration.MemberRegistrationApproved",
-        "net.corda.data.membership.event.registration.MemberRegistrationDeclined"
+        "net.corda.data.membership.event.registration.MemberRegistrationDeclined",
+        "net.corda.data.membership.event.registration.MgmOnboarded"
       ]
     }
   ]

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/event/registration/MemberRegistrationApproved.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/event/registration/MemberRegistrationApproved.avsc
@@ -2,7 +2,7 @@
   "type": "record",
   "name": "MemberRegistrationApproved",
   "namespace": "net.corda.data.membership.event.registration",
-  "doc": "Event for when processing of a registration has finished. Could be for either acceptance or denial.",
+  "doc": "Event for when processing of a successful registration has finished..",
   "fields": [
     {
       "name": "approvedMember",

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/event/registration/MgmOnboarded.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/event/registration/MgmOnboarded.avsc
@@ -1,0 +1,13 @@
+{
+  "type": "record",
+  "name": "MgmOnboarded",
+  "namespace": "net.corda.data.membership.event.registration",
+  "doc": "Event for when processing of a registration for an MGM has finished.",
+  "fields": [
+    {
+      "name": "onboardedMgm",
+      "doc": "Holding identity of the mgm who was onboarded.",
+      "type": "net.corda.data.identity.HoldingIdentity"
+    }
+  ]
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 183
+cordaApiRevision = 184
 
 # Main
 kotlinVersion = 1.7.10


### PR DESCRIPTION
https://r3-cev.atlassian.net/browse/CORE-6472

We need to wait until MGM is registered to return callback to link manager in order to have the tls trustroots.
An event has been added to signal when the MGM finished its onboarding.