### PR TITLE
CORE-6681: ensure snake yaml uses 1.32 for Deteck pluign transitive dependency 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -207,11 +207,15 @@ subprojects {
         }
     }
 
-    // required until detekt plugin updates it's internal version of snakeYaml, not fixed as of detekt version 1.21
-    pluginManager.withPlugin('io.gitlab.arturbosch.detekt') {
-      dependencies {
-            detekt "org.yaml:snakeyaml:$snakeyamlVersion"
-      }
+    pluginManager.withPlugin('io.gitlab.arturbosch.detekt'){
+        dependencies {
+        detekt "io.gitlab.arturbosch.detekt:detekt-cli:$detektPluginVersion"
+            constraints {
+                detekt("org.yaml:snakeyaml:$snakeyamlVersion") {
+                    because "required until detekt plugin updates it's internal version of snakeYaml, not fixed as of detekt version 1.21"
+                }
+            }
+        }
     }
 
     // we do this to allow for Gradle task caching. OSGI attribute Bnd-LastModified breaks gradle caching as it is a timestamp

--- a/build.gradle
+++ b/build.gradle
@@ -210,7 +210,7 @@ subprojects {
     // required until detekt plugin updates it's internal version of snakeYaml, not fixed as of detekt version 1.21
     pluginManager.withPlugin('io.gitlab.arturbosch.detekt') {
       dependencies {
-            detekt "org.yaml:snakeyaml:1.31"
+            detekt "org.yaml:snakeyaml:$snakeyamlVersion"
       }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -112,7 +112,6 @@ subprojects {
 
     apply plugin: "org.gradle.test-retry"
 
-
     pluginManager.withPlugin('org.jetbrains.kotlin.jvm') {
         apply plugin: 'io.gitlab.arturbosch.detekt'
         apply plugin: 'jacoco'

--- a/build.gradle
+++ b/build.gradle
@@ -112,6 +112,7 @@ subprojects {
 
     apply plugin: "org.gradle.test-retry"
 
+
     pluginManager.withPlugin('org.jetbrains.kotlin.jvm') {
         apply plugin: 'io.gitlab.arturbosch.detekt'
         apply plugin: 'jacoco'
@@ -205,6 +206,13 @@ subprojects {
             archiveClassifier.set("javadoc")
             from(dokkaHtml.outputDirectory)
         }
+    }
+
+    // required until detekt plugin updates it's internal version of snakeYaml, not fixed as of detekt version 1.21
+    pluginManager.withPlugin('io.gitlab.arturbosch.detekt') {
+      dependencies {
+            detekt "org.yaml:snakeyaml:1.31"
+      }
     }
 
     // we do this to allow for Gradle task caching. OSGI attribute Bnd-LastModified breaks gradle caching as it is a timestamp

--- a/gradle.properties
+++ b/gradle.properties
@@ -35,6 +35,7 @@ dokkaVersion = 1.7.+
 detektPluginVersion = 1.21.+
 dependencyCheckVersion=0.42.+
 artifactoryPluginVersion = 4.28.2
+snakeyamlVersion=1.32
 
 # Logging
 slf4jVersion = 1.7.36


### PR DESCRIPTION
io.gitlab.arturbosch.detekt pulls in a transitive dependency on snake yaml 1.31 , until Deteck bump their version in a later release we need to force gradle to use the same version of snake yaml decaled in our gradle.properties file (1.32)