### PR TITLE
CORE-6619: use our own class with strings for algorithm identification

### DIFF
--- a/cipher-suite/src/main/kotlin/net/corda/v5/cipher/suite/schemes/CordaAlgorithmIdentifier.kt
+++ b/cipher-suite/src/main/kotlin/net/corda/v5/cipher/suite/schemes/CordaAlgorithmIdentifier.kt
@@ -1,0 +1,9 @@
+package net.corda.v5.cipher.suite.schemes
+
+
+// the name includes Corda so as not to clash in implementations that may use librares
+// with similar identifiers.
+data class CordaAlgorithmIdentifier(
+    val identifier: String,
+    val parameters: List<String>
+)

--- a/cipher-suite/src/main/kotlin/net/corda/v5/cipher/suite/schemes/KeyScheme.kt
+++ b/cipher-suite/src/main/kotlin/net/corda/v5/cipher/suite/schemes/KeyScheme.kt
@@ -1,6 +1,5 @@
 package net.corda.v5.cipher.suite.schemes
 
-import org.bouncycastle.asn1.x509.AlgorithmIdentifier
 import java.security.spec.AlgorithmParameterSpec
 
 /**
@@ -8,7 +7,7 @@ import java.security.spec.AlgorithmParameterSpec
  *
  * @param codeName Unique code name for this key scheme (e.g. CORDA.RSA, CORDA.ECDSA.SECP256K1, CORDA.ECDSA_SECP256R1,
  * CORDA.EDDSA.ED25519, CORDA.SPHINCS-256).
- * @param algorithmOIDs ASN.1 algorithm identifiers for keys which are used to match keys
+ * @param algorithmIDs strings identifying algorithms for keys, and parameters, which are used to match keys
  * to their schemes. There must be at least one defined.
  * @param providerName The provider's name (e.g. "BC") which supports the key scheme.
  * @param algorithmName Key's algorithm (e.g. RSA, ECDSA. EdDSA, SPHINCS-256).
@@ -24,9 +23,9 @@ data class KeyScheme(
      */
     val codeName: String,
     /**
-     * ASN.1 algorithm identifiers for the key scheme.
+     * Algorithm identifier and parameter strings for the key scheme.
      */
-    val algorithmOIDs: List<AlgorithmIdentifier>,
+    val algorithmIDs: List<CordaAlgorithmIdentifier>,
     /**
      * Security provider name which supports the key scheme.
      */
@@ -52,7 +51,7 @@ data class KeyScheme(
         require(codeName.isNotBlank()) { "The codeName must not be blank." }
         require(providerName.isNotBlank()) { "The providerName must not be blank." }
         require(algorithmName.isNotBlank()) { "The algorithmName must not be blank." }
-        require(algorithmOIDs.isNotEmpty()) { "The algorithmOIDs must not be empty." }
+        require(algorithmIDs.isNotEmpty()) { "The algorithmOIDs must not be empty." }
         require(capabilities.isNotEmpty()) { "There must be defined at least one capability." }
     }
 

--- a/cipher-suite/src/main/kotlin/net/corda/v5/cipher/suite/schemes/KeySchemeTemplate.kt
+++ b/cipher-suite/src/main/kotlin/net/corda/v5/cipher/suite/schemes/KeySchemeTemplate.kt
@@ -1,6 +1,5 @@
 package net.corda.v5.cipher.suite.schemes
 
-import org.bouncycastle.asn1.x509.AlgorithmIdentifier
 import java.security.spec.AlgorithmParameterSpec
 
 /**
@@ -8,7 +7,7 @@ import java.security.spec.AlgorithmParameterSpec
  *
  * @param codeName Unique code name for this key scheme (e.g. CORDA.RSA, CORDA.ECDSA.SECP256K1, CORDA.ECDSA_SECP256R1,
  * CORDA.EDDSA.ED25519, CORDA.SPHINCS-256).
- * @param algorithmOIDs ASN.1 algorithm identifiers for keys which are used to match keys
+ * @param algorithmIDs strings identifying algorithms for keys, and parameters, which are used to match keys
  * to their schemes. There must be at least one defined.
  * @param algorithmName Key algorithm (e.g. RSA, ECDSA. EdDSA, SPHINCS-256).
  * @param algSpec Parameter specs for the underlying algorithm. Note that RSA is defined by the key size
@@ -26,7 +25,7 @@ data class KeySchemeTemplate(
     /**
      * ASN.1 algorithm identifiers for the key scheme.
      */
