### PR TITLE
CORE-7090 Change response payload type of group parameters persistence

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/response/command/PersistGroupParametersResponse.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/response/command/PersistGroupParametersResponse.avsc
@@ -5,9 +5,9 @@
   "doc": "Response to a persist group parameters request",
   "fields": [
     {
-      "name": "epoch",
-      "doc": "The version of the persisted set of group parameters.",
-      "type": "int"
+      "name": "groupParameters",
+      "doc": "The persisted set of group parameters.",
+      "type": "net.corda.data.KeyValuePairList"
     }
   ]
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 504
+cordaApiRevision = 505
 
 # Main
 kotlinVersion = 1.7.21


### PR DESCRIPTION
The payload of `PersistGroupParametersResponse` is now of type `KeyValuePairList` (previously was `Int`, since only the epoch of the group parameters was returned).

runtime-os change: https://github.com/corda/corda-runtime-os/pull/2473