### PR TITLE
NOTICK: bump version to 500 for post alpha release

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 435
+cordaApiRevision = 500
 
 # Main
 kotlinVersion = 1.7.21


### PR DESCRIPTION
Bump API version to 500 to avoid confusion / conflicts with versions being used in the Alpha release branch.