### PR TITLE
CORE-7304: Service to determine default signature spec

### DIFF
--- a/application/src/main/kotlin/net/corda/v5/application/crypto/DefaultSignatureSpecService.kt
+++ b/application/src/main/kotlin/net/corda/v5/application/crypto/DefaultSignatureSpecService.kt
@@ -1,0 +1,31 @@
+package net.corda.v5.application.crypto
+
+import net.corda.v5.base.annotations.CordaSerializable
+import net.corda.v5.base.annotations.Suspendable
+import net.corda.v5.crypto.DigestAlgorithmName
+import net.corda.v5.crypto.SignatureSpec
+import java.security.PublicKey
+
+interface DefaultSignatureSpecService {
+    /**
+     * Work out a signature and hash algorithm to use for a given public key, given current security policies.
+     *
+     * @param publicKey the public key to be used for signing
+     *
+     * @return An appropriate [SignatureSpec], or null if nothing is available for the key type.
+     */
+    @Suspendable
+    fun suggest(publicKey: PublicKey): SignatureSpec?
+
+    /**
+     * Work out a signature algorithm given current security policies and a hash algorithm
+     *
+     * @param publicKey the public key to be used for signing
+     * @param digestAlgorithm the digest algorithm to use, e.g. []DigestAlgorithmName.SHA2_256]
+     *
+     * @return An appropriate [SignatureSpec], or null if nothing is available for the key type
+     */
+
+    @Suspendable
+    fun suggest(publicKey: PublicKey, digestAlgorithm: DigestAlgorithmName: DigestAlgorithmName): SignatureSpec?
+}

--- a/application/src/main/kotlin/net/corda/v5/application/crypto/SignatureSpecService.kt
+++ b/application/src/main/kotlin/net/corda/v5/application/crypto/SignatureSpecService.kt
@@ -1,12 +1,13 @@
 package net.corda.v5.application.crypto
 
-import net.corda.v5.base.annotations.CordaSerializable
+import net.corda.v5.base.annotations.DoNotImplement
 import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.crypto.DigestAlgorithmName
 import net.corda.v5.crypto.SignatureSpec
 import java.security.PublicKey
 
