### PR TITLE
CORE-4869 - Add marker for rejected messages

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/markers/AppMessageMarker.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/markers/AppMessageMarker.avsc
@@ -12,6 +12,7 @@
         "net.corda.p2p.markers.ApplicationRejectedStaleMarker",
         "net.corda.p2p.markers.GatewaySentMarker",
         "net.corda.p2p.markers.LinkManagerProcessedMarker",
+        "net.corda.p2p.markers.LinkManagerDiscardedMarker",
         "net.corda.p2p.markers.TtlExpiredMarker"
       ]
     },

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/markers/LinkManagerDiscardedMarker.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/markers/LinkManagerDiscardedMarker.avsc
@@ -1,0 +1,18 @@
+{
+  "type": "record",
+  "name": "LinkManagerDiscardedMarker",
+  "namespace": "net.corda.p2p.markers",
+  "fields": [
+    {
+      "name": "message",
+      "type": "net.corda.p2p.AuthenticatedMessageAndKey",
+      "doc": "A copy of the original message in P2P_OUT_TOPIC."
+    },
+    {
+      "name": "reason",
+      "type": "string",
+      "doc": "The reason why the message was discarded."
+    }
+  ],
+  "doc": "The message was discarded by the sending Link Manager (e.g. because it was invalid)."
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 187-DevPreview-2
+cordaApiRevision = 188-DevPreview-2
 
 # Main
 kotlinVersion = 1.7.10


### PR DESCRIPTION
Adding a marker that can be used to indicate messages that were discarded. This is going to be used by the link manager for scenarios of invalid messages.