### PR TITLE
CORE-6894: generate SBOM on nightly run of CI

### DIFF
--- a/.ci/nightly/JenkinsfileNightly
+++ b/.ci/nightly/JenkinsfileNightly
@@ -1,7 +1,9 @@
 @Library('corda-shared-build-pipeline-steps@5.0') _
 
-cordaNightlyPipeline(
+cordaPipeline(
     nexusAppId: 'net.corda-api-5.0',
     runIntegrationTests: false,
-    dailyBuildCron: 'H 02 * * *'
+    dailyBuildCron: 'H 02 * * *',
+    gradleAdditionalArgs: '-Dscan.tag.Nightly-Build',
+    generateSbom: true
     )


### PR DESCRIPTION
follow on from the following changes to generate a software Bill of Materials as part of our CI system if certain conditions are met

https://github.com/corda/corda-shared-build-pipeline-steps/pull/360
https://github.com/corda/corda-shared-build-pipeline-steps/pull/358

also use cordaPipeline file (we are retiring cordaNightlyPipeline), ensure correct Gradle tagging is passed for Gradle Enterprise filtering.

Nightly Changes tested here:
https://ci02.dev.r3.com/job/Corda5/view/Corda%205%20Nightly%20Jobs/job/Nightlys/job/Corda-API/job/Linux/job/release%252Fos%252F5.0/308/
