### PR TITLE
CORE-7151: Retire JenkinsfileNightlyARM64 file

### DIFF
--- a/.ci/nightly/JenkinsfileNightlyARM64
+++ b/.ci/nightly/JenkinsfileNightlyARM64
@@ -1,8 +1,0 @@
-@Library('corda-shared-build-pipeline-steps@5.0') _
-
-cordaNightlyPipeline(
-    nexusAppId: 'net.corda-api-5.0',
-    runIntegrationTests: false,
-    dailyBuildCron: 'H 01 * * *',
-    linuxArch: 'arm64'
-    )


### PR DESCRIPTION
* Remove Jenkins file JenkinsfileNightlyARM64 from repo

👮🏻👮🏻👮🏻 !!!! DESCRIBE YOUR CHANGES HERE !!!! DO NOT FORGET !!!! 👮🏻👮🏻👮🏻


# PR Checklist:

- [x] Have you run the unit, integration and smoke tests as described [here](https://docs.corda.net/head/testing.html)?
- [x] If you added public APIs, did you write the JavaDocs?
- [x] If the changes are of interest to application developers, have you added them to the [changelog](https://docs.corda.net/head/changelog.html) (`/docs/source/changelog.rst`), and potentially the [release notes](https://docs.corda.net/head/release-notes.html) (`/docs/source/release-notes.rst`)?
- [x] If you are contributing for the first time, please read the [contributor agreement](https://docs.corda.net/head/contributing.html) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://docs.corda.net/head/contributing.html#merging-the-changes-back-into-corda).

Thanks for your code, it's appreciated! :)
