### PR TITLE
NOTICK Remove not needed OSGi uses from api modules

### DIFF
--- a/data/config-schema/build.gradle
+++ b/data/config-schema/build.gradle
@@ -12,8 +12,6 @@ dependencies {
     implementation project(":base")
 
     compileOnly 'org.osgi:osgi.annotation'
-    compileOnly "org.osgi:osgi.core"
 
-    testRuntimeOnly "org.osgi:osgi.core"
 }
 

--- a/data/config-schema/src/main/kotlin/net/corda/schema/configuration/provider/impl/SchemaProviderImpl.kt
+++ b/data/config-schema/src/main/kotlin/net/corda/schema/configuration/provider/impl/SchemaProviderImpl.kt
@@ -6,7 +6,6 @@ import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.v5.base.util.trace
 import net.corda.v5.base.versioning.Version
-import org.osgi.framework.FrameworkUtil
 import java.io.InputStream
 
 internal class SchemaProviderImpl : SchemaProvider {
@@ -32,8 +31,7 @@ internal class SchemaProviderImpl : SchemaProvider {
 
     private fun getResourceInputStream(resource: String): InputStream {
         logger.trace { "Requested schema at $resource." }
-        val bundle = FrameworkUtil.getBundle(this::class.java)
-        val url = bundle?.getResource(resource) ?: this::class.java.classLoader.getResource(resource)
+        val url = this::class.java.classLoader.getResource(resource)
         if (url == null) {
             val msg = "Config schema at $resource cannot be found."
             logger.error(msg)

--- a/data/membership-schema/build.gradle
+++ b/data/membership-schema/build.gradle
@@ -12,7 +12,4 @@ dependencies {
     implementation project(":base")
 
     compileOnly 'org.osgi:osgi.annotation'
-    compileOnly "org.osgi:osgi.core"
-
-    testRuntimeOnly "org.osgi:osgi.core"
 }

--- a/data/membership-schema/src/main/kotlin/net/corda/schema/membership/provider/impl/MembershipSchemaProviderImpl.kt
+++ b/data/membership-schema/src/main/kotlin/net/corda/schema/membership/provider/impl/MembershipSchemaProviderImpl.kt
@@ -7,7 +7,6 @@ import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.v5.base.util.trace
 import net.corda.v5.base.versioning.Version
-import org.osgi.framework.FrameworkUtil
 import java.io.InputStream
 
 internal class MembershipSchemaProviderImpl : MembershipSchemaProvider {
@@ -35,8 +34,7 @@ internal class MembershipSchemaProviderImpl : MembershipSchemaProvider {
 
     private fun getResourceInputStream(resource: String): InputStream {
         logger.trace { "Requested schema at $resource." }
-        val bundle = FrameworkUtil.getBundle(this::class.java)
-        val url = bundle?.getResource(resource) ?: this::class.java.classLoader.getResource(resource)
+        val url = this::class.java.classLoader.getResource(resource)
         if (url == null) {
             val msg = "Membership schema at $resource cannot be found."
             logger.error(msg)


### PR DESCRIPTION
- removes trying to load resource going through `Bundle`. It should not be needed because current class is already loaded whether it is through OSGi or not. Going through the `Bundle` should again ending up calling the same class loader. 
- makes modules OSGi free.