### PR TITLE
CORE-6871 Consensual Finality flow first version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 410
+cordaApiRevision = 411
 
 # Main
 kotlinVersion = 1.7.10

--- a/ledger/ledger-consensual/src/main/kotlin/net/corda/v5/ledger/consensual/ConsensualLedgerService.kt
+++ b/ledger/ledger-consensual/src/main/kotlin/net/corda/v5/ledger/consensual/ConsensualLedgerService.kt
@@ -1,7 +1,10 @@
 package net.corda.v5.ledger.consensual
 
+import net.corda.v5.application.messaging.FlowSession
 import net.corda.v5.base.annotations.DoNotImplement
 import net.corda.v5.base.annotations.Suspendable
+import net.corda.v5.ledger.consensual.transaction.ConsensualSignedTransaction
+import net.corda.v5.ledger.consensual.transaction.ConsensualSignedTransactionVerifier
 import net.corda.v5.ledger.consensual.transaction.ConsensualTransactionBuilder
 
 /**
@@ -21,4 +24,33 @@ interface ConsensualLedgerService {
     fun receiveFinality( ()-> ... )
     ... Vault ...
     */
+
+    /**
+     * Collects signatures, records and broadcasts to involved peers a [ConsensualSignedTransaction].
+     *
+     * @param signedTransaction The [ConsensualSignedTransaction] to finalise and recorded locally and with peer [sessions].
+     * @param sessions The [FlowSession]s of the peers involved in the transaction.
+     *
+     * @return The fully signed [ConsensualSignedTransaction] that was recorded.
+     */
+    @Suspendable
+    fun finality(
+        signedTransaction: ConsensualSignedTransaction,
+        sessions: List<FlowSession>
+    ): ConsensualSignedTransaction
+
+
+    /**
+     * Verifies, signs and records a [ConsensualSignedTransaction].
+     *
+     * @param session The [FlowSession] to receive the [ConsensualSignedTransaction] from.
+     * @param verifier Verifies the received [ConsensualSignedTransaction].
+     *
+     * @return The fully signed [ConsensualSignedTransaction] that was received and recorded.
+     */
+    @Suspendable
+    fun receiveFinality(
+        session: FlowSession,
+        verifier: ConsensualSignedTransactionVerifier
+    ): ConsensualSignedTransaction
 }

--- a/ledger/ledger-consensual/src/main/kotlin/net/corda/v5/ledger/consensual/transaction/ConsensualSignedTransaction.kt
+++ b/ledger/ledger-consensual/src/main/kotlin/net/corda/v5/ledger/consensual/transaction/ConsensualSignedTransaction.kt
@@ -24,10 +24,6 @@ import net.corda.v5.crypto.SecureHash
  * Thus adding or removing a signature does not change it.
  */
 @DoNotImplement
