### PR TITLE
CORE-7219: Update kdoc for ConsensualTransactionBuilder

### DIFF
--- a/ledger/ledger-consensual/src/main/kotlin/net/corda/v5/ledger/consensual/transaction/ConsensualTransactionBuilder.kt
+++ b/ledger/ledger-consensual/src/main/kotlin/net/corda/v5/ledger/consensual/transaction/ConsensualTransactionBuilder.kt
@@ -36,7 +36,7 @@ interface ConsensualTransactionBuilder {
      *
      * @return Returns a [ConsensualSignedTransaction] with signatures for any required signatories that belong to the current node.
      *
-     * @throws [IllegalStateException] when called a second time on the same object to prevent
+     * @throws IllegalStateException when called a second time on the same object to prevent
      *      unintentional duplicate transactions.
      */
     @Suspendable
@@ -52,7 +52,7 @@ interface ConsensualTransactionBuilder {
      * @param signatories The signatories expected to sign the current transaction.
      * @return Returns a [ConsensualSignedTransaction] with signatures for the specified signatory keys.
      *
-     * @throws [IllegalStateException] when called a second time on the same object to prevent
+     * @throws IllegalStateException when called a second time on the same object to prevent
      *      unintentional duplicate transactions.
      */
     @Suspendable
@@ -68,7 +68,7 @@ interface ConsensualTransactionBuilder {
      * @param signatories The signatories expected to sign the current transaction.
      * @return Returns a [ConsensualSignedTransaction] with signatures for the specified signatory keys.
      *
-     * @throws [IllegalStateException] when called a second time on the same object to prevent
+     * @throws IllegalStateException when called a second time on the same object to prevent
      *      unintentional duplicate transactions.
      */
     @Suspendable

--- a/ledger/ledger-consensual/src/main/kotlin/net/corda/v5/ledger/consensual/transaction/ConsensualTransactionBuilder.kt
+++ b/ledger/ledger-consensual/src/main/kotlin/net/corda/v5/ledger/consensual/transaction/ConsensualTransactionBuilder.kt
@@ -24,9 +24,6 @@ interface ConsensualTransactionBuilder {
      *
      * @param states The states of the output to add to the current [ConsensualTransactionBuilder].
      * @return Returns a new [ConsensualTransactionBuilder] with the specified output states.
-     *
-     * @throws [IllegalStateException] when called a second time on the same object to prevent
-     *      unintentional duplicate transactions.
      */
     fun withStates(vararg states: ConsensualState) : ConsensualTransactionBuilder
 

--- a/ledger/ledger-consensual/src/main/kotlin/net/corda/v5/ledger/consensual/transaction/ConsensualTransactionBuilder.kt
+++ b/ledger/ledger-consensual/src/main/kotlin/net/corda/v5/ledger/consensual/transaction/ConsensualTransactionBuilder.kt
@@ -24,6 +24,9 @@ interface ConsensualTransactionBuilder {
      *
      * @param states The states of the output to add to the current [ConsensualTransactionBuilder].
      * @return Returns a new [ConsensualTransactionBuilder] with the specified output states.
+     *
+     * @throws [IllegalStateException] when called a second time on the same object to prevent
+     *      unintentional duplicate transactions.
      */
     fun withStates(vararg states: ConsensualState) : ConsensualTransactionBuilder
 
@@ -36,8 +39,8 @@ interface ConsensualTransactionBuilder {
      *
      * @return Returns a [ConsensualSignedTransaction] with signatures for any required signatories that belong to the current node.
      *
-     * @throws [UnsupportedOperationException] when called second time on the same object to prevent duplicate
-     *      transactions accidentally.
+     * @throws [IllegalStateException] when called a second time on the same object to prevent
+     *      unintentional duplicate transactions.
      */
     @Suspendable
     fun sign(): ConsensualSignedTransaction
@@ -52,8 +55,8 @@ interface ConsensualTransactionBuilder {
      * @param signatories The signatories expected to sign the current transaction.
      * @return Returns a [ConsensualSignedTransaction] with signatures for the specified signatory keys.
      *
-     * @throws [UnsupportedOperationException] when called second time on the same object to prevent duplicate
-     *      transactions accidentally.
+     * @throws [IllegalStateException] when called a second time on the same object to prevent
+     *      unintentional duplicate transactions.
      */
     @Suspendable
     fun sign(signatories: Iterable<PublicKey>): ConsensualSignedTransaction
@@ -68,8 +71,8 @@ interface ConsensualTransactionBuilder {
      * @param signatories The signatories expected to sign the current transaction.
      * @return Returns a [ConsensualSignedTransaction] with signatures for the specified signatory keys.
      *
-     * @throws [UnsupportedOperationException] when called second time on the same object to prevent duplicate
-     *      transactions accidentally.
+     * @throws [IllegalStateException] when called a second time on the same object to prevent
+     *      unintentional duplicate transactions.
      */
     @Suspendable
     fun sign(vararg signatories: PublicKey): ConsensualSignedTransaction

--- a/ledger/ledger-utxo/src/main/kotlin/net/corda/v5/ledger/utxo/transaction/UtxoTransactionBuilder.kt
+++ b/ledger/ledger-utxo/src/main/kotlin/net/corda/v5/ledger/utxo/transaction/UtxoTransactionBuilder.kt
@@ -127,6 +127,9 @@ interface UtxoTransactionBuilder {
      * Signs the transaction with any required signatories that belong to the current node.
      *
      * @return Returns a [UtxoSignedTransaction] with signatures for any required signatories that belong to the current node.
+     *
+     * @throws IllegalStateException when called a second time on the same object to prevent
+     *      unintentional duplicate transactions.
      */
     @Suspendable
     fun sign(): UtxoSignedTransaction
@@ -136,6 +139,9 @@ interface UtxoTransactionBuilder {
      *
      * @param signatories The signatories expected to sign the current transaction.
      * @return Returns a [UtxoSignedTransaction] with signatures for the specified signatory keys.
+     *
+     * @throws IllegalStateException when called a second time on the same object to prevent
+     *      unintentional duplicate transactions.
      */
     @Suspendable
     fun sign(signatories: Iterable<PublicKey>): UtxoSignedTransaction
@@ -145,6 +151,9 @@ interface UtxoTransactionBuilder {
      *
      * @param signatories The signatories expected to sign the current transaction.
      * @return Returns a [UtxoSignedTransaction] with signatures for the specified signatory keys.
+     *
+     * @throws IllegalStateException when called a second time on the same object to prevent
+     *      unintentional duplicate transactions.
      */
     @Suspendable
     fun sign(vararg signatories: PublicKey): UtxoSignedTransaction


### PR DESCRIPTION
* Attempting to sign twice will throw IllegalStateException rather than UnsupportedOperationException.
* ~Calling withStates will also consume the original builder (for the same reason).~

👮🏻👮🏻👮🏻 !!!! DESCRIBE YOUR CHANGES HERE !!!! DO NOT FORGET !!!! 👮🏻👮🏻👮🏻


# PR Checklist:

- [x] Have you run the unit, integration and smoke tests as described [here](https://docs.corda.net/head/testing.html)?
- [x] If you added public APIs, did you write the JavaDocs?
- [ ] If the changes are of interest to application developers, have you added them to the [changelog](https://docs.corda.net/head/changelog.html) (`/docs/source/changelog.rst`), and potentially the [release notes](https://docs.corda.net/head/release-notes.html) (`/docs/source/release-notes.rst`)?
