### PR TITLE
CORE-6342: Add role to static registration context

### DIFF
--- a/data/membership-schema/src/main/resources/net/corda/schema/membership/member/static/registration/1.0/corda.member.static.registration.json
+++ b/data/membership-schema/src/main/resources/net/corda/schema/membership/member/static/registration/1.0/corda.member.static.registration.json
@@ -4,12 +4,38 @@
   "title": "Corda static member registration context schema",
   "description": "Definition of the registration context required for registering a member in a static group.",
   "type": "object",
+  "patternProperties": {
+    "^corda.roles.[0-9]+$": {
+      "description": "The member role. Can be multiple specified by index.",
+      "type": "string",
+      "enum": ["notary", "member"],
+      "examples": [
+        "notary"
+      ]
+    }
+  },
   "properties": {
     "corda.key.scheme": {
       "description": "The key scheme to use when generating keys for a static member. Available key schemes are obtainable through the Keys HTTP API.",
       "type": "string",
       "examples": [
         "CORDA.ECDSA.SECP256R1"
+      ]
+    },
+    "corda.notary.service.name": {
+      "description": "The notary service X500 name. Valid only when one of the roles is notary.",
+      "type": "string",
+      "minLength": 3,
+      "examples": [
+        "O=NotaryService, L=London, C=GB"
+      ]
+    },
+    "corda.notary.service.plugin": {
+      "description": "The notary plugin type (FQN of notary service plugin class). Valid only when one of the roles is notary.",
+      "type": "string",
+      "pattern": "^(([a-zA-Z][a-zA-Z_$0-9]*(\\.[a-zA-Z][a-zA-Z_$0-9]*)*)\\.)?([a-zA-Z][a-zA-Z_$0-9]*)$",
+      "examples": [
+        "net.corda.notary.MyNotaryService"
       ]
     }
   },

--- a/data/membership-schema/src/main/resources/net/corda/schema/membership/member/static/registration/1.0/corda.member.static.registration.json
+++ b/data/membership-schema/src/main/resources/net/corda/schema/membership/member/static/registration/1.0/corda.member.static.registration.json
@@ -6,9 +6,9 @@
   "type": "object",
   "patternProperties": {
     "^corda.roles.[0-9]+$": {
-      "description": "The member role. Can be multiple specified by index.",
+      "description": "The member roles. Can be multiple specified by index.",
       "type": "string",
-      "enum": ["notary", "member"],
+      "enum": ["notary"],
       "examples": [
         "notary"
       ]

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 407
+cordaApiRevision = 411
 
 # Main
 kotlinVersion = 1.7.10


### PR DESCRIPTION
Adds optional notary details and roles to the static registration context.

 Runtime PR in https://github.com/corda/corda-runtime-os/pull/2264