### PR TITLE
CORE-6497 Uniqueness checker message bus integration

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/uniqueness/UniquenessCheckRequestAvro.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/uniqueness/UniquenessCheckRequestAvro.avsc
@@ -4,6 +4,16 @@
   "namespace": "net.corda.data.uniqueness",
   "fields": [
     {
+      "name": "holdingIdentity",
+      "type": "net.corda.data.identity.HoldingIdentity",
+      "doc": "The holding identity of the virtual node making the uniqueness check request."
+    },
+    {
+      "name": "flowExternalEventContext",
+      "type": "net.corda.data.flow.event.external.ExternalEventContext",
+      "doc": "The context of the external event that this request was sent from."
+    },
+    {
       "name": "txId",
       "type": "string"
     },

--- a/data/topic-schema/src/main/kotlin/net/corda/schema/Schemas.kt
+++ b/data/topic-schema/src/main/kotlin/net/corda/schema/Schemas.kt
@@ -161,6 +161,15 @@ class Schemas {
     }
 
     /**
+     * Uniqueness checker schema
+     */
+    class UniquenessChecker {
+        companion object {
+            const val UNIQUENESS_CHECK_TOPIC = "uniqueness.check"
+        }
+    }
+
+    /**
      * Virtual Node schema
      */
     class VirtualNode {

--- a/data/topic-schema/src/main/resources/net/corda/schema/UniquenessChecker.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/UniquenessChecker.yaml
@@ -1,0 +1,6 @@
+topics:
+  UniquenessCheckTopic:
+    name: uniqueness.check
+    consumers:
+    producers:
+    config:

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 401
+cordaApiRevision = 192
 
 # Main
 kotlinVersion = 1.7.10

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 192
+cordaApiRevision = 402
 
 # Main
 kotlinVersion = 1.7.10


### PR DESCRIPTION
API changes required to provide additional context to the uniqueness checker so it can respond to requests made over the external events API.

See https://github.com/corda/corda-runtime-os/pull/2119 for a full description and test notes.