### PR TITLE
CORE-7089 Add command to distribute membership package

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/command/registration/RegistrationCommand.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/command/registration/RegistrationCommand.avsc
@@ -13,6 +13,7 @@
         "net.corda.data.membership.command.registration.mgm.ProcessMemberVerificationResponse",
         "net.corda.data.membership.command.registration.mgm.ApproveRegistration",
         "net.corda.data.membership.command.registration.mgm.DeclineRegistration",
+        "net.corda.data.membership.command.registration.mgm.DistributeMembershipPackage",
         "net.corda.data.membership.command.registration.member.PersistMemberRegistrationState",
         "net.corda.data.membership.command.registration.member.ProcessMemberVerificationRequest"
       ]

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/command/registration/mgm/DistributeMembershipPackage.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/command/registration/mgm/DistributeMembershipPackage.avsc
@@ -1,0 +1,13 @@
+{
+  "type": "record",
+  "name": "DistributeMembershipPackage",
+  "namespace": "net.corda.data.membership.command.registration.mgm",
+  "doc": "Command issued once a member registration has been approved, and the updated membership package needs to be distributed to the members.",
+  "fields": [
+    {
+      "name": "groupParametersEpoch",
+      "type": "int",
+      "doc": "Epoch of the group parameters to be distributed."
+    }
+  ]
+}


### PR DESCRIPTION
Introduces command `DistributeMembershipPackage` which is issued after registration approval, for the MGM to distribute the updated membership package.
https://r3-cev.atlassian.net/browse/CORE-7089