-    val algorithmOIDs: List<AlgorithmIdentifier>,
+    val algorithmIDs: List<CordaAlgorithmIdentifier>,
     /**
      * Key's algorithm name.
      */
@@ -47,7 +46,7 @@ data class KeySchemeTemplate(
     init {
         require(codeName.isNotBlank()) { "The codeName must not be blank." }
         require(algorithmName.isNotBlank()) { "The algorithmName must not be blank." }
-        require(algorithmOIDs.isNotEmpty()) { "The algorithmOIDs must not be empty." }
+        require(algorithmIDs.isNotEmpty()) { "The algorithmOIDs must not be empty." }
         require(capabilities.isNotEmpty()) { "There must be defined at least one capability." }
     }
 
@@ -57,7 +56,7 @@ data class KeySchemeTemplate(
     fun makeScheme(providerName: String): KeyScheme = KeyScheme(
         providerName = providerName,
         codeName = codeName,
-        algorithmOIDs = algorithmOIDs.toList(),
+        algorithmIDs = algorithmIDs,
         algorithmName = algorithmName,
         algSpec = algSpec,
         keySize = keySize,

--- a/cipher-suite/src/main/kotlin/net/corda/v5/cipher/suite/schemes/KeySchemeTemplates.kt
+++ b/cipher-suite/src/main/kotlin/net/corda/v5/cipher/suite/schemes/KeySchemeTemplates.kt
@@ -13,17 +13,10 @@ import net.corda.v5.crypto.RSA_CODE_NAME
 import net.corda.v5.crypto.SM2_CODE_NAME
 import net.corda.v5.crypto.SPHINCS256_CODE_NAME
 import net.corda.v5.crypto.X25519_CODE_NAME
-import org.bouncycastle.asn1.ASN1Integer
 import org.bouncycastle.asn1.ASN1ObjectIdentifier
 import org.bouncycastle.asn1.DLSequence
-import org.bouncycastle.asn1.bc.BCObjectIdentifiers
 import org.bouncycastle.asn1.cryptopro.CryptoProObjectIdentifiers
-import org.bouncycastle.asn1.gm.GMObjectIdentifiers
 import org.bouncycastle.asn1.nist.NISTObjectIdentifiers
-import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers
-import org.bouncycastle.asn1.sec.SECObjectIdentifiers
-import org.bouncycastle.asn1.x509.AlgorithmIdentifier
-import org.bouncycastle.asn1.x9.X9ObjectIdentifiers
 import org.bouncycastle.jcajce.spec.EdDSAParameterSpec
 import org.bouncycastle.jce.ECNamedCurveTable
 import org.bouncycastle.jce.spec.GOST3410ParameterSpec
@@ -56,7 +49,7 @@ val SHA512_256 = DLSequence(arrayOf(NISTObjectIdentifiers.id_sha512_256))
 @JvmField
 val RSA_TEMPLATE = KeySchemeTemplate(
     codeName = RSA_CODE_NAME,
-    algorithmOIDs = listOf(AlgorithmIdentifier(PKCSObjectIdentifiers.rsaEncryption, null)),
+    algorithmIDs = listOf(CordaAlgorithmIdentifier("rsaEncryption", listOf())),
     algorithmName = "RSA",
     algSpec = null,
     keySize = 3072,
@@ -69,7 +62,7 @@ val RSA_TEMPLATE = KeySchemeTemplate(
 @JvmField
 val ECDSA_SECP256K1_TEMPLATE = KeySchemeTemplate(
     codeName = ECDSA_SECP256K1_CODE_NAME,
-    algorithmOIDs = listOf(AlgorithmIdentifier(X9ObjectIdentifiers.id_ecPublicKey, SECObjectIdentifiers.secp256k1)),
+    algorithmIDs = listOf(CordaAlgorithmIdentifier("id_ecPublicKey", listOf("secp256k1"))),
     algorithmName = "EC",
     algSpec = ECNamedCurveTable.getParameterSpec("secp256k1"),
     keySize = null,
@@ -82,7 +75,7 @@ val ECDSA_SECP256K1_TEMPLATE = KeySchemeTemplate(
 @JvmField
 val ECDSA_SECP256R1_TEMPLATE = KeySchemeTemplate(
     codeName = ECDSA_SECP256R1_CODE_NAME,
-    algorithmOIDs = listOf(AlgorithmIdentifier(X9ObjectIdentifiers.id_ecPublicKey, SECObjectIdentifiers.secp256r1)),
+    algorithmIDs = listOf(CordaAlgorithmIdentifier("id_ecPublicKey", listOf("secp256r1"))),
     algorithmName = "EC",
     algSpec = ECNamedCurveTable.getParameterSpec("secp256r1"),
     keySize = null,
@@ -95,7 +88,7 @@ val ECDSA_SECP256R1_TEMPLATE = KeySchemeTemplate(
 @JvmField
 val EDDSA_ED25519_TEMPLATE = KeySchemeTemplate(
     codeName = EDDSA_ED25519_CODE_NAME,
-    algorithmOIDs = listOf(AlgorithmIdentifier(ID_CURVE_25519PH, null)),
+    algorithmIDs = listOf(CordaAlgorithmIdentifier("ID_CURVE_25519PH", listOf())),
     algorithmName = "Ed25519",
     algSpec = EdDSAParameterSpec(EdDSAParameterSpec.Ed25519),
     keySize = null,
@@ -109,7 +102,7 @@ val EDDSA_ED25519_TEMPLATE = KeySchemeTemplate(
 @JvmField
 val X25519_TEMPLATE = KeySchemeTemplate(
     codeName = X25519_CODE_NAME,
-    algorithmOIDs = listOf(AlgorithmIdentifier(ID_CURVE_X25519, null)),
+    algorithmIDs = listOf(CordaAlgorithmIdentifier("ID_CURVE_X25519", listOf())),
     algorithmName = "X25519",
     algSpec = null,
     keySize = null,
@@ -122,7 +115,7 @@ val X25519_TEMPLATE = KeySchemeTemplate(
 @JvmField
 val SPHINCS256_TEMPLATE = KeySchemeTemplate(
     codeName = SPHINCS256_CODE_NAME,
-    algorithmOIDs = listOf(AlgorithmIdentifier(BCObjectIdentifiers.sphincs256, DLSequence(arrayOf(ASN1Integer(0), SHA512_256)))),
+    algorithmIDs = listOf(CordaAlgorithmIdentifier("sphincs256", listOf("0", "SHA512_256"))),
     algorithmName = "SPHINCS256",
     algSpec = SPHINCS256KeyGenParameterSpec(SPHINCS256KeyGenParameterSpec.SHA512_256),
     keySize = null,
@@ -135,7 +128,7 @@ val SPHINCS256_TEMPLATE = KeySchemeTemplate(
 @JvmField
 val SM2_TEMPLATE = KeySchemeTemplate(
     codeName = SM2_CODE_NAME,
-    algorithmOIDs = listOf(AlgorithmIdentifier(X9ObjectIdentifiers.id_ecPublicKey, GMObjectIdentifiers.sm2p256v1)),
+    algorithmIDs = listOf(CordaAlgorithmIdentifier("id_ecPublicKey", listOf("sm2p256v1"))),
     algorithmName = "EC",
     algSpec = ECNamedCurveTable.getParameterSpec("sm2p256v1"),
     keySize = null,
@@ -148,16 +141,7 @@ val SM2_TEMPLATE = KeySchemeTemplate(
 @JvmField
 val GOST3410_GOST3411_TEMPLATE = KeySchemeTemplate(
     codeName = GOST3410_GOST3411_CODE_NAME,
-    algorithmOIDs = listOf(
-        AlgorithmIdentifier(
-            CryptoProObjectIdentifiers.gostR3410_94, DLSequence(
-                arrayOf(
-                    CryptoProObjectIdentifiers.gostR3410_94_CryptoPro_A,
-                    CryptoProObjectIdentifiers.gostR3411_94_CryptoProParamSet
-                )
-            )
-        )
-    ),
+    algorithmIDs = listOf(CordaAlgorithmIdentifier("gostR3410_94", listOf("gostR3410_94_CryptoPro_A", "gostR3411_94_CryptoProParamSet"))),
     algorithmName = "GOST3410",
     algSpec = GOST3410ParameterSpec(CryptoProObjectIdentifiers.gostR3410_94_CryptoPro_A.id),
     keySize = null,
@@ -170,7 +154,7 @@ val GOST3410_GOST3411_TEMPLATE = KeySchemeTemplate(
 @JvmField
 val COMPOSITE_KEY_TEMPLATE = KeySchemeTemplate(
     codeName = COMPOSITE_KEY_CODE_NAME,
-    algorithmOIDs = listOf(AlgorithmIdentifier(OID_COMPOSITE_KEY_IDENTIFIER)),
+    algorithmIDs = listOf(CordaAlgorithmIdentifier("OID_COMPOSITE_KEY_IDENTIFIER", listOf())),
     algorithmName = CompositeKey.KEY_ALGORITHM,
     algSpec = null,
     keySize = null,

--- a/cipher-suite/src/test/kotlin/net/corda/v5/cipher/suite/schemes/KeySchemeTemplateTests.kt
+++ b/cipher-suite/src/test/kotlin/net/corda/v5/cipher/suite/schemes/KeySchemeTemplateTests.kt
@@ -1,12 +1,6 @@
 package net.corda.v5.cipher.suite.schemes
 
 import net.corda.v5.crypto.ECDSA_SECP256K1_CODE_NAME
-import org.bouncycastle.asn1.ASN1Integer
-import org.bouncycastle.asn1.DLSequence
-import org.bouncycastle.asn1.bc.BCObjectIdentifiers
-import org.bouncycastle.asn1.sec.SECObjectIdentifiers
-import org.bouncycastle.asn1.x509.AlgorithmIdentifier
-import org.bouncycastle.asn1.x9.X9ObjectIdentifiers
 import org.bouncycastle.pqc.jcajce.spec.SPHINCS256KeyGenParameterSpec
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -18,7 +12,7 @@ class KeySchemeTemplateTests {
     fun `Should create KeyScheme out of the template`() {
         val template = KeySchemeTemplate(
             codeName = "some-code",
-            algorithmOIDs = listOf(AlgorithmIdentifier(BCObjectIdentifiers.sphincs256, DLSequence(arrayOf(ASN1Integer(0), SHA512_256)))),
+            algorithmIDs = listOf(CordaAlgorithmIdentifier("sphincs256", arrayListOf("0", "SHA512_256"))),
             algorithmName = "some-algorithm",
             algSpec = SPHINCS256KeyGenParameterSpec(SPHINCS256KeyGenParameterSpec.SHA512_256),
             keySize = 17,
@@ -29,9 +23,9 @@ class KeySchemeTemplateTests {
         assertEquals(template.algorithmName, scheme.algorithmName)
         assertEquals(template.algSpec, scheme.algSpec)
         assertEquals(template.keySize, scheme.keySize)
-        assertEquals(template.algorithmOIDs.size, scheme.algorithmOIDs.size)
-        scheme.algorithmOIDs.forEachIndexed { i, a ->
-            assertEquals(template.algorithmOIDs[i], a)
+        assertEquals(template.algorithmIDs.size, scheme.algorithmIDs.size)
+        scheme.algorithmIDs.forEachIndexed { i, a ->
+            assertEquals(template.algorithmIDs[i], a)
         }
         assertEquals("BC", scheme.providerName)
         assertEquals(1, scheme.capabilities.size)
@@ -43,7 +37,7 @@ class KeySchemeTemplateTests {
         assertThrows<IllegalArgumentException> {
             KeySchemeTemplate(
                 codeName = "  ",
-                algorithmOIDs = listOf(AlgorithmIdentifier(X9ObjectIdentifiers.id_ecPublicKey, SECObjectIdentifiers.secp256k1)),
+                algorithmIDs = listOf(CordaAlgorithmIdentifier("id_ecPublicKey", listOf("secp256k1"))),
                 algorithmName = "EC",
                 algSpec = null,
                 keySize = null,
@@ -57,7 +51,7 @@ class KeySchemeTemplateTests {
         assertThrows<IllegalArgumentException> {
             KeySchemeTemplate(
                 codeName = ECDSA_SECP256K1_CODE_NAME,
-                algorithmOIDs = emptyList(),
+                algorithmIDs = emptyList(),
                 algorithmName = "EC",
                 algSpec = null,
                 keySize = null,
@@ -71,7 +65,7 @@ class KeySchemeTemplateTests {
         assertThrows<IllegalArgumentException> {
             KeySchemeTemplate(
                 codeName = ECDSA_SECP256K1_CODE_NAME,
-                algorithmOIDs = listOf(AlgorithmIdentifier(X9ObjectIdentifiers.id_ecPublicKey, SECObjectIdentifiers.secp256k1)),
+                algorithmIDs = listOf(CordaAlgorithmIdentifier("id_ecPublicKey", listOf("secp256k1"))),
                 algorithmName = "  ",
                 algSpec = null,
                 keySize = null,
@@ -85,7 +79,7 @@ class KeySchemeTemplateTests {
         assertThrows<IllegalArgumentException> {
             KeySchemeTemplate(
                 codeName = ECDSA_SECP256K1_CODE_NAME,
-                algorithmOIDs = listOf(AlgorithmIdentifier(X9ObjectIdentifiers.id_ecPublicKey, SECObjectIdentifiers.secp256k1)),
+                algorithmIDs = listOf(CordaAlgorithmIdentifier("X9ObjectIdentifiers", listOf("secp256k1"))),
                 algorithmName = "some-algorithm",
                 algSpec = null,
                 keySize = null,

--- a/cipher-suite/src/test/kotlin/net/corda/v5/cipher/suite/schemes/KeySchemeTests.kt
+++ b/cipher-suite/src/test/kotlin/net/corda/v5/cipher/suite/schemes/KeySchemeTests.kt
@@ -1,11 +1,10 @@
 package net.corda.v5.cipher.suite.schemes
 
 import net.corda.v5.crypto.ECDSA_SECP256K1_CODE_NAME
-import org.bouncycastle.asn1.sec.SECObjectIdentifiers
-import org.bouncycastle.asn1.x509.AlgorithmIdentifier
-import org.bouncycastle.asn1.x9.X9ObjectIdentifiers
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+
+
 
 class KeySchemeTests {
     @Test
@@ -13,7 +12,7 @@ class KeySchemeTests {
         assertThrows<IllegalArgumentException> {
             KeyScheme(
                 codeName = "  ",
-                algorithmOIDs = listOf(AlgorithmIdentifier(X9ObjectIdentifiers.id_ecPublicKey, SECObjectIdentifiers.secp256k1)),
+                algorithmIDs = listOf(CordaAlgorithmIdentifier("id_ecPublicKey", listOf("secp256k1"))),
                 providerName = "provider",
                 algorithmName = "EC",
                 algSpec = null,
@@ -24,11 +23,11 @@ class KeySchemeTests {
     }
 
     @Test
-    fun `Should throw IllegalArgumentException when initializing with empty algorithmOIDs`() {
+    fun `Should throw IllegalArgumentException when initializing with empty algorithmIDs`() {
         assertThrows<IllegalArgumentException> {
             KeyScheme(
                 codeName = ECDSA_SECP256K1_CODE_NAME,
-                algorithmOIDs = emptyList(),
+                algorithmIDs = emptyList(),
                 providerName = "provider",
                 algorithmName = "EC",
                 algSpec = null,
@@ -43,7 +42,7 @@ class KeySchemeTests {
         assertThrows<IllegalArgumentException> {
             KeyScheme(
                 codeName = ECDSA_SECP256K1_CODE_NAME,
-                algorithmOIDs = listOf(AlgorithmIdentifier(X9ObjectIdentifiers.id_ecPublicKey, SECObjectIdentifiers.secp256k1)),
+                algorithmIDs = listOf(CordaAlgorithmIdentifier("id_ecPublicKey", listOf("secp256k1"))),
                 providerName = "  ",
                 algorithmName = "EC",
                 algSpec = null,
@@ -58,7 +57,7 @@ class KeySchemeTests {
         assertThrows<IllegalArgumentException> {
             KeyScheme(
                 codeName = ECDSA_SECP256K1_CODE_NAME,
-                algorithmOIDs = listOf(AlgorithmIdentifier(X9ObjectIdentifiers.id_ecPublicKey, SECObjectIdentifiers.secp256k1)),
+                algorithmIDs = listOf(CordaAlgorithmIdentifier("id_ecPublicKey", listOf("secp256k1"))),
                 providerName = "provider",
                 algorithmName = "  ",
                 algSpec = null,
@@ -73,7 +72,7 @@ class KeySchemeTests {
         assertThrows<IllegalArgumentException> {
             KeyScheme(
                 codeName = ECDSA_SECP256K1_CODE_NAME,
-                algorithmOIDs = listOf(AlgorithmIdentifier(X9ObjectIdentifiers.id_ecPublicKey, SECObjectIdentifiers.secp256k1)),
+                algorithmIDs = listOf(CordaAlgorithmIdentifier("id_ecPublicKey", listOf("secp256k1"))),
                 providerName = "provider",
                 algorithmName = "some-algorithm",
                 algSpec = null,


### PR DESCRIPTION
This is a step towards dropping  a dependency on Bouncy Castle.

We could pass in OIDs directly,
but that would mean listing out all
relevant OIDs in this repository.