-interface DefaultSignatureSpecService {
+@DoNotImplement
+interface SignatureSpecService {
     /**
      * Work out a signature and hash algorithm to use for a given public key, given current security policies.
      *
@@ -15,7 +16,7 @@ interface DefaultSignatureSpecService {
      * @return An appropriate [SignatureSpec], or null if nothing is available for the key type.
      */
     @Suspendable
-    fun suggest(publicKey: PublicKey): SignatureSpec?
+    fun defaultSignatureSpecFor(publicKey: PublicKey): SignatureSpec?
 
     /**
      * Work out a signature algorithm given current security policies and a hash algorithm
@@ -27,5 +28,5 @@ interface DefaultSignatureSpecService {
      */
 
     @Suspendable
-    fun suggest(publicKey: PublicKey, digestAlgorithm: DigestAlgorithmName: DigestAlgorithmName): SignatureSpec?
+    fun defaultSignatureSpecFor(publicKey: PublicKey, digestAlgorithm: DigestAlgorithmName): SignatureSpec?
 }

--- a/application/src/main/kotlin/net/corda/v5/application/crypto/SignatureSpecService.kt
+++ b/application/src/main/kotlin/net/corda/v5/application/crypto/SignatureSpecService.kt
@@ -9,7 +9,7 @@ import java.security.PublicKey
 @DoNotImplement
 interface SignatureSpecService {
     /**
-     * Work out a signature and hash algorithm to use for a given public key, given current security policies.
+     * Works out a signature spec for specified public key, given current security policies.
      *
      * @param publicKey the public key to be used for signing
      *
@@ -19,20 +19,30 @@ interface SignatureSpecService {
     fun defaultSignatureSpec(publicKey: PublicKey): SignatureSpec?
 
     /**
-     * Work out a signature algorithm given current security policies and a hash algorithm
+     * Works out a signature spec for specified public key and digest algorithm given current security policies.
      *
      * @param publicKey the public key to be used for signing
-     * @param digestAlgorithmName the digest algorithm to use, e.g. []DigestAlgorithmName.SHA2_256]
+     * @param digestAlgorithmName the digest algorithm to use, e.g. [DigestAlgorithmName.SHA2_256]
      *
      * @return An appropriate [SignatureSpec], or null if nothing is available for the key type
      */
-
     @Suspendable
     fun defaultSignatureSpec(publicKey: PublicKey, digestAlgorithmName: DigestAlgorithmName): SignatureSpec?
 
+    /**
+     * Returns compatible signature specs for specified public key, given current security policies.
+     *
+     * @param publicKey the public key to be used for signing
+     */
     @Suspendable
     fun compatibleSignatureSpecs(publicKey: PublicKey): List<SignatureSpec>
 
+    /**
+     * Returns compatible signature specs for specified public key and digest algorithm, given current security policies.
+     *
+     * @param publicKey the public key to be used for signing
+     * @param digestAlgorithmName the digest algorithm to use, e.g. [DigestAlgorithmName.SHA2_256]
+     */
     @Suspendable
     fun compatibleSignatureSpecs(publicKey: PublicKey, digestAlgorithmName: DigestAlgorithmName): List<SignatureSpec>
 }

--- a/application/src/main/kotlin/net/corda/v5/application/crypto/SignatureSpecService.kt
+++ b/application/src/main/kotlin/net/corda/v5/application/crypto/SignatureSpecService.kt
@@ -22,17 +22,17 @@ interface SignatureSpecService {
      * Work out a signature algorithm given current security policies and a hash algorithm
      *
      * @param publicKey the public key to be used for signing
-     * @param digestAlgorithm the digest algorithm to use, e.g. []DigestAlgorithmName.SHA2_256]
+     * @param digestAlgorithmName the digest algorithm to use, e.g. []DigestAlgorithmName.SHA2_256]
      *
      * @return An appropriate [SignatureSpec], or null if nothing is available for the key type
      */
 
     @Suspendable
-    fun defaultSignatureSpec(publicKey: PublicKey, digestAlgorithm: DigestAlgorithmName): SignatureSpec?
+    fun defaultSignatureSpec(publicKey: PublicKey, digestAlgorithmName: DigestAlgorithmName): SignatureSpec?
 
     @Suspendable
     fun compatibleSignatureSpecs(publicKey: PublicKey): List<SignatureSpec>
 
     @Suspendable
-    fun compatibleSignatureSpecs(publicKey: PublicKey, hash: DigestAlgorithmName): List<SignatureSpec>
+    fun compatibleSignatureSpecs(publicKey: PublicKey, digestAlgorithmName: DigestAlgorithmName): List<SignatureSpec>
 }

