### PR TITLE
CORE-8431 Interfaces and functions for getting data out of signed TX

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 506
+cordaApiRevision = 507
 
 # Main
 kotlinVersion = 1.7.21

--- a/ledger/ledger-common/src/main/kotlin/net/corda/v5/ledger/common/transaction/CordaPackageSummary.kt
+++ b/ledger/ledger-common/src/main/kotlin/net/corda/v5/ledger/common/transaction/CordaPackageSummary.kt
@@ -1,0 +1,26 @@
+package net.corda.v5.ledger.common.transaction
+
+/**
+ * Summary of the metadata of a corda package (CPK or CPI)
+ */
+interface CordaPackageSummary {
+    /**
+     * @property name Name of the package
+     */
+    val name: String
+
+    /**
+     * @property version Version of the pacakge
+     */
+    val version: String
+
+    /**
+     * @property signerSummaryHash hash sum identifying the signer for signed packages (CPIs). Null for CPKs
+     */
+    val signerSummaryHash: String?
+
+    /**
+     * @property fileChecksum checksum of the package file
+     */
+    val fileChecksum: String
+}

--- a/ledger/ledger-common/src/main/kotlin/net/corda/v5/ledger/common/transaction/TransactionMetadata.kt
+++ b/ledger/ledger-common/src/main/kotlin/net/corda/v5/ledger/common/transaction/TransactionMetadata.kt
@@ -1,0 +1,59 @@
+package net.corda.v5.ledger.common.transaction
+
+/**
+ * This interface represents the metadata governing a transaction, capturing a snapshot
+ * of the system and software versions as the transaction was created.
+ */
+interface TransactionMetadata {
+
+    /**
+     * Returns the ledger model this transaction belongs to.
+     *
+     * @return the class name of the transaction implementation
+     */
+    fun getLedgerModel(): String
+
+    /**
+     * Returns the version of the ledger this transaction was created with
+     *
+     * @return the ledger version at creation time
+     */
+    fun getLedgerVersion(): Int
+
+    /**
+     * Returns the transaction subtype. This is ledger specific, check with the documentation of the
+     * ledger model you are using.
+     *
+     * @return Transaction subtype as string defined in the ledger model
+     */
+    fun getTransactionSubtype(): String?
+
+    /**
+     * Get information about the CPI running on the virtual node creating the transaction
+     *
+     * @return a summary of the CPI
+     */
+    fun getCpiMetadata(): CordaPackageSummary?
+
+    /**
+     * Get information about the contract CPKs governing the transaction (installed on the
+     * virtual node when the transaction was created)
+     *
+     * @return list of CPK summaries
+     */
+    fun getCpkMetadata(): List<CordaPackageSummary>
+
+    /**
+     * Get the digest settings used to calculate the transaction hashes
+     *
+     * @return digest settings as map
+     */
+    fun getDigestSettings(): LinkedHashMap<String, Any>
+
+    /**
+     * Version of the metadata JSON schema to parse this metadata entity
+     *
+     * @return The schema version
+     */
+    fun getSchemaVersion(): Int
+}

--- a/ledger/ledger-utxo/src/main/kotlin/net/corda/v5/ledger/utxo/transaction/UtxoSignedTransaction.kt
+++ b/ledger/ledger-utxo/src/main/kotlin/net/corda/v5/ledger/utxo/transaction/UtxoSignedTransaction.kt
@@ -5,9 +5,11 @@ import net.corda.v5.base.annotations.DoNotImplement
 import net.corda.v5.crypto.SecureHash
 import net.corda.v5.ledger.common.Party
 import net.corda.v5.ledger.common.transaction.TransactionMetadata
+import net.corda.v5.ledger.utxo.Command
 import net.corda.v5.ledger.utxo.StateAndRef
 import net.corda.v5.ledger.utxo.StateRef
 import net.corda.v5.ledger.utxo.TimeWindow
+import java.security.PublicKey
 
 /**
  * Defines a signed UTXO transaction.
@@ -68,6 +70,16 @@ interface UtxoSignedTransaction {
      * @property metadata The metadata for this transaction
      */
     val metadata: TransactionMetadata
+
+    /**
+     * @property commands The list of commands for this transaction
+     */
+    val commands: List<Command>
+
+    /**
+     * @property signatories The list of keys that need to sign this transaction
+     */
+    val signatories: List<PublicKey>
 
     /**
      * Converts the current [UtxoSignedTransaction] into a [UtxoLedgerTransaction].

--- a/ledger/ledger-utxo/src/main/kotlin/net/corda/v5/ledger/utxo/transaction/UtxoSignedTransaction.kt
+++ b/ledger/ledger-utxo/src/main/kotlin/net/corda/v5/ledger/utxo/transaction/UtxoSignedTransaction.kt
@@ -3,6 +3,11 @@ package net.corda.v5.ledger.utxo.transaction
 import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.base.annotations.DoNotImplement
 import net.corda.v5.crypto.SecureHash
+import net.corda.v5.ledger.common.Party
+import net.corda.v5.ledger.common.transaction.TransactionMetadata
+import net.corda.v5.ledger.utxo.StateAndRef
+import net.corda.v5.ledger.utxo.StateRef
+import net.corda.v5.ledger.utxo.TimeWindow
 
 /**
  * Defines a signed UTXO transaction.
@@ -33,6 +38,36 @@ interface UtxoSignedTransaction {
      * @property signatures The signatures that have been applied to the transaction.
      */
     val signatures: List<DigitalSignatureAndMetadata>
+
+    /**
+     * @property inputStateRefs The stateRefs of the inputs to this transaction
+     */
+    val inputStateRefs: List<StateRef>
+
+    /**
+     * @property referenceStateRefs The state refs of any reference states used by this transaction
+     */
+    val referenceStateRefs: List<StateRef>
+
+    /**
+     * @property outputStateAndRefs The state and ref of the ouputs of this transaction
+     */
+    val outputStateAndRefs: List<StateAndRef<*>>
+
+    /**
+     * @property notary The notary used for notarising this transaction
+     */
+    val notary: Party
+
+    /**
+     * @property timeWindow The validity time window for completing/notarising this transaction
+     */
+    val timeWindow: TimeWindow
+
+    /**
+     * @property metadata The metadata for this transaction
+     */
+    val metadata: TransactionMetadata
 
     /**
      * Converts the current [UtxoSignedTransaction] into a [UtxoLedgerTransaction].


### PR DESCRIPTION
Add functionality to the UTXO signed transaction to get some of the data out without transforming to a ledger transaction (which would be costly because it requires backchain resolution).
Currently limited to the properties that will be required for the notary.