### PR TITLE
CORE-6083 - Add URL path as a config option for gateway

### DIFF
--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/p2p.gateway/1.0/corda.p2p.gateway.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/p2p.gateway/1.0/corda.p2p.gateway.json
@@ -21,7 +21,8 @@
     "urlPath": {
       "description": "The url path the gateway server will be listening to.",
       "type": "string",
-      "default": "/"
+      "default": "/",
+      "pattern": "^\\/[\\/.a-zA-Z0-9-]*$"
     },
     "sslConfig": {
       "description": "Used for one-way TLS between Gateways.",

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/p2p.gateway/1.0/corda.p2p.gateway.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/p2p.gateway/1.0/corda.p2p.gateway.json
@@ -18,6 +18,11 @@
       "minimum": 0,
       "maximum": 65535
     },
+    "urlPath": {
+      "description": "The url path the gateway server will be listening to.",
+      "type": "string",
+      "default": "/"
+    },
     "sslConfig": {
       "description": "Used for one-way TLS between Gateways.",
       "type": "object",

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 421
+cordaApiRevision = 422
 
 # Main
 kotlinVersion = 1.7.10

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 420
+cordaApiRevision = 421
 
 # Main
 kotlinVersion = 1.7.10


### PR DESCRIPTION
Add configuration option to adjust the URL path the gateway server is listening to for requests.

To keep things simple, I've added a validation pattern that allows relatively simple paths for now (i.e. alphanumerics separated by slashes). The root path was selected as default, so that it works out of the box with URLs that do not specify any custom path.

Corresponding runtime PR: https://github.com/corda/corda-runtime-os/pull/2378