-// Why do we make it illegal to have a custom serializer for a corda serializable annotated class/interface?
-// This seems very dangerous moving forward if we need to provide custom serializers for existing code
-// net.corda.internal.serialization.amqp.CachingCustomSerializerRegistry - Illegal custom serializer detected for interface net.corda.v5.ledger.consensual.transaction.ConsensualSignedTransaction: net.corda.internal.serialization.amqp.standard.CustomSerializer.Proxy
-//@CordaSerializable
 interface ConsensualSignedTransaction {
     /**
      * @property id The ID of the transaction.

--- a/ledger/ledger-consensual/src/main/kotlin/net/corda/v5/ledger/consensual/transaction/ConsensualSignedTransaction.kt
+++ b/ledger/ledger-consensual/src/main/kotlin/net/corda/v5/ledger/consensual/transaction/ConsensualSignedTransaction.kt
@@ -25,7 +25,10 @@ import java.security.PublicKey
  * Thus adding or removing a signature does not change it.
  */
 @DoNotImplement
-@CordaSerializable
+// Why do we make it illegal to have a custom serializer for a corda serializable annotated class/interface?
+// This seems very dangerous moving forward if we need to provide custom serializers for existing code
+// net.corda.internal.serialization.amqp.CachingCustomSerializerRegistry - Illegal custom serializer detected for interface net.corda.v5.ledger.consensual.transaction.ConsensualSignedTransaction: net.corda.internal.serialization.amqp.standard.CustomSerializer.Proxy
+//@CordaSerializable
 interface ConsensualSignedTransaction {
     /**
      * @property id The ID of the transaction.

--- a/ledger/ledger-consensual/src/main/kotlin/net/corda/v5/ledger/consensual/transaction/ConsensualSignedTransaction.kt
+++ b/ledger/ledger-consensual/src/main/kotlin/net/corda/v5/ledger/consensual/transaction/ConsensualSignedTransaction.kt
@@ -1,10 +1,9 @@
 package net.corda.v5.ledger.consensual.transaction
 
+import java.security.PublicKey
 import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
-import net.corda.v5.base.annotations.CordaSerializable
 import net.corda.v5.base.annotations.DoNotImplement
 import net.corda.v5.crypto.SecureHash
-import java.security.PublicKey
 
 /**
  * Defines a signed Consensual transaction.

--- a/ledger/ledger-consensual/src/main/kotlin/net/corda/v5/ledger/consensual/transaction/ConsensualSignedTransactionVerifier.kt
+++ b/ledger/ledger-consensual/src/main/kotlin/net/corda/v5/ledger/consensual/transaction/ConsensualSignedTransactionVerifier.kt
@@ -1,13 +1,10 @@
 package net.corda.v5.ledger.consensual.transaction
 
-import net.corda.v5.base.annotations.CordaSerializable
 import net.corda.v5.base.annotations.Suspendable
 
-@CordaSerializable
 fun interface ConsensualSignedTransactionVerifier {
 
-    // Should this return a Try.Success/Error? Or control purely through exceptions, but this means that should not
-    // be used to determine behaviour in the peer flow.
+    // TODO [CORE-7027] Document that this API should throw to fail verification
     @Suspendable
     fun verify(signedTransaction: ConsensualSignedTransaction)
 }

--- a/ledger/ledger-consensual/src/main/kotlin/net/corda/v5/ledger/consensual/transaction/ConsensualSignedTransactionVerifier.kt
+++ b/ledger/ledger-consensual/src/main/kotlin/net/corda/v5/ledger/consensual/transaction/ConsensualSignedTransactionVerifier.kt
@@ -1,0 +1,13 @@
+package net.corda.v5.ledger.consensual.transaction
+
+import net.corda.v5.base.annotations.CordaSerializable
+import net.corda.v5.base.annotations.Suspendable
+
+@CordaSerializable
+fun interface ConsensualSignedTransactionVerifier {
+
+    // Should this return a Try.Success/Error? Or control purely through exceptions, but this means that should not
+    // be used to determine behaviour in the peer flow.
+    @Suspendable
+    fun verify(signedTransaction: ConsensualSignedTransaction)
+}

--- a/ledger/ledger-consensual/src/main/kotlin/net/corda/v5/ledger/consensual/transaction/ConsensualTransactionBuilder.kt
+++ b/ledger/ledger-consensual/src/main/kotlin/net/corda/v5/ledger/consensual/transaction/ConsensualTransactionBuilder.kt
@@ -3,6 +3,7 @@ package net.corda.v5.ledger.consensual.transaction
 import net.corda.v5.base.annotations.DoNotImplement
 import net.corda.v5.ledger.consensual.ConsensualState
 import java.security.PublicKey
+import net.corda.v5.base.annotations.Suspendable
 
 /**
  * Defines a builder for [ConsensualSignedTransaction]s.
@@ -42,5 +43,6 @@ interface ConsensualTransactionBuilder {
      * @throws [UnsupportedOperationException] when called second time on the same object to prevent duplicate
      *      transactions accidentally.
      */
+    @Suspendable
     fun signInitial(publicKey: PublicKey): ConsensualSignedTransaction
 }


### PR DESCRIPTION
Added `ConsensualFinalityFlow` and `ConsensualReceiveFinalityFlow` which are both accessed by `ConsensualLedgerService`.