### PR TITLE
CORE-7255 - Remove ECIES refs

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/p2p/UnauthenticatedRegistrationRequest.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/p2p/UnauthenticatedRegistrationRequest.avsc
@@ -11,7 +11,7 @@
     },
     {
       "name": "payload",
-      "doc": "The registration request encrypted using ECIES encryption.",
+      "doc": "The registration request encrypted using hybrid encryption.",
       "type": "bytes"
     }
   ]

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/p2p/UnauthenticatedRegistrationRequestHeader.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/p2p/UnauthenticatedRegistrationRequestHeader.avsc
@@ -2,7 +2,7 @@
   "type": "record",
   "name": "UnauthenticatedRegistrationRequestHeader",
   "namespace": "net.corda.data.membership.p2p",
-  "doc": "Registration request header containing information required for ECIES encryption/decryption.",
+  "doc": "Registration request header containing information required for hybrid encryption/decryption.",
   "fields": [
     {
       "name": "salt",


### PR DESCRIPTION
We are using hybrid encryption scheme in reality, not ECIES. We should remove/rename any references to ECIES to avoid any confusion in the future.