### PR TITLE
NOTICK Bump API version to 400

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 188
+cordaApiRevision = 400
 
 # Main
 kotlinVersion = 1.7.10


### PR DESCRIPTION
Following creation of  the `release/os/5.0-DevPreview2` branch, the version in `release/os/5.0` is being bumped to 400 to avoid confusion / conflicts with versions being used in the DP2 branch.

See [this page](https://r3-cev.atlassian.net/wiki/spaces/CB/pages/4071850170/Working+with+corda-api+and+corda-runtime-os+repos+for+Corda+5#API-version-forks) for allocated version ranges.