### PR TITLE
CORE-6674 - Identifiable States

### DIFF
--- a/ledger/ledger-utxo/src/main/kotlin/net/corda/v5/ledger/utxo/IdentifiableState.kt
+++ b/ledger/ledger-utxo/src/main/kotlin/net/corda/v5/ledger/utxo/IdentifiableState.kt
@@ -1,0 +1,15 @@
+package net.corda.v5.ledger.utxo
+
+import java.util.*
+
+/**
+ * Defines a contract state that is identifiable.
+ *
+ * The expectation is that identifiable state implementations will evolve by superseding previous versions of
+ * themselves whilst sharing a common identifier (id).
+ *
+ * @property id The identifier of the current state.
+ */
+interface IdentifiableState : ContractState {
+    val id: UUID
+}

--- a/ledger/ledger-utxo/src/test/java/net/corda/v5/ledger/utxo/AbstractMockTestHarness.java
+++ b/ledger/ledger-utxo/src/test/java/net/corda/v5/ledger/utxo/AbstractMockTestHarness.java
@@ -17,6 +17,8 @@ import java.security.PublicKey;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
 import java.util.zip.ZipInputStream;
 
 public class AbstractMockTestHarness {
@@ -54,11 +56,13 @@ public class AbstractMockTestHarness {
     protected final Party notaryParty = new Party(notaryName, notaryKey);
     protected final String encumbranceTag1 = "ENCUMBRANCE_TAG_1";
     protected final String encumbranceTag2 = "ENCUMBRANCE_TAG_2";
+    protected final UUID id = UUID.fromString("66870685-0e1e-43a1-88c9-0aeb6cc10b18");
 
     protected final StateAndRef<ContractState> contractStateAndRef = createStateAndRef(Mockito.mock(ContractState.class));
     protected final StateRef contractStateRef = createStateAndRef(Mockito.mock(ContractState.class)).getRef();
     protected final TransactionState<ContractState> contractTransactionState = contractStateAndRef.getState();
     protected final ContractState contractState = contractTransactionState.getContractState();
+    protected final IdentifiableState identifiableState = Mockito.mock(IdentifiableState.class);
 
     protected final UtxoLedgerService utxoLedgerService = Mockito.mock(UtxoLedgerService.class);
     protected final UtxoLedgerTransaction utxoLedgerTransaction = Mockito.mock(UtxoLedgerTransaction.class);
@@ -73,6 +77,7 @@ public class AbstractMockTestHarness {
     public AbstractMockTestHarness() {
         initializeContract();
         initializeContractState();
+        initializeIdentifiableState();
         initializeAttachment();
         initializeTimeWindow();
         initializeUtxoLedgerService();
@@ -119,6 +124,11 @@ public class AbstractMockTestHarness {
 
     private void initializeContractState() {
         Mockito.when(contractState.getParticipants()).thenReturn(keys);
+    }
+
+    private void initializeIdentifiableState() {
+        Mockito.when(identifiableState.getParticipants()).thenReturn(keys);
+        Mockito.when(identifiableState.getId()).thenReturn(id);
     }
 
     private void initializeAttachment() {

--- a/ledger/ledger-utxo/src/test/java/net/corda/v5/ledger/utxo/IdentifiableStateJavaApiTests.java
+++ b/ledger/ledger-utxo/src/test/java/net/corda/v5/ledger/utxo/IdentifiableStateJavaApiTests.java
@@ -1,0 +1,23 @@
+package net.corda.v5.ledger.utxo;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.security.PublicKey;
+import java.util.UUID;
+
+public class IdentifiableStateJavaApiTests extends AbstractMockTestHarness {
+
+    @Test
+    public void getParticipantsShouldReturnTheCorrectValue() {
+        Iterable<PublicKey> value = identifiableState.getParticipants();
+        Assertions.assertEquals(keys, value);
+    }
+
+    @Test
+    public void getIdShouldReturnTheCorrectValue() {
+        UUID value = identifiableState.getId();
+        Assertions.assertEquals(id, value);
+    }
+}
+


### PR DESCRIPTION
This PR adds the `IdentifiableState` API to Corda 5, and includes Java API Compatibility tests.

`IdentifiableState` replaces `LinearState` from Corda 4 and no longer requires the `UniqueIdentifier` type to be implemented. Instead, it just provides an `id` property of type `UUID`.

The `externalId` in Corda 4 was of little value and should be implemented by the CorDapp developer, if/when required.