### PR TITLE
CORE-6991 Add schemas for group parameters persistence

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/request/MembershipPersistenceRequest.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/request/MembershipPersistenceRequest.avsc
@@ -16,6 +16,7 @@
         "net.corda.data.membership.db.request.command.PersistMemberInfo",
         "net.corda.data.membership.db.request.command.PersistGroupPolicy",
         "net.corda.data.membership.db.request.command.PersistGroupParameters",
+        "net.corda.data.membership.db.request.command.PersistGroupParametersInitialSnapshot",
         "net.corda.data.membership.db.request.command.AddNotaryToGroupParameters",
         "net.corda.data.membership.db.request.command.UpdateMemberAndRegistrationRequestToApproved",
         "net.corda.data.membership.db.request.command.UpdateMemberAndRegistrationRequestToDeclined",

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/request/MembershipPersistenceRequest.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/request/MembershipPersistenceRequest.avsc
@@ -15,6 +15,8 @@
         "net.corda.data.membership.db.request.command.PersistRegistrationRequest",
         "net.corda.data.membership.db.request.command.PersistMemberInfo",
         "net.corda.data.membership.db.request.command.PersistGroupPolicy",
+        "net.corda.data.membership.db.request.command.PersistGroupParameters",
+        "net.corda.data.membership.db.request.command.AddNotaryToGroupParameters",
         "net.corda.data.membership.db.request.command.UpdateMemberAndRegistrationRequestToApproved",
         "net.corda.data.membership.db.request.command.UpdateMemberAndRegistrationRequestToDeclined",
         "net.corda.data.membership.db.request.command.UpdateRegistrationRequestStatus",

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/request/command/AddNotaryToGroupParameters.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/request/command/AddNotaryToGroupParameters.avsc
@@ -1,0 +1,13 @@
+{
+  "type": "record",
+  "name": "AddNotaryToGroupParameters",
+  "namespace": "net.corda.data.membership.db.request.command",
+  "doc": "Add a notary virtual node to the notary service in an existing set of group parameters.",
+  "fields": [
+    {
+      "name": "notary",
+      "doc": "Notary virtual node to be added to the group parameters",
+      "type": "net.corda.data.membership.PersistentMemberInfo"
+    }
+  ]
+}

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/request/command/PersistGroupParameters.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/request/command/PersistGroupParameters.avsc
@@ -2,7 +2,7 @@
   "type": "record",
   "name": "PersistGroupParameters",
   "namespace": "net.corda.data.membership.db.request.command",
-  "doc": "Persist a new set or update an existing set of group parameters.",
+  "doc": "Persist a new set or update an existing set of group parameters as distributed by the MGM.",
   "fields": [
     {
       "name": "groupParameters",

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/request/command/PersistGroupParameters.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/request/command/PersistGroupParameters.avsc
@@ -1,0 +1,13 @@
+{
+  "type": "record",
+  "name": "PersistGroupParameters",
+  "namespace": "net.corda.data.membership.db.request.command",
+  "doc": "Persist a new set or update an existing set of group parameters.",
+  "fields": [
+    {
+      "name": "groupParameters",
+      "doc": "Parameters which all group members agree to abide by",
+      "type": "net.corda.data.KeyValuePairList"
+    }
+  ]
+}

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/request/command/PersistGroupParametersInitialSnapshot.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/request/command/PersistGroupParametersInitialSnapshot.avsc
@@ -1,0 +1,7 @@
+{
+  "type": "record",
+  "name": "PersistGroupParametersInitialSnapshot",
+  "namespace": "net.corda.data.membership.db.request.command",
+  "doc": "MGM command to create and persist a new set of group parameters.",
+  "fields": []
+}

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/response/MembershipPersistenceResponse.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/response/MembershipPersistenceResponse.avsc
@@ -15,6 +15,7 @@
         "null",
         "net.corda.data.membership.db.response.query.MemberInfoQueryResponse",
         "net.corda.data.membership.db.response.command.PersistGroupPolicyResponse",
+        "net.corda.data.membership.db.response.command.PersistGroupParametersResponse",
         "net.corda.data.membership.db.response.query.RegistrationRequestQueryResponse",
         "net.corda.data.membership.db.response.query.RegistrationRequestsQueryResponse",
         "net.corda.data.membership.db.response.query.PersistenceFailedResponse",

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/response/command/PersistGroupParametersResponse.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/response/command/PersistGroupParametersResponse.avsc
@@ -1,0 +1,13 @@
+{
+  "type": "record",
+  "name": "PersistGroupParametersResponse",
+  "namespace": "net.corda.data.membership.db.response.command",
+  "doc": "Response to a persist group parameters request",
+  "fields": [
+    {
+      "name": "epoch",
+      "doc": "The version of the persisted set of group parameters.",
+      "type": "int"
+    }
+  ]
+}

--- a/data/db-schema/src/main/kotlin/net/corda/db/schema/DbSchema.kt
+++ b/data/db-schema/src/main/kotlin/net/corda/db/schema/DbSchema.kt
@@ -29,6 +29,7 @@ object DbSchema {
     const val VNODE_MEMBER_INFO = "vnode_member_info"
     const val VNODE_GROUP_POLICY = "vnode_group_policy"
     const val VNODE_MEMBER_SIGNATURE = "vnode_member_signature"
+    const val VNODE_GROUP_PARAMETERS = "vnode_group_parameters"
 
     const val LEDGER_CONSENSUAL_TRANSACTION_TABLE = "consensual_transaction"
     const val LEDGER_CONSENSUAL_TRANSACTION_STATUS_TABLE = "consensual_transaction_status"

--- a/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/vnode-vault-creation-v1.0.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/vnode-vault-creation-v1.0.xml
@@ -107,11 +107,8 @@
                        tableName="vnode_member_signature"/>
 
         <createTable tableName="vnode_group_parameters">
-            <column name="epoch" type="INT" autoIncrement="true">
+            <column name="epoch" type="INT">
                 <constraints nullable="false" primaryKey="true"/>
-            </column>
-            <column name="last_modified" type="TIMESTAMP">
-                <constraints nullable="false"/>
             </column>
             <column name="parameters" type="VARBINARY(1048576)">
                 <constraints nullable="false"/>

--- a/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/vnode-vault-creation-v1.0.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/vnode-vault-creation-v1.0.xml
@@ -105,5 +105,17 @@
         <addPrimaryKey columnNames="group_id, member_name"
                        constraintName="vnode_member_signature_pkey"
                        tableName="vnode_member_signature"/>
+
+        <createTable tableName="vnode_group_parameters">
+            <column name="epoch" type="INT" autoIncrement="true">
+                <constraints nullable="false" primaryKey="true"/>
+            </column>
+            <column name="last_modified" type="TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="parameters" type="VARBINARY(1048576)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
     </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
https://r3-cev.atlassian.net/browse/CORE-6991
runtime-os PR : https://github.com/corda/corda-runtime-os/pull/2284
Adds new avro schemas for MembershipPersistenceRequest (PersistGroupParametersInitialSnapshot, PersistGroupParameters, AddNotaryToGroupParameters), MembershipPersistenceResponse, and DB schema for `vnode_group_parameters`.