### PR TITLE
CORE-5553 Modified the UTXO Token State Observer API

### DIFF
--- a/ledger/ledger-utxo/src/main/kotlin/net/corda/v5/ledger/utxo/observer/UtxoToken.kt
+++ b/ledger/ledger-utxo/src/main/kotlin/net/corda/v5/ledger/utxo/observer/UtxoToken.kt
@@ -7,12 +7,10 @@ import java.math.BigDecimal
 /**
  * The [UtxoToken] defines the structure of a token produced by an instance of [UtxoLedgerTokenStateObserver]
  *
- * @property poolKey The key of the token pool this token belongs to.
  * @property amount The amount represented by this token.
  * @property filterFields Optional fields available to the [TokenSelection] API [TokenClaimCriteria].
  */
 data class UtxoToken(
-    val poolKey: UtxoTokenPoolKey,
     val amount: BigDecimal,
     val filterFields: UtxoTokenFilterFields?
 )

--- a/ledger/ledger-utxo/src/test/java/net/corda/v5/ledger/utxo/observer/TokenCacheJavaAPITest.java
+++ b/ledger/ledger-utxo/src/test/java/net/corda/v5/ledger/utxo/observer/TokenCacheJavaAPITest.java
@@ -14,6 +14,21 @@ import java.math.BigDecimal;
 public class TokenCacheJavaAPITest {
 
     @Test
+    public void getTokenPoolKey() {
+        TransactionState<ContractState> transactionState = Mockito.mock(TransactionState.class);
+        ContractState contractState = Mockito.mock(ContractState.class);
+        StateAndRef<ContractState> stateAndRef = Mockito.mock(StateAndRef.class);
+
+        Mockito.when(transactionState.getContractState()).thenReturn(contractState);
+
+        final ExampleTokenStateObserver observer = new ExampleTokenStateObserver();
+
+        UtxoTokenPoolKey result = observer.getTokenPoolKey(stateAndRef);
+
+        Assertions.assertThat(result).isNotNull();
+    }
+
+    @Test
     public void callOnProduced() {
         TransactionState<ContractState> transactionState = Mockito.mock(TransactionState.class);
         ContractState contractState = Mockito.mock(ContractState.class);
@@ -40,10 +55,15 @@ public class TokenCacheJavaAPITest {
         @Override
         public UtxoToken onProduced(@NotNull StateAndRef<? extends ContractState> stateAndRef) {
             return new UtxoToken(
-                    new UtxoTokenPoolKey(new SecureHash("A", new byte[10]), "sym"),
                     new BigDecimal(0),
                     new UtxoTokenFilterFields()
             );
+        }
+
+        @NotNull
+        @Override
+        public UtxoTokenPoolKey getTokenPoolKey(@NotNull StateAndRef<? extends ContractState> stateAndRef) {
+            return new UtxoTokenPoolKey(new SecureHash("A", new byte[10]), "sym");
         }
     }
 }

--- a/ledger/ledger-utxo/src/test/java/net/corda/v5/ledger/utxo/observer/UtxoLedgerTokenStateObserverJavaExample.java
+++ b/ledger/ledger-utxo/src/test/java/net/corda/v5/ledger/utxo/observer/UtxoLedgerTokenStateObserverJavaExample.java
@@ -21,9 +21,15 @@ public class UtxoLedgerTokenStateObserverJavaExample implements UtxoLedgerTokenS
         ExampleStateJ state = stateAndRef.getState().getContractState();
 
         return new UtxoToken(
-                new UtxoTokenPoolKey(ExampleStateK.class.getName(), state.issuer, state.currency),
                 state.amount,
                 new UtxoTokenFilterFields()
         );
+    }
+
+    @NotNull
+    @Override
+    public UtxoTokenPoolKey getTokenPoolKey(@NotNull StateAndRef<? extends ExampleStateJ> stateAndRef) {
+        ExampleStateJ state = stateAndRef.getState().getContractState();
+        return new UtxoTokenPoolKey(ExampleStateK.class.getName(), state.issuer, state.currency);
     }
 }

--- a/ledger/ledger-utxo/src/test/kotlin/net/corda/v5/ledger/utxo/observer/UtxoLedgerTokenStateObserverKotlinExample.kt
+++ b/ledger/ledger-utxo/src/test/kotlin/net/corda/v5/ledger/utxo/observer/UtxoLedgerTokenStateObserverKotlinExample.kt
@@ -14,9 +14,13 @@ class UtxoLedgerTokenStateObserverKotlinExample : UtxoLedgerTokenStateObserver<E
     override fun onProduced(stateAndRef: StateAndRef<ExampleStateK>): UtxoToken {
         val state = stateAndRef.state.contractState
         return UtxoToken(
-            UtxoTokenPoolKey(ExampleStateK::class.java.name, state.issuer, state.currency),
             state.amount,
             UtxoTokenFilterFields()
         )
+    }
+
+    override fun getTokenPoolKey(stateAndRef: StateAndRef<ExampleStateK>): UtxoTokenPoolKey {
+        val state = stateAndRef.state.contractState
+        return UtxoTokenPoolKey(ExampleStateK::class.java.name, state.issuer, state.currency)
     }
 }


### PR DESCRIPTION
Modified the UTXO Token State Observer API to support both consume and produce events, by splitting out the token pool key generation from the main token generation.
