### PR TITLE
CORE-7169 Use public keys instead of parties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 417
+cordaApiRevision = 418
 
 # Main
 kotlinVersion = 1.7.10

--- a/ledger/ledger-consensual/src/main/kotlin/net/corda/v5/ledger/consensual/ConsensualState.kt
+++ b/ledger/ledger-consensual/src/main/kotlin/net/corda/v5/ledger/consensual/ConsensualState.kt
@@ -1,8 +1,8 @@
 package net.corda.v5.ledger.consensual
 
 import net.corda.v5.base.annotations.CordaSerializable
-import net.corda.v5.ledger.common.Party
 import net.corda.v5.ledger.consensual.transaction.ConsensualLedgerTransaction
+import java.security.PublicKey
 
 /**
  * A consensual state (or just "state") contains opaque data used by a consensual ledger. It can be thought of as a disk
@@ -22,7 +22,7 @@ interface ConsensualState {
      *
      * The participants list should normally be derived from the contents of the state.
      */
-    val participants: List<Party>
+    val participants: List<PublicKey>
 
     /**
      * An override of this function needs to be provided to:

--- a/ledger/ledger-consensual/src/test/java/net/corda/v5/ledger/consensual/ConsensualStateJavaApiTest.java
+++ b/ledger/ledger-consensual/src/test/java/net/corda/v5/ledger/consensual/ConsensualStateJavaApiTest.java
@@ -1,7 +1,5 @@
 package net.corda.v5.ledger.consensual;
 
-import net.corda.v5.base.types.MemberX500Name;
-import net.corda.v5.ledger.common.Party;
 import net.corda.v5.ledger.consensual.transaction.ConsensualLedgerTransaction;
 import org.assertj.core.api.Assertions;
 import org.jetbrains.annotations.NotNull;
@@ -10,21 +8,23 @@ import org.junit.jupiter.api.Test;
 import java.security.PublicKey;
 import java.util.List;
 
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class ConsensualStateJavaApiTest {
 
-    private final MemberX500Name name = new MemberX500Name("Bob Plc", "Rome", "IT");
     private final PublicKey key = mock(PublicKey.class);
-    private final Party party = new Party(name, key);
-    private final List<Party> participants = List.of(party);
+    private final List<PublicKey> participants = List.of(key);
     private final ConsensualState consensualState = mock(ConsensualState.class);
 
     @Test
     public void participants() {
         when(consensualState.getParticipants()).thenReturn(participants);
 
-        final List<Party> result = consensualState.getParticipants();
+        final List<PublicKey> result = consensualState.getParticipants();
 
         Assertions.assertThat(result).isNotNull();
         Assertions.assertThat(result).isEqualTo(participants);
@@ -50,15 +50,15 @@ public class ConsensualStateJavaApiTest {
     }
 
     class CustomConsensualState implements ConsensualState {
-        private final List<Party> participants;
+        private final List<PublicKey> participants;
 
-        public CustomConsensualState(List<Party> participants) {
+        public CustomConsensualState(List<PublicKey> participants) {
             this.participants = participants;
         }
 
         @NotNull
         @Override
-        public List<Party> getParticipants() {
+        public List<PublicKey> getParticipants() {
             return participants;
         }
 


### PR DESCRIPTION
Use PublicKeys instead of Parties in ConsensualStates

Runtime-os: https://github.com/corda/corda-runtime-os/pull/2343