### PR TITLE
CORE-6627: Fix publishing of Java artifacts.

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'corda-api.common-library'
-    id 'corda.common-publishing'
     id 'org.jetbrains.kotlin.jvm'
+    id 'corda.common-publishing'
 }
 
 description 'Corda Application'

--- a/base/build.gradle
+++ b/base/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'corda-api.common-library'
-    id 'corda.common-publishing'
     id 'org.jetbrains.kotlin.jvm'
+    id 'corda.common-publishing'
 }
 
 description 'Corda Base'

--- a/buildSrc/src/main/groovy/corda.common-publishing.gradle
+++ b/buildSrc/src/main/groovy/corda.common-publishing.gradle
@@ -11,22 +11,26 @@ if (System.getenv('CORDA_ARTIFACTORY_USERNAME') != null || project.hasProperty('
             publications {
                 register('maven', MavenPublication) { mvn ->
                     afterEvaluate {
-                        artifactId = tasks.named('jar', Jar).flatMap { it.archiveBaseName }.get()
-                        groupId group.toString()
-                        from components.findByName('cordapp') ?: components.findByName('kotlin') ?: components.java
+                        mvn.artifactId = tasks.named('jar', Jar).flatMap { Jar jar -> jar.archiveBaseName }.get()
+                        mvn.groupId group.toString()
+                        mvn.from components.findByName('cordapp') ?: components.findByName('kotlin') ?: components.java
 
-                        try {
-                            artifact tasks.named('sourcesJar', Jar)
-                        } catch (UnknownTaskException ignored) {
+                        if (mvn.artifacts.matching { MavenArtifact a -> a.classifier == 'sources' }.isEmpty()) {
+                            try {
+                                mvn.artifact tasks.named('sourcesJar', Jar)
+                            } catch (UnknownTaskException ignored) {
+                            }
                         }
 
-                        try {
-                            artifact tasks.named('javadocJar', Jar)
-                        } catch (UnknownTaskException ignored) {
+                        if (mvn.artifacts.matching { MavenArtifact a -> a.classifier == 'javadoc' }.isEmpty()) {
+                            try {
+                                mvn.artifact tasks.named('javadocJar', Jar)
+                            } catch (UnknownTaskException ignored) {
+                            }
                         }
 
-                        mvn.artifacts = mvn.artifacts.findAll { a ->
-                            !(a instanceof MavenArtifact) || a.classifier != 'ignore'
+                        mvn.artifacts = mvn.artifacts.findAll { MavenArtifact a ->
+                            a.classifier != 'ignore'
                         }
                     }
                 }

--- a/buildSrc/src/main/groovy/corda.java-only.gradle
+++ b/buildSrc/src/main/groovy/corda.java-only.gradle
@@ -1,3 +1,9 @@
 pluginManager.withPlugin('org.jetbrains.kotlin.jvm') {
     throw new StopExecutionException("Module '${project.path}' should only contain Java classes")
 }
+
+pluginManager.withPlugin('java') {
+    java {
+        withJavadocJar()
+    }
+}

--- a/serialization/src/main/java/net/corda/v5/serialization/SerializationCustomSerializer.java
+++ b/serialization/src/main/java/net/corda/v5/serialization/SerializationCustomSerializer.java
@@ -15,6 +15,8 @@ public interface SerializationCustomSerializer<OBJ, PROXY> {
     /**
      * Should facilitate the conversion of the third party object into the serializable
      * local class specified by {@code PROXY}
+     * @param obj original object for serialization
+     * @return proxy object to be written to AMQP.
      */
     @NotNull
     PROXY toProxy(@NotNull OBJ obj);
@@ -22,6 +24,8 @@ public interface SerializationCustomSerializer<OBJ, PROXY> {
     /**
      * Should facilitate the conversion of the proxy object into a new instance of the
      * unserializable type
+     * @param proxy object from AMQP
+     * @return original object recreated from {@code proxy}
      */
     @NotNull
     OBJ fromProxy(@NotNull PROXY proxy);

--- a/serialization/src/main/java/net/corda/v5/serialization/annotations/CordaSerializationTransformEnumDefault.java
+++ b/serialization/src/main/java/net/corda/v5/serialization/annotations/CordaSerializationTransformEnumDefault.java
@@ -12,28 +12,27 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * each additional constant added a new annotation should be appended to the class. If more than one
  * is required the wrapper annotation {@link CordaSerializationTransformEnumDefaults} should be used to
  * encapsulate them
- * <p/>
- * For Example:<p/>
+ * <p>
+ * For Example:<p>
  * Enum before modification:
  * <pre>
  *  enum class ExampleEnum {
  *    A, B, C
  *  }
  * </pre>
- * <p/>
+ * <p>
  * Assuming at some point a new constant is added it is required we have some mechanism by which to tell
  * nodes with an older version of the class on their Class Path what to do if they attempt to deserialize
  * an example of the class with that new value
- * <p/>
  * <pre>
  *  &#64;CordaSerializationTransformEnumDefault(newName = "D", oldName = "C")
  *  enum class ExampleEnum {
  *    A, B, C, D
  *  }
  * </pre>
- * <p/>
+ * <p>
  * So, on deserialisation treat any instance of the enum that is encoded as D as C
- * <p/>
+ * <p>
  * Adding a second new constant requires the wrapper annotation {@link CordaSerializationTransformEnumDefaults}
  * <pre>
  *  &#64;CordaSerializationTransformEnumDefaults(
@@ -47,7 +46,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *
  * It's fine to assign the second new value a default that may not be present in all versions as in this
  * case it will work down the transform hierarchy until it finds a value it can apply, in this case it would
- * try E -> D -> C (when E -> D fails)
+ * try E -&#62; D -&#62; C (when E -&#62; D fails)
  */
 @Target(TYPE)
 @Retention(RUNTIME)

--- a/serialization/src/main/java/net/corda/v5/serialization/annotations/CordaSerializationTransformEnumDefaults.java
+++ b/serialization/src/main/java/net/corda/v5/serialization/annotations/CordaSerializationTransformEnumDefaults.java
@@ -13,7 +13,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *
  * NOTE: Order is important, new values should always be added before any others
  *
- * <pre/>
+ * <pre>
  *  // initial implementation
  *  enum class ExampleEnum {
  *    A, B, C
@@ -34,7 +34,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  *    A, B, C, D, E
  *  }
  * </pre>
- * <p/>
+ * <p>
  * IMPORTANT - Once added (and in production) do NOT remove old annotations. See documentation for
  * more discussion on this point!.
  */

--- a/serialization/src/main/java/net/corda/v5/serialization/annotations/CordaSerializationTransformRenames.java
+++ b/serialization/src/main/java/net/corda/v5/serialization/annotations/CordaSerializationTransformRenames.java
@@ -9,9 +9,9 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 /**
  * This annotation is used to mark a class as having had multiple elements renamed as a container annotation for
  * instances of {@link CordaSerializationTransformRename}, each of which details an individual rename.
- * <p/>
+ * <p>
  * NOTE: Order is important, new values should always be added before existing
- * <p/>
+ * <p>
  * IMPORTANT - Once added (and in production) do NOT remove old annotations. See documentation for
  * more discussion on this point!.
  */


### PR DESCRIPTION
I've updated the `corda.common-publishing` convention plugin _not_ to create a `sourcesJar` task, should one already exist. We instruct the `java` Gradle plugin to publish a `sources` artifact, but I suspect the Kotlin Gradle plugin discards it. Or else Gradle just adds the `sources` artifact to `components.java` already? However, now that the `:serialization` module is pure Java we end up with two `sources` artifacts, which is forbidden of course.

We also need to instruct `java-only` modules to create a `Javadoc` artifact, because Dokka only works for Kotlin modules. Which has given me some Javadoc errors to fix too.

And I've also discovered that we must apply the Kotlin plugin _before_ we apply `corda.common-publishing`, or else we don't publish the main artifact!? This could be another example of multiple `Project.afterEvaluate {}` handlers executing in a unspecified order tripping us up. I _cannot_ find any other explanation.