### PR TITLE
CORE-8870 Increase the interval between group parameters database reconciliation

### DIFF
--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/reconciliation/1.0/corda.reconciliation.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/reconciliation/1.0/corda.reconciliation.json
@@ -46,7 +46,7 @@
       "type": "integer",
       "minimum": 5000,
       "maximum": 2147483647,
-      "default": 30000
+      "default": 120000
     }
   }
 }


### PR DESCRIPTION
Group parameters reconciliation was set to a 30 second interval by default. This can be an expensive operation as the number of vnodes increases and for the combined worker this can take up processing time and impact performance. In general we don't expect the group parameters to change often so the PR increases that interval to 2 minutes.

Reconciliation time for group parameters on the combined worker when 11 vnodes are created was observed to be ~4 seconds.