### PR TITLE
CORE-8145: Add missing entry to PK

### DIFF
--- a/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/cpx-creation-v1.0.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/cpx-creation-v1.0.xml
@@ -254,7 +254,7 @@
             </column>
         </createTable>
 
-        <addPrimaryKey tableName="cpi_cpk" columnNames="cpi_name, cpi_version, cpi_signer_summary_hash, cpk_file_checksum"
+        <addPrimaryKey tableName="cpi_cpk" columnNames="cpi_name, cpi_version, cpi_signer_summary_hash, cpk_name, cpk_version, cpk_signer_summary_hash, cpk_file_checksum"
                        constraintName="cpi_cpk_pk" schemaName="${schema.name}"/>
 
         <addForeignKeyConstraint baseTableName="cpi_cpk" baseColumnNames="cpi_name, cpi_version, cpi_signer_summary_hash"

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 500
+cordaApiRevision = 501
 
 # Main
 kotlinVersion = 1.7.21


### PR DESCRIPTION
The [CpiCpkEntity](https://github.com/corda/corda-runtime-os/blob/799d93fa95e253217e8a74b3199b6a8b0ee707f6/libs/virtual-node/cpi-datamodel/src/main/kotlin/net/corda/libs/cpi/datamodel/CpiCpkEntity.kt#L59-L73) in the runtime os repo expects the `cpk_signer_summary_hash` to be part of the pk. This change aligns this with the migration here in API