### PR TITLE
CORE-6391: Make notary info not inherit the layter property map

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 413
+cordaApiRevision = 414
 
 # Main
 kotlinVersion = 1.7.10

--- a/membership/src/main/kotlin/net/corda/v5/membership/NotaryInfo.kt
+++ b/membership/src/main/kotlin/net/corda/v5/membership/NotaryInfo.kt
@@ -1,14 +1,13 @@
 package net.corda.v5.membership
 
 import net.corda.v5.base.annotations.CordaSerializable
-import net.corda.v5.base.types.LayeredPropertyMap
 import net.corda.v5.base.types.MemberX500Name
 
 /**
  * Stores information about a notary service available in the network.
  */
 @CordaSerializable
-interface NotaryInfo : LayeredPropertyMap {
+interface NotaryInfo {
     /**
      * Identity of the notary (note that it can be an identity of the distributed node).
      *


### PR DESCRIPTION
Runtime PR https://github.com/corda/corda-runtime-os/pull/2307