### PR TITLE
CORE-6376: use DP2 specific downstream job to ensure compatibility

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 cordaPipeline(
     runIntegrationTests: false,
     nexusAppId: 'net.corda-api-5.0',
-    dependentJobsNames: ['/Corda5/corda-runtime-os-version-compatibility/release%2Fos%2F5.0'],
+    dependentJobsNames: ['/Corda5/corda-runtime-os-version-compatibility/release%2Fos%2F5.0-DevPreview2'],
     javadocJar: true,
     // always use -beta-9999999999999 for local publication as this is used for the version compatibility checks,
     //  This is a PR gate, so we want to check the "post merge" state before publication for real.


### PR DESCRIPTION
- downstream job we use should not be the `release/os/5.0` job but rather the DP2 specific branch for the compatibility job 

