### PR TITLE
CORE-5091 Consensual Transaction signing improvements

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 416
+cordaApiRevision = 417
 
 # Main
 kotlinVersion = 1.7.10

--- a/ledger/ledger-consensual/src/main/kotlin/net/corda/v5/ledger/consensual/ConsensualLedgerService.kt
+++ b/ledger/ledger-consensual/src/main/kotlin/net/corda/v5/ledger/consensual/ConsensualLedgerService.kt
@@ -20,8 +20,6 @@ interface ConsensualLedgerService {
 
     /* TODO
     fun fetchTransaction(id: SecureHash)
-    fun finality(sessions)
-    fun receiveFinality( ()-> ... )
     ... Vault ...
     */
 

--- a/ledger/ledger-consensual/src/main/kotlin/net/corda/v5/ledger/consensual/transaction/ConsensualSignedTransaction.kt
+++ b/ledger/ledger-consensual/src/main/kotlin/net/corda/v5/ledger/consensual/transaction/ConsensualSignedTransaction.kt
@@ -62,6 +62,19 @@ interface ConsensualSignedTransaction {
      */
     fun addSignature(signature: DigitalSignatureAndMetadata): ConsensualSignedTransaction
 
+
+    /**
+     * Crosschecks the missing signatures with the available keys and signs the transaction with their intersection
+     * if there are any. (Disabled until crypto support becomes available.)
+     *
+     * @return Returns a new [ConsensualSignedTransaction] containing the new signature.
+     *
+    @Suspendable
+     * @return Returns the new [ConsensualSignedTransaction] containing the applied signature and a
+     *          list of added signatures.
+    fun addMissingSignatures(): Pair(ConsensualSignedTransaction, list<DigitalSignatureAndMetadata>)
+    */
+
     /**
      * Gets the signing keys for any missing transaction signatures.
      *

--- a/ledger/ledger-consensual/src/main/kotlin/net/corda/v5/ledger/consensual/transaction/ConsensualSignedTransaction.kt
+++ b/ledger/ledger-consensual/src/main/kotlin/net/corda/v5/ledger/consensual/transaction/ConsensualSignedTransaction.kt
@@ -85,7 +85,7 @@ interface ConsensualSignedTransaction {
     /**
      * Verify all available signatures and whether there are any missing ones.
      *
-     * @throws TransactionVerificationException in both cases.
+     * @throws TransactionVerificationException if any signatures are invalid or missing.
      */
     fun verifySignatureValidity()
 }

--- a/ledger/ledger-consensual/src/main/kotlin/net/corda/v5/ledger/consensual/transaction/ConsensualSignedTransaction.kt
+++ b/ledger/ledger-consensual/src/main/kotlin/net/corda/v5/ledger/consensual/transaction/ConsensualSignedTransaction.kt
@@ -3,6 +3,7 @@ package net.corda.v5.ledger.consensual.transaction
 import java.security.PublicKey
 import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.base.annotations.DoNotImplement
+import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.crypto.SecureHash
 
 /**
@@ -49,12 +50,13 @@ interface ConsensualSignedTransaction {
      *      [ConsensualSignedTransaction].
      * @return Returns a new [ConsensualSignedTransaction] containing the applied signature.
      */
+    @Suspendable
     fun sign(publicKey: PublicKey): ConsensualSignedTransaction
 
     /**
      * Adds a signature to the current [ConsensualSignedTransaction].
      *
-     * @param signature The signature tobe added to the [ConsensualSignedTransaction].
+     * @param signature The signature to be added to the [ConsensualSignedTransaction].
      *
      * @return Returns a new [ConsensualSignedTransaction] containing the new signature.
      */

--- a/ledger/ledger-consensual/src/main/kotlin/net/corda/v5/ledger/consensual/transaction/ConsensualSignedTransaction.kt
+++ b/ledger/ledger-consensual/src/main/kotlin/net/corda/v5/ledger/consensual/transaction/ConsensualSignedTransaction.kt
@@ -49,7 +49,16 @@ interface ConsensualSignedTransaction {
      *      [ConsensualSignedTransaction].
      * @return Returns a new [ConsensualSignedTransaction] containing the applied signature.
      */
-    fun addSignature(publicKey: PublicKey): ConsensualSignedTransaction
+    fun sign(publicKey: PublicKey): ConsensualSignedTransaction
+
+    /**
+     * Adds a signature to the current [ConsensualSignedTransaction].
+     *
+     * @param signature The signature tobe added to the [ConsensualSignedTransaction].
+     *
+     * @return Returns a new [ConsensualSignedTransaction] containing the new signature.
+     */
+    fun addSignature(signature: DigitalSignatureAndMetadata): ConsensualSignedTransaction
 
     /**
      * Gets the signing keys for any missing transaction signatures.

--- a/ledger/ledger-consensual/src/main/kotlin/net/corda/v5/ledger/consensual/transaction/ConsensualSignedTransaction.kt
+++ b/ledger/ledger-consensual/src/main/kotlin/net/corda/v5/ledger/consensual/transaction/ConsensualSignedTransaction.kt
@@ -87,7 +87,7 @@ interface ConsensualSignedTransaction {
      *
      * @throws TransactionVerificationException if any signatures are invalid or missing.
      */
-    fun verifySignatureValidity()
+    fun verifySignatures()
 }
 
 

--- a/ledger/ledger-consensual/src/main/kotlin/net/corda/v5/ledger/consensual/transaction/ConsensualSignedTransaction.kt
+++ b/ledger/ledger-consensual/src/main/kotlin/net/corda/v5/ledger/consensual/transaction/ConsensualSignedTransaction.kt
@@ -60,8 +60,8 @@ interface ConsensualSignedTransaction {
      *
      * @return Returns a new [ConsensualSignedTransaction] containing the new signature.
      */
+    @Suspendable
     fun addSignature(signature: DigitalSignatureAndMetadata): ConsensualSignedTransaction
-
 
     /**
      * Crosschecks the missing signatures with the available keys and signs the transaction with their intersection
@@ -80,6 +80,7 @@ interface ConsensualSignedTransaction {
      *
      * @return Returns a [Set] of [PublicKey] representing the signing keys for any missing transaction signatures.
      */
+    @Suspendable
     fun getMissingSigningKeys(): Set<PublicKey>
 
     /**
@@ -87,6 +88,7 @@ interface ConsensualSignedTransaction {
      *
      * @throws TransactionVerificationException if any signatures are invalid or missing.
      */
+    @Suspendable
     fun verifySignatures()
 }
 

--- a/ledger/ledger-consensual/src/main/kotlin/net/corda/v5/ledger/consensual/transaction/ConsensualSignedTransaction.kt
+++ b/ledger/ledger-consensual/src/main/kotlin/net/corda/v5/ledger/consensual/transaction/ConsensualSignedTransaction.kt
@@ -81,6 +81,13 @@ interface ConsensualSignedTransaction {
      * @return Returns a [Set] of [PublicKey] representing the signing keys for any missing transaction signatures.
      */
     fun getMissingSigningKeys(): Set<PublicKey>
+
+    /**
+     * Verify all available signatures and whether there are any missing ones.
+     *
+     * @throws TransactionVerificationException in both cases.
+     */
+    fun verifySignatureValidity()
 }
 
 

--- a/ledger/ledger-consensual/src/main/kotlin/net/corda/v5/ledger/consensual/transaction/ConsensualSignedTransaction.kt
+++ b/ledger/ledger-consensual/src/main/kotlin/net/corda/v5/ledger/consensual/transaction/ConsensualSignedTransaction.kt
@@ -48,10 +48,10 @@ interface ConsensualSignedTransaction {
      *
      * @param publicKey The private counterpart of the specified public key will be used for signing the
      *      [ConsensualSignedTransaction].
-     * @return Returns a new [ConsensualSignedTransaction] containing the applied signature.
+     * @return Returns the new [ConsensualSignedTransaction] containing the applied signature and the signature itself.
      */
     @Suspendable
-    fun sign(publicKey: PublicKey): ConsensualSignedTransaction
+    fun addSignature(publicKey: PublicKey): Pair<ConsensualSignedTransaction, DigitalSignatureAndMetadata>
 
     /**
      * Adds a signature to the current [ConsensualSignedTransaction].

--- a/ledger/ledger-consensual/src/main/kotlin/net/corda/v5/ledger/consensual/transaction/ConsensualTransactionBuilder.kt
+++ b/ledger/ledger-consensual/src/main/kotlin/net/corda/v5/ledger/consensual/transaction/ConsensualTransactionBuilder.kt
@@ -28,21 +28,49 @@ interface ConsensualTransactionBuilder {
     fun withStates(vararg states: ConsensualState) : ConsensualTransactionBuilder
 
     /**
-     * 1. Verifies the content of the [ConsensualTransactionBuilder]
-     * 2.a Creates
-     * 2.b signs
-     * 2.c and returns a [ConsensualSignedTransaction]
+     * Verifies the content of the [ConsensualTransactionBuilder] and
+     * signs the transaction with any required signatories that belong to the current node.
      *
      * Calling this function once consumes the [ConsensualTransactionBuilder], so it cannot be used again.
      * Therefore, if you want to build two transactions you need two builders.
      *
-     * @param publicKey The private counterpart of the specified public key will be used for signing the
-     *      [ConsensualSignedTransaction].
-     * @return Returns a new [ConsensualSignedTransaction] with the specified details.
+     * @return Returns a [ConsensualSignedTransaction] with signatures for any required signatories that belong to the current node.
      *
      * @throws [UnsupportedOperationException] when called second time on the same object to prevent duplicate
      *      transactions accidentally.
      */
     @Suspendable
-    fun sign(publicKey: PublicKey): ConsensualSignedTransaction
+    fun sign(): ConsensualSignedTransaction
+
+    /**
+     * Verifies the content of the [ConsensualTransactionBuilder] and
+     * signs the transaction with the specified signatory keys.
+     *
+     * Calling this function once consumes the [ConsensualTransactionBuilder], so it cannot be used again.
+     * Therefore, if you want to build two transactions you need two builders.
+     *
+     * @param signatories The signatories expected to sign the current transaction.
+     * @return Returns a [ConsensualSignedTransaction] with signatures for the specified signatory keys.
+     *
+     * @throws [UnsupportedOperationException] when called second time on the same object to prevent duplicate
+     *      transactions accidentally.
+     */
+    @Suspendable
+    fun sign(signatories: Iterable<PublicKey>): ConsensualSignedTransaction
+
+    /**
+     * Verifies the content of the [ConsensualTransactionBuilder] and
+     * signs the transaction with the specified signatory keys.
+     *
+     * Calling this function once consumes the [ConsensualTransactionBuilder], so it cannot be used again.
+     * Therefore, if you want to build two transactions you need two builders.
+     *
+     * @param signatories The signatories expected to sign the current transaction.
+     * @return Returns a [ConsensualSignedTransaction] with signatures for the specified signatory keys.
+     *
+     * @throws [UnsupportedOperationException] when called second time on the same object to prevent duplicate
+     *      transactions accidentally.
+     */
+    @Suspendable
+    fun sign(vararg signatories: PublicKey): ConsensualSignedTransaction
 }

--- a/ledger/ledger-consensual/src/main/kotlin/net/corda/v5/ledger/consensual/transaction/ConsensualTransactionBuilder.kt
+++ b/ledger/ledger-consensual/src/main/kotlin/net/corda/v5/ledger/consensual/transaction/ConsensualTransactionBuilder.kt
@@ -44,5 +44,5 @@ interface ConsensualTransactionBuilder {
      *      transactions accidentally.
      */
     @Suspendable
-    fun signInitial(publicKey: PublicKey): ConsensualSignedTransaction
+    fun sign(publicKey: PublicKey): ConsensualSignedTransaction
 }

--- a/ledger/ledger-consensual/src/test/java/net/corda/v5/ledger/consensual/transaction/ConsensualSignedTransactionJavaApiTest.java
+++ b/ledger/ledger-consensual/src/test/java/net/corda/v5/ledger/consensual/transaction/ConsensualSignedTransactionJavaApiTest.java
@@ -60,16 +60,28 @@ public class ConsensualSignedTransactionJavaApiTest {
     }
 
     @Test
-    public void addSignature() {
+    public void sign() {
         PublicKey mockPublicKey = mock(PublicKey.class);
         final ConsensualSignedTransaction consensualSignedTransaction = mock(ConsensualSignedTransaction.class);
-        when(consensualSignedTransaction.addSignature(mockPublicKey)).thenReturn(consensualSignedTransaction);
+        when(consensualSignedTransaction.sign(mockPublicKey)).thenReturn(consensualSignedTransaction);
 
-        final ConsensualSignedTransaction result = consensualSignedTransaction.addSignature(mockPublicKey);
+        final ConsensualSignedTransaction result = consensualSignedTransaction.sign(mockPublicKey);
 
         Assertions.assertThat(result).isNotNull();
         Assertions.assertThat(result).isEqualTo(consensualSignedTransaction);
-        verify(consensualSignedTransaction, times(1)).addSignature(mockPublicKey);
+        verify(consensualSignedTransaction, times(1)).sign(mockPublicKey);
+    }
+
+    @Test
+    public void addSignature() {
+        final ConsensualSignedTransaction consensualSignedTransaction = mock(ConsensualSignedTransaction.class);
+        when(consensualSignedTransaction.addSignature(signatureWithMetaData)).thenReturn(consensualSignedTransaction);
+
+        final ConsensualSignedTransaction result = consensualSignedTransaction.addSignature(signatureWithMetaData);
+
+        Assertions.assertThat(result).isNotNull();
+        Assertions.assertThat(result).isEqualTo(consensualSignedTransaction);
+        verify(consensualSignedTransaction, times(1)).addSignature(signatureWithMetaData);
     }
 
     @Test

--- a/ledger/ledger-consensual/src/test/java/net/corda/v5/ledger/consensual/transaction/ConsensualSignedTransactionJavaApiTest.java
+++ b/ledger/ledger-consensual/src/test/java/net/corda/v5/ledger/consensual/transaction/ConsensualSignedTransactionJavaApiTest.java
@@ -1,5 +1,6 @@
 package net.corda.v5.ledger.consensual.transaction;
 
+import kotlin.Pair;
 import net.corda.v5.application.crypto.DigitalSignatureAndMetadata;
 import net.corda.v5.application.crypto.DigitalSignatureMetadata;
 import net.corda.v5.crypto.DigitalSignature;
@@ -60,20 +61,21 @@ public class ConsensualSignedTransactionJavaApiTest {
     }
 
     @Test
-    public void sign() {
+    public void addSignaturePublicKey() {
         PublicKey mockPublicKey = mock(PublicKey.class);
         final ConsensualSignedTransaction consensualSignedTransaction = mock(ConsensualSignedTransaction.class);
-        when(consensualSignedTransaction.sign(mockPublicKey)).thenReturn(consensualSignedTransaction);
+        Pair<ConsensualSignedTransaction, DigitalSignatureAndMetadata> expectedResult = new Pair(consensualSignedTransaction, signatureWithMetaData);
+        when(consensualSignedTransaction.addSignature(mockPublicKey)).thenReturn(expectedResult);
 
-        final ConsensualSignedTransaction result = consensualSignedTransaction.sign(mockPublicKey);
+        final Pair<ConsensualSignedTransaction, DigitalSignatureAndMetadata> result = consensualSignedTransaction.addSignature(mockPublicKey);
 
         Assertions.assertThat(result).isNotNull();
-        Assertions.assertThat(result).isEqualTo(consensualSignedTransaction);
-        verify(consensualSignedTransaction, times(1)).sign(mockPublicKey);
+        Assertions.assertThat(result).isEqualTo(expectedResult);
+        verify(consensualSignedTransaction, times(1)).addSignature(mockPublicKey);
     }
 
     @Test
-    public void addSignature() {
+    public void addSignatureSignature() {
         final ConsensualSignedTransaction consensualSignedTransaction = mock(ConsensualSignedTransaction.class);
         when(consensualSignedTransaction.addSignature(signatureWithMetaData)).thenReturn(consensualSignedTransaction);
 

--- a/ledger/ledger-consensual/src/test/java/net/corda/v5/ledger/consensual/transaction/ConsensualTransactionBuilderJavaApiTest.java
+++ b/ledger/ledger-consensual/src/test/java/net/corda/v5/ledger/consensual/transaction/ConsensualTransactionBuilderJavaApiTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 
 import java.security.PublicKey;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -67,7 +68,18 @@ public class ConsensualTransactionBuilderJavaApiTest {
 
 
     @Test
-    public void signInitial() {
+    public void signWithZeroKey() {
+        final ConsensualSignedTransaction mockSignedTransaction = mock(ConsensualSignedTransaction.class);
+        when(consensualTransactionBuilder.sign()).thenReturn(mockSignedTransaction);
+
+        final ConsensualSignedTransaction result = consensualTransactionBuilder.sign();
+
+        Assertions.assertThat(result).isNotNull();
+        Assertions.assertThat(result).isEqualTo(mockSignedTransaction);
+        verify(consensualTransactionBuilder, times(1)).sign();
+    }
+    @Test
+    public void signWithOneKey() {
         final PublicKey publicKey = mock(PublicKey.class);
         final ConsensualSignedTransaction mockSignedTransaction = mock(ConsensualSignedTransaction.class);
         when(consensualTransactionBuilder.sign(publicKey)).thenReturn(mockSignedTransaction);
@@ -78,4 +90,31 @@ public class ConsensualTransactionBuilderJavaApiTest {
         Assertions.assertThat(result).isEqualTo(mockSignedTransaction);
         verify(consensualTransactionBuilder, times(1)).sign(publicKey);
     }
+    @Test
+    public void signWithTwoKeys() {
+        final PublicKey publicKey1 = mock(PublicKey.class);
+        final PublicKey publicKey2 = mock(PublicKey.class);
+        final ConsensualSignedTransaction mockSignedTransaction = mock(ConsensualSignedTransaction.class);
+        when(consensualTransactionBuilder.sign(publicKey1, publicKey2)).thenReturn(mockSignedTransaction);
+
+        final ConsensualSignedTransaction result = consensualTransactionBuilder.sign(publicKey1, publicKey2);
+
+        Assertions.assertThat(result).isNotNull();
+        Assertions.assertThat(result).isEqualTo(mockSignedTransaction);
+        verify(consensualTransactionBuilder, times(1)).sign(publicKey1, publicKey2);
+    }
+    @Test
+    public void signWithListOfKeys() {
+        final List<PublicKey> publicKeyList = Arrays.asList(mock(PublicKey.class), mock(PublicKey.class));
+        final ConsensualSignedTransaction mockSignedTransaction = mock(ConsensualSignedTransaction.class);
+        when(consensualTransactionBuilder.sign(publicKeyList)).thenReturn(mockSignedTransaction);
+
+        final ConsensualSignedTransaction result = consensualTransactionBuilder.sign(publicKeyList);
+
+        Assertions.assertThat(result).isNotNull();
+        Assertions.assertThat(result).isEqualTo(mockSignedTransaction);
+        verify(consensualTransactionBuilder, times(1)).sign(publicKeyList);
+    }
+
+
 }

--- a/ledger/ledger-consensual/src/test/java/net/corda/v5/ledger/consensual/transaction/ConsensualTransactionBuilderJavaApiTest.java
+++ b/ledger/ledger-consensual/src/test/java/net/corda/v5/ledger/consensual/transaction/ConsensualTransactionBuilderJavaApiTest.java
@@ -70,12 +70,12 @@ public class ConsensualTransactionBuilderJavaApiTest {
     public void signInitial() {
         final PublicKey publicKey = mock(PublicKey.class);
         final ConsensualSignedTransaction mockSignedTransaction = mock(ConsensualSignedTransaction.class);
-        when(consensualTransactionBuilder.signInitial(publicKey)).thenReturn(mockSignedTransaction);
+        when(consensualTransactionBuilder.sign(publicKey)).thenReturn(mockSignedTransaction);
 
-        final ConsensualSignedTransaction result = consensualTransactionBuilder.signInitial(publicKey);
+        final ConsensualSignedTransaction result = consensualTransactionBuilder.sign(publicKey);
 
         Assertions.assertThat(result).isNotNull();
         Assertions.assertThat(result).isEqualTo(mockSignedTransaction);
-        verify(consensualTransactionBuilder, times(1)).signInitial(publicKey);
+        verify(consensualTransactionBuilder, times(1)).sign(publicKey);
     }
 }

--- a/ledger/ledger-utxo/src/main/kotlin/net/corda/v5/ledger/utxo/transaction/UtxoSignedTransaction.kt
+++ b/ledger/ledger-utxo/src/main/kotlin/net/corda/v5/ledger/utxo/transaction/UtxoSignedTransaction.kt
@@ -3,6 +3,7 @@ package net.corda.v5.ledger.utxo.transaction
 import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.base.annotations.CordaSerializable
 import net.corda.v5.base.annotations.DoNotImplement
+import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.crypto.SecureHash
 import java.security.PublicKey
 
@@ -25,6 +26,7 @@ interface UtxoSignedTransaction {
      * @param signatures The signatures and metadata to add to the current [UtxoSignedTransaction].
      * @return Returns a new [UtxoSignedTransaction] containing the applied signatures.
      */
+    @Suspendable
     fun addSignatures(signatures: Iterable<DigitalSignatureAndMetadata>): UtxoSignedTransaction
 
     /**
@@ -33,6 +35,7 @@ interface UtxoSignedTransaction {
      * @param signatures The signatures and metadata to add to the current [UtxoSignedTransaction].
      * @return Returns a new [UtxoSignedTransaction] containing the applied signature.
      */
+    @Suspendable
     fun addSignatures(vararg signatures: DigitalSignatureAndMetadata): UtxoSignedTransaction
 
     /**
@@ -40,6 +43,7 @@ interface UtxoSignedTransaction {
      *
      * @return Returns a [List] of [PublicKey] representing the missing signatories from the current [UtxoSignedTransaction].
      */
+    @Suspendable
     fun getMissingSignatories(): List<PublicKey>
 
     /**

--- a/ledger/ledger-utxo/src/main/kotlin/net/corda/v5/ledger/utxo/transaction/UtxoTransactionBuilder.kt
+++ b/ledger/ledger-utxo/src/main/kotlin/net/corda/v5/ledger/utxo/transaction/UtxoTransactionBuilder.kt
@@ -2,6 +2,7 @@ package net.corda.v5.ledger.utxo.transaction
 
 import net.corda.v5.base.annotations.CordaSerializable
 import net.corda.v5.base.annotations.DoNotImplement
+import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.crypto.SecureHash
 import net.corda.v5.ledger.common.Party
 import net.corda.v5.ledger.utxo.Command
@@ -127,6 +128,7 @@ interface UtxoTransactionBuilder {
      *
      * @return Returns a [UtxoSignedTransaction] with signatures for any required signatories that belong to the current node.
      */
+    @Suspendable
     fun sign(): UtxoSignedTransaction
 
     /**
@@ -135,6 +137,7 @@ interface UtxoTransactionBuilder {
      * @param signatories The signatories expected to sign the current transaction.
      * @return Returns a [UtxoSignedTransaction] with signatures for the specified signatory keys.
      */
+    @Suspendable
     fun sign(signatories: Iterable<PublicKey>): UtxoSignedTransaction
 
     /**
@@ -143,5 +146,6 @@ interface UtxoTransactionBuilder {
      * @param signatories The signatories expected to sign the current transaction.
      * @return Returns a [UtxoSignedTransaction] with signatures for the specified signatory keys.
      */
+    @Suspendable
     fun sign(vararg signatories: PublicKey): UtxoSignedTransaction
 }


### PR DESCRIPTION
* Overload `ConsensualSignedTransaction.addSignature()` accepts signatures now
* Its `PublicKey` signer part returns a `Pair(newTx, newSignature)`
* `ConsensualSignedTransaction.verifySignatures()`
* Rename `ConsensualTransactionBuilder.signInitial()` to `ConsensualTransactionBuilder.sign()` to be consistent with its utxo counterpart
* Some `@Suspendable`s for Utxo signing methods.

Its runtime-os counterpart: https://github.com/corda/corda-runtime-os/pull/2305