### PR TITLE
CORE-8652: Add regex for vNode state

### DIFF
--- a/data/rbac-schema/src/main/kotlin/net/corda/rbac/schema/RbacKeys.kt
+++ b/data/rbac-schema/src/main/kotlin/net/corda/rbac/schema/RbacKeys.kt
@@ -28,6 +28,11 @@ object RbacKeys {
     const val VNODE_SHORT_HASH_REGEX = "$UUID_CHARS{12}"
 
     /**
+     * State of the vNode. E.g. ACTIVE or IN_MAINTENANCE.
+     */
+    const val VNODE_STATE_REGEX = "[_a-zA-Z0-9]{3,255}"
+
+    /**
      * RBAC user name regex
      */
     const val USER_REGEX = "[-._@a-zA-Z0-9]{3,255}"

--- a/data/rbac-schema/src/test/kotlin/net/corda/rbac/schema/TestPatternsMatch.kt
+++ b/data/rbac-schema/src/test/kotlin/net/corda/rbac/schema/TestPatternsMatch.kt
@@ -6,6 +6,7 @@ import net.corda.rbac.schema.RbacKeys.USER_REGEX
 import net.corda.rbac.schema.RbacKeys.USER_URL_REGEX
 import net.corda.rbac.schema.RbacKeys.UUID_REGEX
 import net.corda.rbac.schema.RbacKeys.VNODE_SHORT_HASH_REGEX
+import net.corda.rbac.schema.RbacKeys.VNODE_STATE_REGEX
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -31,6 +32,14 @@ class TestPatternsMatch {
 
         assertTrue(wildcardMatch(validShortHashId, VNODE_SHORT_HASH_REGEX))
         assertFalse(wildcardMatch("invalid", VNODE_SHORT_HASH_REGEX))
+    }
+
+    @Test
+    fun testVNodeState() {
+        val valid = "IN_MAINTENANCE"
+
+        assertTrue(wildcardMatch(valid, VNODE_STATE_REGEX))
+        assertFalse(wildcardMatch("inv@lid", VNODE_STATE_REGEX))
     }
 
     @Test


### PR DESCRIPTION
This is a non-breaking `corda-api` change.