### PR TITLE
CORE-7326: Upgrade to Kotlin 1.7.20.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,10 +7,10 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 424
+cordaApiRevision = 425
 
 # Main
-kotlinVersion = 1.7.10
+kotlinVersion = 1.7.20
 kotlin.stdlib.default.dependency = false
 
 # These are the same annotations that Kotlin uses.


### PR DESCRIPTION
Kotlin 1.7.20 has been released, as a minor update to Kotlin 1.7.10.

Contains small tweak to Kotlin generic types to resolve new compiler warning.