### PR TITLE
CORE-5406: Use new packaging format 2 Gradle plugin

### DIFF
--- a/buildSrc/src/main/groovy/corda-api.common-library.gradle
+++ b/buildSrc/src/main/groovy/corda-api.common-library.gradle
@@ -8,6 +8,9 @@ plugins {
 pluginManager.withPlugin('net.corda.plugins.cordapp-cpk') {
     throw new StopExecutionException('corda-api.common-library plugin is incompatible with building CPKs and CPBs')
 }
+pluginManager.withPlugin('net.corda.plugins.cordapp-cpk2') {
+    throw new StopExecutionException('corda-api.common-library plugin is incompatible with building CPKs and CPBs')
+}
 
 configurations {
     testArtifacts {

--- a/cordapp-configuration/src/main/java/net/corda/cordapp/ConfigurationPlugin.java
+++ b/cordapp-configuration/src/main/java/net/corda/cordapp/ConfigurationPlugin.java
@@ -25,8 +25,8 @@ public final class ConfigurationPlugin implements Plugin<Project> {
 
     // These are the IDs of the Corda Gradle plugins that CorDapp developers need.
     private static final List<String> CORDAPP_PLUGIN_IDS = unmodifiableList(asList(
-        "net.corda.plugins.cordapp-cpk",
-        "net.corda.plugins.cordapp-cpb",
+        "net.corda.plugins.cordapp-cpk2",
+        "net.corda.plugins.cordapp-cpb2",
         "net.corda.plugins.quasar-utils"
     ));
 

--- a/cordapp-configuration/src/main/resources/net/corda/cordapp/cordapp-configuration.properties
+++ b/cordapp-configuration/src/main/resources/net/corda/cordapp/cordapp-configuration.properties
@@ -14,7 +14,7 @@ Corda-InitiatedFlow-Classes=IMPLEMENTS;net.corda.v5.application.flows.ResponderF
 Corda-Subflow-Classes=IMPLEMENTS;net.corda.v5.application.flows.Subflow
 
 # Corda should adjust this version over time, as required.
-Minimum-Corda-Plugins-Version=6.0.0
+Minimum-Corda-Plugins-Version=7.0.0
 
 # CorDapps must always import these packages so that Corda can
 # still create lazy JPA proxies within the OSGi framework.

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,9 +16,6 @@ kotlin.stdlib.default.dependency = false
 # These are the same annotations that Kotlin uses.
 jetbrainsAnnotationsVersion = 13.0
 
-# at the moment, required for packaging to build test cpks for unit tests
-gradlePluginsVersion = 6.0.0-BETA17
-
 # License
 ## TODO: Change to correct name and URL
 licenseName = Corda Pre-Release Software License Agreement

--- a/settings.gradle
+++ b/settings.gradle
@@ -28,7 +28,6 @@ pluginManagement {
     plugins {
         id 'com.gradle.enterprise' version gradleEnterpriseVersion
         id 'com.gradle.common-custom-user-data-gradle-plugin' version gradleDataPlugin
-        id 'net.corda.plugins.cordapp-cpk' version gradlePluginsVersion
         id 'org.jetbrains.kotlin.jvm' version kotlinVersion
         id 'org.jetbrains.kotlin.plugin.allopen' version kotlinVersion
         id 'org.jetbrains.kotlin.plugin.jpa' version kotlinVersion


### PR DESCRIPTION
- Update `cordapp-configuration` plugin to use cpk2/cpb2 plugins
- Make `corda-api.common-library.gradle` fail if `net.corda.plugins.cordapp-cpk2` is loaded
- Remove unused `net.corda.plugins.cordapp-cpk` plugin from `corda-api`