--- a/application/src/main/kotlin/net/corda/v5/application/crypto/SignatureSpecService.kt
+++ b/application/src/main/kotlin/net/corda/v5/application/crypto/SignatureSpecService.kt
@@ -9,7 +9,7 @@ import java.security.PublicKey
 @DoNotImplement
 interface SignatureSpecService {
     /**
-     * Works out a signature spec for specified public key, given current security policies.
+     * Works out a default signature spec for specified public key, given current security policies.
      *
      * @param publicKey the public key to be used for signing
      *
@@ -19,7 +19,7 @@ interface SignatureSpecService {
     fun defaultSignatureSpec(publicKey: PublicKey): SignatureSpec?
 
     /**
-     * Works out a signature spec for specified public key and digest algorithm given current security policies.
+     * Works out a default signature spec for specified public key and digest algorithm given current security policies.
      *
      * @param publicKey the public key to be used for signing
      * @param digestAlgorithmName the digest algorithm to use, e.g. [DigestAlgorithmName.SHA2_256]

--- a/application/src/main/kotlin/net/corda/v5/application/crypto/SignatureSpecService.kt
+++ b/application/src/main/kotlin/net/corda/v5/application/crypto/SignatureSpecService.kt
@@ -29,4 +29,10 @@ interface SignatureSpecService {
 
     @Suspendable
     fun defaultSignatureSpecFor(publicKey: PublicKey, digestAlgorithm: DigestAlgorithmName): SignatureSpec?
+
+    @Suspendable
+    fun compatibleSignatureSpecsFor(publicKey: PublicKey): List<SignatureSpec>
+
+    @Suspendable
+    fun compatibleSignatureSpecsFor(publicKey: PublicKey, hash: DigestAlgorithmName): List<SignatureSpec>
 }

--- a/application/src/main/kotlin/net/corda/v5/application/crypto/SignatureSpecService.kt
+++ b/application/src/main/kotlin/net/corda/v5/application/crypto/SignatureSpecService.kt
@@ -16,7 +16,7 @@ interface SignatureSpecService {
      * @return An appropriate [SignatureSpec], or null if nothing is available for the key type.
      */
     @Suspendable
-    fun defaultSignatureSpecFor(publicKey: PublicKey): SignatureSpec?
+    fun defaultSignatureSpec(publicKey: PublicKey): SignatureSpec?
 
     /**
      * Work out a signature algorithm given current security policies and a hash algorithm
@@ -28,11 +28,11 @@ interface SignatureSpecService {
      */
 
     @Suspendable
-    fun defaultSignatureSpecFor(publicKey: PublicKey, digestAlgorithm: DigestAlgorithmName): SignatureSpec?
+    fun defaultSignatureSpec(publicKey: PublicKey, digestAlgorithm: DigestAlgorithmName): SignatureSpec?
 
     @Suspendable
-    fun compatibleSignatureSpecsFor(publicKey: PublicKey): List<SignatureSpec>
+    fun compatibleSignatureSpecs(publicKey: PublicKey): List<SignatureSpec>
 
     @Suspendable
-    fun compatibleSignatureSpecsFor(publicKey: PublicKey, hash: DigestAlgorithmName): List<SignatureSpec>
+    fun compatibleSignatureSpecs(publicKey: PublicKey, hash: DigestAlgorithmName): List<SignatureSpec>
 }

--- a/cipher-suite/src/main/kotlin/net/corda/v5/cipher/suite/CipherSchemeMetadata.kt
+++ b/cipher-suite/src/main/kotlin/net/corda/v5/cipher/suite/CipherSchemeMetadata.kt
@@ -80,7 +80,7 @@ interface CipherSchemeMetadata : KeyEncodingService, AlgorithmParameterSpecEncod
     fun findKeyFactory(scheme: KeyScheme): KeyFactory
 
     /**
-     * Returns a default the signature spec compatible with the specified [PublicKey].
+     * Returns a default signature spec compatible with the specified [PublicKey].
      *
      * @return [SignatureSpec] with the signatureName formatted like "SHA256withECDSA" if that can be inferred or
      * otherwise null.

--- a/cipher-suite/src/main/kotlin/net/corda/v5/cipher/suite/CipherSchemeMetadata.kt
+++ b/cipher-suite/src/main/kotlin/net/corda/v5/cipher/suite/CipherSchemeMetadata.kt
@@ -80,12 +80,12 @@ interface CipherSchemeMetadata : KeyEncodingService, AlgorithmParameterSpecEncod
     fun findKeyFactory(scheme: KeyScheme): KeyFactory
 
     /**
-     * Infers the signature spec from the [PublicKey].
+     * Returns a default the signature spec compatible with the specified [PublicKey].
      *
      * @return [SignatureSpec] with the signatureName formatted like "SHA256withECDSA" if that can be inferred or
      * otherwise null.
      */
