### PR TITLE
CORE-8913: Define producers/consumers for RPC topics

### DIFF
--- a/data/topic-schema/src/main/kotlin/net/corda/schema/Schemas.kt
+++ b/data/topic-schema/src/main/kotlin/net/corda/schema/Schemas.kt
@@ -158,7 +158,6 @@ class Schemas {
     class Permissions {
         companion object {
             const val PERMISSIONS_USER_SUMMARY_TOPIC = "permissions.user.summary"
-            const val USER_PERMISSIONS_MGMT_TOPIC = "user.permissions.management"
         }
     }
 

--- a/data/topic-schema/src/main/resources/net/corda/schema/Permissions.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/Permissions.yaml
@@ -1,13 +1,11 @@
 topics:
-  UserPermissionsManagementTopic:
-    name: user.permissions.management
-    consumers:
-    producers:
-    config:
   PermissionsUserSummaryTopic:
     name: permissions.user.summary
     consumers:
+      - rpc
+      - db
     producers:
+      - db
     config:
       cleanup.policy: compact
       segment.ms: 600000

--- a/data/topic-schema/src/main/resources/net/corda/schema/RPC.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/RPC.yaml
@@ -2,17 +2,24 @@ topics:
   RPCPermissionsManagementTopic:
     name: rpc.permissions.management
     consumers:
+      - db
     producers:
+      - rpc
     config:
   RPCPermissionsManagementResponseTopic:
     name: rpc.permissions.management.resp
     consumers:
+      - rpc
     producers:
+      - db
     config:
   RPCPermissionsGroupTopic:
     name: rpc.permissions.group
     consumers:
+      - rpc
+      - db
     producers:
+      - db
     config:
       cleanup.policy: compact
       segment.ms: 600000
@@ -23,7 +30,10 @@ topics:
   RPCPermissionsPermissionTopic:
     name: rpc.permissions.permission
     consumers:
+      - rpc
+      - db
     producers:
+      - db
     config:
       cleanup.policy: compact
       segment.ms: 600000
@@ -34,7 +44,10 @@ topics:
   RPCPermissionsUserTopic:
     name: rpc.permissions.user
     consumers:
+      - rpc
+      - db
     producers:
+      - db
     config:
       cleanup.policy: compact
       segment.ms: 600000
@@ -45,7 +58,10 @@ topics:
   RPCPermissionsRoleTopic:
     name: rpc.permissions.role
     consumers:
+      - rpc
+      - db
     producers:
+      - db
     config:
       cleanup.policy: compact
       segment.ms: 600000


### PR DESCRIPTION
Also delete redundant topic `user.permissions.management`.

Potentially, this should be a non-breaking change.

Related PR: https://github.com/corda/corda-runtime-os/pull/2717