### PR TITLE
CORE-6121: Add Java compatibility tests for Merkle tree interfaces

### DIFF
--- a/application/src/test/java/net/corda/v5/application/crypto/MerkleTreeFactoryJavaApiTest.java
+++ b/application/src/test/java/net/corda/v5/application/crypto/MerkleTreeFactoryJavaApiTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Test;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -37,7 +36,7 @@ class MerkleTreeFactoryJavaApiTest {
         final MerkleTreeHashDigest hashDigest = mock(MerkleTreeHashDigest.class);
         // TODO: figure out what to do about the default third argument to createHashDigest, not supported in Java
         // by default. According to our coding standards doc, we should either replace this with a manual
-        // overload.
+        // overload. See JIRA CORE-8374.
         when(merkleTreeFactory.createHashDigest(any(), any(), any())).thenReturn(hashDigest);
 
         final MerkleTreeHashDigest result = merkleTreeFactory.createHashDigest(

--- a/application/src/test/java/net/corda/v5/application/crypto/MerkleTreeFactoryJavaApiTest.java
+++ b/application/src/test/java/net/corda/v5/application/crypto/MerkleTreeFactoryJavaApiTest.java
@@ -1,0 +1,49 @@
+package net.corda.v5.application.crypto;
+
+import net.corda.v5.crypto.DigestAlgorithmName;
+import net.corda.v5.crypto.merkle.MerkleTree;
+import net.corda.v5.crypto.merkle.MerkleTreeHashDigest;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class MerkleTreeFactoryJavaApiTest {
+
+    private final MerkleTreeFactory merkleTreeFactory = mock(MerkleTreeFactory.class);
+
+    @Test
+    void createTree() {
+        final MerkleTree tree = mock(MerkleTree.class);
+        when(merkleTreeFactory.createTree(any(), any())).thenReturn(tree);
+
+        final List<byte[]> leaves = new ArrayList<>();
+        final MerkleTreeHashDigest digest = mock(MerkleTreeHashDigest.class);
+        final MerkleTree result = merkleTreeFactory.createTree(leaves, digest);
+
+        Assertions.assertThat(result).isEqualTo(tree);
+    }
+
+    @Test
+    void createHashDigest() {
+        final DigestAlgorithmName digestAlgorithmName = DigestAlgorithmName.DEFAULT_ALGORITHM_NAME;
+        final MerkleTreeHashDigest hashDigest = mock(MerkleTreeHashDigest.class);
+        // TODO: figure out what to do about the default third argument to createHashDigest, not supported in Java
+        // by default. According to our coding standards doc, we should either replace this with a manual
+        // overload.
+        when(merkleTreeFactory.createHashDigest(any(), any(), any())).thenReturn(hashDigest);
+
+        final MerkleTreeHashDigest result = merkleTreeFactory.createHashDigest(
+                "FakeProvider",
+                digestAlgorithmName,
+                new HashMap<>());
+        Assertions.assertThat(result).isEqualTo(hashDigest);
+    }
+}

--- a/application/src/test/java/net/corda/v5/application/crypto/merkle/MerkleTreeJavaApiTest.java
+++ b/application/src/test/java/net/corda/v5/application/crypto/merkle/MerkleTreeJavaApiTest.java
@@ -17,7 +17,7 @@ class MerkleTreeJavaApiTest {
     private final MerkleTree merkleTree = mock(MerkleTree.class);
 
     @Test
-    void createTree() {
+    void createAuditProof() {
         final MerkleProof proof = mock(MerkleProof.class);
         when(merkleTree.createAuditProof(any())).thenReturn(proof);
 

--- a/application/src/test/java/net/corda/v5/application/crypto/merkle/MerkleTreeJavaApiTest.java
+++ b/application/src/test/java/net/corda/v5/application/crypto/merkle/MerkleTreeJavaApiTest.java
@@ -1,0 +1,29 @@
+package net.corda.v5.application.crypto.merkle;
+
+import net.corda.v5.crypto.merkle.MerkleProof;
+import net.corda.v5.crypto.merkle.MerkleTree;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class MerkleTreeJavaApiTest {
+
+    private final MerkleTree merkleTree = mock(MerkleTree.class);
+
+    @Test
+    void createTree() {
+        final MerkleProof proof = mock(MerkleProof.class);
+        when(merkleTree.createAuditProof(any())).thenReturn(proof);
+
+        final List<Integer> leafIndices = new ArrayList<>();
+        final MerkleProof result = merkleTree.createAuditProof(leafIndices);
+
+        Assertions.assertThat(result).isEqualTo(proof);
+    }
+}

--- a/application/src/test/java/net/corda/v5/crypto/merkle/MerkleProofJavaApiTest.java
+++ b/application/src/test/java/net/corda/v5/crypto/merkle/MerkleProofJavaApiTest.java
@@ -1,0 +1,25 @@
+package net.corda.v5.crypto.merkle;
+
+import net.corda.v5.crypto.SecureHash;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class MerkleProofJavaApiTest {
+
+    private final MerkleProof merkleProof = mock(MerkleProof.class);
+
+    @Test
+    void verify() {
+        when(merkleProof.verify(any(), any())).thenReturn(true);
+
+        final SecureHash hash = new SecureHash("SHA-256", "123".getBytes());
+        final MerkleTreeHashDigest digest = mock(MerkleTreeHashDigest.class);
+        final boolean result = merkleProof.verify(hash, digest);
+
+        Assertions.assertThat(result).isEqualTo(true);
+    }
+}

--- a/cipher-suite/src/test/java/net/corda/v5/cipher/suite/merkle/MerkleTreeProviderJavaApiTest.java
+++ b/cipher-suite/src/test/java/net/corda/v5/cipher/suite/merkle/MerkleTreeProviderJavaApiTest.java
@@ -1,0 +1,48 @@
+package net.corda.v5.cipher.suite.merkle;
+
+import net.corda.v5.crypto.DigestAlgorithmName;
+import net.corda.v5.crypto.extensions.merkle.MerkleTreeHashDigestProvider;
+import net.corda.v5.crypto.merkle.MerkleTree;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class MerkleTreeProviderJavaApiTest {
+
+    private final MerkleTreeProvider merkleTreeProvider = mock(MerkleTreeProvider.class);
+
+    @Test
+    void createTree() {
+        final MerkleTree tree = mock(MerkleTree.class);
+        when(merkleTreeProvider.createTree(any(), any())).thenReturn(tree);
+
+        final List<byte[]> leaves = new ArrayList<>();
+        final MerkleTreeHashDigestProvider digestProvider = mock(MerkleTreeHashDigestProvider.class);
+        final MerkleTree result = merkleTreeProvider.createTree(leaves, digestProvider);
+
+        Assertions.assertThat(result).isEqualTo(tree);
+    }
+
+    @Test
+    void createHashDigestProvider() {
+        final DigestAlgorithmName digestAlgorithmName = DigestAlgorithmName.DEFAULT_ALGORITHM_NAME;
+        final MerkleTreeHashDigestProvider hashDigestProvider = mock(MerkleTreeHashDigestProvider.class);
+        // TODO: figure out what to do about the default third argument to createHashDigestProvider, not supported in Java
+        // by default. According to our coding standards doc, we should either replace this with a manual
+        // overload. See JIRA CORE-8374.
+        when(merkleTreeProvider.createHashDigestProvider(any(), any(), any())).thenReturn(hashDigestProvider);
+
+        final MerkleTreeHashDigestProvider result = merkleTreeProvider.createHashDigestProvider(
+                "FakeProvider",
+                digestAlgorithmName,
+                new HashMap<>());
+        Assertions.assertThat(result).isEqualTo(hashDigestProvider);
+    }
+}


### PR DESCRIPTION
Add tests to make sure Merkle tree related Kotlin interfaces are compatible with Java:

* [x] `MerkleTree`
* [x] ~`MerkleTreeHash`~ (that's not a thing; why did I think that was a thing?)
* [x] `MerkleProof`
* [x] `MerkleTreeFactory` (but see [this JIRA ticket](https://r3-cev.atlassian.net/browse/CORE-8374) about a compatibility issue I noticed)
* [x] `MerkleTreeProvider` ([same JIRA ticket](https://r3-cev.atlassian.net/browse/CORE-8374) for resolving an incompatibility)

# PR Checklist:

- [ ] Have you run the unit, integration and smoke tests as described [here](https://docs.corda.net/head/testing.html)?
- [ ] If you added public APIs, did you write the JavaDocs?
- [ ] If the changes are of interest to application developers, have you added them to the [changelog](https://docs.corda.net/head/changelog.html) (`/docs/source/changelog.rst`), and potentially the [release notes](https://docs.corda.net/head/release-notes.html) (`/docs/source/release-notes.rst`)?
- [ ] If you are contributing for the first time, please read the [contributor agreement](https://docs.corda.net/head/contributing.html) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://docs.corda.net/head/contributing.html#merging-the-changes-back-into-corda).

Thanks for your code, it's appreciated! :)
