### PR TITLE
CORE-6605 updated Jackson 2.13.3 -> 2.13.4 

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -47,7 +47,7 @@ grgitPluginVersion = 4.0.2
 taskTreePluginVersion = 2.1.0
 javaxPersistenceApiVersion = 2.2
 hibernateVersion = 5.6.10.Final
-jacksonVersion = 2.13.3
+jacksonVersion = 2.13.4
 
 # Testing
 assertjVersion = 3.23.+


### PR DESCRIPTION
Affected versions of this package are vulnerable to Denial of Service (DoS) due missing to nested depth limitation for collections.