-    fun inferSignatureSpec(publicKey: PublicKey): SignatureSpec?
+    fun defaultSignatureSpec(publicKey: PublicKey): SignatureSpec?
 
     /**
      * Infers the signature spec from the [PublicKey] and [DigestAlgorithmName]. The [digest] may be ignored for some

--- a/cipher-suite/src/main/kotlin/net/corda/v5/cipher/suite/CipherSchemeMetadata.kt
+++ b/cipher-suite/src/main/kotlin/net/corda/v5/cipher/suite/CipherSchemeMetadata.kt
@@ -80,6 +80,14 @@ interface CipherSchemeMetadata : KeyEncodingService, AlgorithmParameterSpecEncod
     fun findKeyFactory(scheme: KeyScheme): KeyFactory
 
     /**
+     * Infers the signature spec from the [PublicKey]. TODO elaborate
+     *
+     * @return [SignatureSpec] with the signatureName formatted like "SHA256withECDSA" if that can be inferred or
+     * otherwise null.
+     */
+    fun inferSignatureSpec(publicKey: PublicKey): SignatureSpec?
+
+    /**
      * Infers the signature spec from the [PublicKey] and [DigestAlgorithmName]. The [digest] may be ignored for some
      * public key types as the digest is integral part of the signing/verification, e.g. if the [publicKey] is 'EdDSA'
      * hen the [digest] is set to "EdDSA" by the platform's default implementation.
@@ -94,6 +102,11 @@ interface CipherSchemeMetadata : KeyEncodingService, AlgorithmParameterSpecEncod
      * formatted like "SHA256withECDSA" .
      */
     fun supportedSignatureSpec(scheme: KeyScheme): List<SignatureSpec>
+
+    /**
+     * TODO kdoc
+     */
+    fun supportedSignatureSpec(scheme: KeyScheme, digest: DigestAlgorithmName): List<SignatureSpec>
 
     /**
      * Returns list of the [DigestAlgorithmName] for the given [KeyScheme] from which [SignatureSpec] can be inferred.

--- a/cipher-suite/src/main/kotlin/net/corda/v5/cipher/suite/CipherSchemeMetadata.kt
+++ b/cipher-suite/src/main/kotlin/net/corda/v5/cipher/suite/CipherSchemeMetadata.kt
@@ -80,7 +80,7 @@ interface CipherSchemeMetadata : KeyEncodingService, AlgorithmParameterSpecEncod
     fun findKeyFactory(scheme: KeyScheme): KeyFactory
 
     /**
-     * Infers the signature spec from the [PublicKey]. TODO elaborate
+     * Infers the signature spec from the [PublicKey].
      *
      * @return [SignatureSpec] with the signatureName formatted like "SHA256withECDSA" if that can be inferred or
      * otherwise null.
@@ -90,7 +90,7 @@ interface CipherSchemeMetadata : KeyEncodingService, AlgorithmParameterSpecEncod
     /**
      * Infers the signature spec from the [PublicKey] and [DigestAlgorithmName]. The [digest] may be ignored for some
      * public key types as the digest is integral part of the signing/verification, e.g. if the [publicKey] is 'EdDSA'
-     * hen the [digest] is set to "EdDSA" by the platform's default implementation.
+     * then the [digest] is set to "EdDSA" by the platform's default implementation.
      *
      * @return [SignatureSpec] with the signatureName formatted like "SHA256withECDSA" if that can be inferred or
      * otherwise null.
@@ -99,12 +99,13 @@ interface CipherSchemeMetadata : KeyEncodingService, AlgorithmParameterSpecEncod
 
     /**
      * Returns list of the non-custom signature specs for the given [KeyScheme] with the signatureName
-     * formatted like "SHA256withECDSA" .
+     * formatted like "SHA256withECDSA".
      */
     fun supportedSignatureSpec(scheme: KeyScheme): List<SignatureSpec>
 
     /**
-     * TODO kdoc
+     * Returns list of the non-custom signature specs for the given [KeyScheme] and [DigestAlgorithmName]
+     * with the signatureName formatted like "SHA256withECDSA".
      */
     fun supportedSignatureSpec(scheme: KeyScheme, digest: DigestAlgorithmName): List<SignatureSpec>
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 432
+cordaApiRevision = 433
 
 # Main
 kotlinVersion = 1.7.20


### PR DESCRIPTION
Adds `SignatureSpecService` application service to provide users with default signature spec and compatible signature specs APIs for specified public key and (optionally) digest algorithm name.

complement runtime-os PR: [#2437](https://github.com/corda/corda-runtime-os/pull/2437)