### PR TITLE
CORE-7094: Add DTOs for Bulk permissions operations

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/permissions/management/PermissionManagementRequest.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/permissions/management/PermissionManagementRequest.avsc
@@ -24,6 +24,7 @@
         "net.corda.data.permissions.management.user.RemoveRoleFromUserRequest",
         "net.corda.data.permissions.management.role.CreateRoleRequest",
         "net.corda.data.permissions.management.permission.CreatePermissionRequest",
+        "net.corda.data.permissions.management.permission.BulkCreatePermissionsRequest",
         "net.corda.data.permissions.management.role.AddPermissionToRoleRequest",
         "net.corda.data.permissions.management.role.RemovePermissionFromRoleRequest"
       ]

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/permissions/management/PermissionManagementResponse.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/permissions/management/PermissionManagementResponse.avsc
@@ -10,7 +10,8 @@
         "net.corda.data.ExceptionEnvelope",
         "net.corda.data.permissions.User",
         "net.corda.data.permissions.Role",
-        "net.corda.data.permissions.Permission"
+        "net.corda.data.permissions.Permission",
+        "net.corda.data.permissions.management.permission.BulkCreatePermissionsResponse"
       ]
     }
   ]

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/permissions/management/permission/BulkCreatePermissionsRequest.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/permissions/management/permission/BulkCreatePermissionsRequest.avsc
@@ -1,0 +1,23 @@
+{
+  "type": "record",
+  "name": "BulkCreatePermissionsRequest",
+  "namespace": "net.corda.data.permissions.management.permission",
+  "fields": [
+    {
+      "name": "permissionsToCreate",
+      "type": {
+        "type": "array",
+        "items": "CreatePermissionRequest"
+      },
+      "doc": "A set of permissions to create."
+    },
+    {
+      "name": "roleIds",
+      "type": {
+        "type": "array",
+        "items": "string"
+      },
+      "doc": "Identifiers of the existing roles for permissions to be associated with."
+    }
+  ]
+}

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/permissions/management/permission/BulkCreatePermissionsResponse.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/permissions/management/permission/BulkCreatePermissionsResponse.avsc
@@ -1,0 +1,23 @@
+{
+  "type": "record",
+  "name": "BulkCreatePermissionsResponse",
+  "namespace": "net.corda.data.permissions.management.permission",
+  "fields": [
+    {
+      "name": "permissionIds",
+      "type": {
+        "type": "array",
+        "items": "string"
+      },
+      "doc": "A set of IDs of permissions created."
+    },
+    {
+      "name": "roleIds",
+      "type": {
+        "type": "array",
+        "items": "string"
+      },
+      "doc": "Identifiers of the existing roles for permissions to be associated with."
+    }
+  ]
+}


### PR DESCRIPTION
This is a non-breaking change.
`corda-runtime-os` PR which uses these new constructs is: https://github.com/corda/corda-runtime-os/pull/2427