### PR TITLE
CORE-5375: Add changeset_id to changelog and changelog audit

### DIFF
--- a/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/cpx-creation-v1.0.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/cpx-creation-v1.0.xml
@@ -154,7 +154,7 @@
             <column name="content" type="TEXT">
                 <constraints nullable="false"/>
             </column>
-            <column name="change_uuid" type="VARCHAR(255)">
+            <column name="change_uuid" type="UUID">
                 <constraints nullable="false"/>
             </column>
             <!-- audit -->
@@ -198,7 +198,7 @@
             <column name="content" type="TEXT">
                 <constraints nullable="false"/>
             </column>
-            <column name="change_uuid" type="VARCHAR(255)">
+            <column name="change_uuid" type="UUID">
                 <constraints nullable="false"/>
             </column>
             <column name="is_deleted" type="BOOLEAN">

--- a/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/cpx-creation-v1.0.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/cpx-creation-v1.0.xml
@@ -201,6 +201,9 @@
             <column name="changeset_id" type="UUID">
                 <constraints nullable="false"/>
             </column>
+            <column name="entity_version" type="INT">
+                <constraints nullable="false"/>
+            </column>
             <column name="is_deleted" type="BOOLEAN">
                 <constraints nullable="false"/>
             </column>
@@ -210,7 +213,7 @@
             </column>
         </createTable>
 
-        <addPrimaryKey tableName="cpk_db_change_log_audit" columnNames="cpk_name, cpk_version, cpk_signer_summary_hash, cpk_file_checksum, entity_version, file_path"
+        <addPrimaryKey tableName="cpk_db_change_log_audit" columnNames="cpk_name, cpk_version, cpk_signer_summary_hash, cpk_file_checksum, changeset_id, entity_version, file_path"
                        constraintName="cpk_db_change_log_audit_pk" schemaName="${schema.name}"/>
 
         <createTable tableName="cpi_cpk" schemaName="${schema.name}">

--- a/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/cpx-creation-v1.0.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/cpx-creation-v1.0.xml
@@ -154,6 +154,9 @@
             <column name="content" type="TEXT">
                 <constraints nullable="false"/>
             </column>
+            <column name="change_uuid" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
             <!-- audit -->
             <column name="entity_version" type="INT">
                 <constraints nullable="false"/>
@@ -195,7 +198,7 @@
             <column name="content" type="TEXT">
                 <constraints nullable="false"/>
             </column>
-            <column name="entity_version" type="INT">
+            <column name="change_uuid" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
             <column name="is_deleted" type="BOOLEAN">

--- a/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/cpx-creation-v1.0.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/cpx-creation-v1.0.xml
@@ -154,7 +154,7 @@
             <column name="content" type="TEXT">
                 <constraints nullable="false"/>
             </column>
-            <column name="change_uuid" type="UUID">
+            <column name="changeset_id" type="UUID">
                 <constraints nullable="false"/>
             </column>
             <!-- audit -->
@@ -198,7 +198,7 @@
             <column name="content" type="TEXT">
                 <constraints nullable="false"/>
             </column>
-            <column name="change_uuid" type="UUID">
+            <column name="changeset_id" type="UUID">
                 <constraints nullable="false"/>
             </column>
             <column name="is_deleted" type="BOOLEAN">

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 419
+cordaApiRevision = 420
 
 # Main
 kotlinVersion = 1.7.10


### PR DESCRIPTION
Change UUIDs now serve as a on upload record of uniqueness between change sets. Two identical CPIs will have the same migrations, but different change UUIDS. This lets us tag migrations we run with the changeset UUID, which in turn makes it possible to associate a database state, with the changelogs that created that state in the audit table.

`corda-runtime-os` PR: https://github.com/corda/corda-runtime-os/pull/2371