### PR TITLE
CORE-8310 Registration context accepts arbitrary string for notary plugin name

### DIFF
--- a/data/membership-schema/src/main/resources/net/corda/schema/membership/member/dynamic/registration/1.0/corda.member.dynamic.registration.json
+++ b/data/membership-schema/src/main/resources/net/corda/schema/membership/member/dynamic/registration/1.0/corda.member.dynamic.registration.json
@@ -58,7 +58,7 @@
     "corda.notary.service.plugin": {
       "description": "The notary plugin type (FQN of notary service plugin class). Valid only when one of the roles is notary.",
       "type": "string",
-      "pattern": "^(([a-zA-Z][a-zA-Z_$0-9]*(\\.[a-zA-Z][a-zA-Z_$0-9]*)*)\\.)?([a-zA-Z][a-zA-Z_$0-9]*)$",
+      "maxLength": 255,
       "examples": [
         "net.corda.notary.MyNotaryService"
       ]

--- a/data/membership-schema/src/main/resources/net/corda/schema/membership/mgm/registration/1.0/corda.mgm.registration.json
+++ b/data/membership-schema/src/main/resources/net/corda/schema/membership/mgm/registration/1.0/corda.mgm.registration.json
@@ -34,13 +34,15 @@
     "corda.group.protocol.registration": {
       "description": "Group configuration. The fully qualified class name of the registration protocol that all registering members should use.",
       "type": "string",
+      "pattern": "^(([a-zA-Z][a-zA-Z_$0-9]*(\\.[a-zA-Z][a-zA-Z_$0-9]*)*)\\.)?([a-zA-Z][a-zA-Z_$0-9]*)$",
       "examples": [
         "net.corda.membership.impl.registration.dynamic.MemberRegistrationService"
       ]
     },
     "corda.group.protocol.synchronisation": {
       "description": "Group configuration. The fully qualified class name of the synchronisation protocol that all members should use.",
-      "type": "string"
+      "type": "string",
+      "pattern": "^(([a-zA-Z][a-zA-Z_$0-9]*(\\.[a-zA-Z][a-zA-Z_$0-9]*)*)\\.)?([a-zA-Z][a-zA-Z_$0-9]*)$"
     },
     "corda.group.key.session.policy": {
       "description": "The policy for handling session keys. 'Combined' means a combined ledger and session key is used. 'Distinct means these keys must differ'",


### PR DESCRIPTION
The registration context schema has been updated to allow arbitrary strings instead of fully-qualified package/class names for the notary service plugin name field.
https://r3-cev.atlassian.net/browse/CORE-8310