### PR TITLE
CORE-7317 Closing non initiated sessions

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/flow/state/checkpoint/FlowStackItem.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/flow/state/checkpoint/FlowStackItem.avsc
@@ -15,12 +15,12 @@
       "doc": "Flag to show if the flow is an initiating flow type."
     },
     {
-      "name": "sessionIds",
+      "name": "sessions",
       "type": {
         "type": "array",
-        "items": "string"
+        "items": "net.corda.data.flow.state.checkpoint.FlowStackItemSession"
       },
-      "doc": "List of any session IDs associated with this flow."
+      "doc": "List of any session associated with this flow or subFlow."
     },
     {
       "name": "contextUserProperties",

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/flow/state/checkpoint/FlowStackItemSession.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/flow/state/checkpoint/FlowStackItemSession.avsc
@@ -1,0 +1,18 @@
+{
+  "type": "record",
+  "name": "FlowStackItemSession",
+  "namespace": "net.corda.data.flow.state.checkpoint",
+  "doc": "Represents a session in the flow stack.",
+  "fields": [
+    {
+      "name": "sessionId",
+      "type": "string",
+      "doc": "The session ID."
+    },
+    {
+      "name": "initiated",
+      "type": "boolean",
+      "doc": "Flag to show if the session has sent a session init message or was initiated by a peer session."
+    }
+  ]
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 433
+cordaApiRevision = 434
 
 # Main
 kotlinVersion = 1.7.20


### PR DESCRIPTION
Add `FlowStackItemSession` to maintain whether a session has been initiated or not, so that we do not executing closing or errorring logic upon them when a flow or subflow finishes or completes.