### PR TITLE
CORE-2368: Add certificate read APIs

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/certificates/rpc/request/CertificateRpcRequest.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/certificates/rpc/request/CertificateRpcRequest.avsc
@@ -19,6 +19,7 @@
       "doc": "The request type.",
       "type": [
         "ImportCertificateRpcRequest",
+        "ListCertificateAliasesRpcRequest",
         "RetrieveCertificateRpcRequest"
       ]
     }

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/certificates/rpc/request/ListCertificateAliasesRpcRequest.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/certificates/rpc/request/ListCertificateAliasesRpcRequest.avsc
@@ -1,0 +1,7 @@
+{
+  "type": "record",
+  "name": "ListCertificateAliasesRpcRequest",
+  "namespace": "net.corda.data.certificates.rpc.request",
+  "doc": "RPC request to list all the certificate aliases.",
+  "fields": []
+}

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/certificates/rpc/response/CertificateRpcResponse.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/certificates/rpc/response/CertificateRpcResponse.avsc
@@ -9,6 +9,7 @@
       "doc": "The response payload.",
       "type": [
         "CertificateImportedRpcResponse",
+        "ListCertificateAliasRpcResponse",
         "CertificateRetrievalRpcResponse"
       ]
     }

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/certificates/rpc/response/ListCertificateAliasRpcResponse.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/certificates/rpc/response/ListCertificateAliasRpcResponse.avsc
@@ -1,0 +1,16 @@
+{
+  "type": "record",
+  "name": "ListCertificateAliasRpcResponse",
+  "namespace": "net.corda.data.certificates.rpc.response",
+  "doc": "RPC operations response with a certificate aliases.",
+  "fields": [
+    {
+      "name": "aliases",
+      "doc": "The certificates alias.",
+      "type": {
+        "type": "array",
+        "items": "string"
+      }
+    }
+  ]
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 505
+cordaApiRevision = 504
 
 # Main
 kotlinVersion = 1.7.21

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 500
+cordaApiRevision = 504
 
 # Main
 kotlinVersion = 1.7.21


### PR DESCRIPTION
The runtime Pull request can be found at https://github.com/corda/corda-runtime-os/pull/2556

This pull request adds a command to list the certificates aliases.