### PR TITLE
CORE-7186: Add regex constants for RBAC arguments

### DIFF
--- a/data/rbac-schema/src/main/kotlin/net/corda/rbac/schema/RbacKeys.kt
+++ b/data/rbac-schema/src/main/kotlin/net/corda/rbac/schema/RbacKeys.kt
@@ -15,4 +15,35 @@ object RbacKeys {
      * Separator for permission string which sits between prefix and the wildcard expression
      */
     const val PREFIX_SEPARATOR = ":"
+
+    /**
+     * Regular expressions to validate common data structures as part of RBAC checks
+     */
+    private const val UUID_CHARS = "[a-fA-F0-9]"
+    const val UUID_REGEX = "$UUID_CHARS{8}-$UUID_CHARS{4}-$UUID_CHARS{4}-$UUID_CHARS{4}-$UUID_CHARS{12}"
+
+    /**
+     * vNode short hash
+     */
+    const val VNODE_SHORT_HASH_REGEX = "$UUID_CHARS{12}"
+
+    /**
+     * RBAC user name regex
+     */
+    const val USER_REGEX = "[-._@a-zA-Z0-9]{3,255}"
+
+    // first.last@company.com is a valid username, however when encoded in the URL it will be shown as
+    // first.last%40company.com
+    private const val ALLOWED_USER_URL_CHARS = "[-._a-zA-Z0-9]"
+    const val USER_URL_REGEX = "$ALLOWED_USER_URL_CHARS{3,200}[%40]{0,3}$ALLOWED_USER_URL_CHARS{0,50}"
+
+    /**
+     * Flow start client request ID
+     */
+    const val CLIENT_REQ_REGEX = "[-._A-Za-z0-9]{1,250}"
+
+    /**
+     * FQN for a flow to be started
+     */
+    const val FLOW_NAME_REGEX = "[._\$a-zA-Z0-9]{1,250}"
 }

--- a/data/rbac-schema/src/main/kotlin/net/corda/rbac/schema/RbacKeys.kt
+++ b/data/rbac-schema/src/main/kotlin/net/corda/rbac/schema/RbacKeys.kt
@@ -16,11 +16,11 @@ object RbacKeys {
      */
     const val PREFIX_SEPARATOR = ":"
 
+    private const val UUID_CHARS = "[a-fA-F0-9]"
     /**
      * Regular expressions to validate common data structures as part of RBAC checks
      */
-    private const val UUID_CHARS = "[a-fA-F0-9]"
-    const val UUID_REGEX = "$UUID_CHARS{8}-$UUID_CHARS{4}-$UUID_CHARS{4}-$UUID_CHARS{4}-$UUID_CHARS{12}"
+    const val UUID_REGEX = "$UUID_CHARS{8}-$UUID_CHARS{4}-[1-5]$UUID_CHARS{3}-[89aAbB]$UUID_CHARS{3}-$UUID_CHARS{12}"
 
     /**
      * vNode short hash

--- a/data/rbac-schema/src/test/kotlin/net/corda/rbac/schema/TestPatternsMatch.kt
+++ b/data/rbac-schema/src/test/kotlin/net/corda/rbac/schema/TestPatternsMatch.kt
@@ -1,0 +1,72 @@
+package net.corda.rbac.schema
+
+import net.corda.rbac.schema.RbacKeys.CLIENT_REQ_REGEX
+import net.corda.rbac.schema.RbacKeys.FLOW_NAME_REGEX
+import net.corda.rbac.schema.RbacKeys.USER_REGEX
+import net.corda.rbac.schema.RbacKeys.USER_URL_REGEX
+import net.corda.rbac.schema.RbacKeys.UUID_REGEX
+import net.corda.rbac.schema.RbacKeys.VNODE_SHORT_HASH_REGEX
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class TestPatternsMatch {
+
+    private fun wildcardMatch(input: String, regex: String): Boolean {
+        return input.matches(regex.toRegex(RegexOption.IGNORE_CASE))
+    }
+
+    @Test
+    fun testUUID() {
+        val validUUIDString = UUID.randomUUID().toString()
+
+        assertTrue(wildcardMatch(validUUIDString, UUID_REGEX))
+        assertFalse(wildcardMatch("invalid", UUID_REGEX))
+    }
+
+    @Test
+    fun testVNodeShortHash() {
+        val validShortHashId = "ABCDEF123456"
+
+        assertTrue(wildcardMatch(validShortHashId, VNODE_SHORT_HASH_REGEX))
+        assertFalse(wildcardMatch("invalid", VNODE_SHORT_HASH_REGEX))
+    }
+
+    @Test
+    fun testUser() {
+        listOf("joe.bloggs@company_1.com", "plainUser").forEach { validUserName ->
+            assertTrue(wildcardMatch(validUserName, USER_REGEX)) { "Failed for $validUserName" }
+        }
+        assertFalse(wildcardMatch("joe/bloggs", USER_REGEX))
+        assertFalse(wildcardMatch("0", USER_REGEX))
+    }
+
+    @Test
+    fun testUserInURL() {
+        listOf("joe.bloggs%40company_1.com", "plainUser").forEach { validUserName ->
+            assertTrue(wildcardMatch(validUserName, USER_URL_REGEX)) { "Failed for $validUserName" }
+        }
+
+        assertFalse(wildcardMatch("joe/bloggs", USER_URL_REGEX))
+        assertFalse(wildcardMatch("0", USER_URL_REGEX))
+    }
+
+    @Test
+    fun testClientRequestId() {
+        val validClientRequestId = "My-Request_Id.1"
+
+        assertTrue(wildcardMatch(validClientRequestId, CLIENT_REQ_REGEX))
+        assertFalse(wildcardMatch("client/request", CLIENT_REQ_REGEX))
+        assertFalse(wildcardMatch("#client@request", CLIENT_REQ_REGEX))
+    }
+
+    @Test
+    fun testFlowName() {
+        val validFlowName = "com.company.MyFlow_1$2"
+
+        assertTrue(wildcardMatch(validFlowName, FLOW_NAME_REGEX))
+        assertFalse(wildcardMatch("flow/name", FLOW_NAME_REGEX))
+        assertFalse(wildcardMatch("#flow@name", FLOW_NAME_REGEX))
+    }
+}


### PR DESCRIPTION
Putting those in `corda-api` as they wll be needed at multiple modules in `corda-runtime-os` repo.

Corresponding `corda-runtime-os` PR: https://github.com/corda/corda-runtime-os/pull/2397