### PR TITLE
CORE-8918 Define producers/ consumers for Crypto topics

### DIFF
--- a/data/topic-schema/src/main/kotlin/net/corda/schema/Schemas.kt
+++ b/data/topic-schema/src/main/kotlin/net/corda/schema/Schemas.kt
@@ -50,22 +50,22 @@ class Schemas {
      */
     class Crypto {
         companion object {
-            const val HSM_REGISTRATION_MESSAGE_TOPIC = "crypto.registration.hsm"
-            const val RPC_OPS_MESSAGE_TOPIC = "crypto.ops.rpc"
-            val RPC_OPS_MESSAGE_RESPONSE_TOPIC = getRPCResponseTopic(RPC_OPS_MESSAGE_TOPIC)
-            const val RPC_OPS_CLIENT_TOPIC = "crypto.ops.rpc.client"
-            const val FLOW_OPS_MESSAGE_TOPIC = "crypto.ops.flow"
+            const val EVENT_TOPIC = "crypto.event"
             const val HSM_CONFIG_TOPIC = "crypto.config.hsm"
+            const val HSM_CONFIGURATION_HSM_LABEL_TOPIC = "crypto.config.hsm.label"
             const val MEMBER_CONFIG_TOPIC = "crypto.config.member"
             const val SIGNING_KEY_PERSISTENCE_TOPIC = "crypto.key.info"
             const val SOFT_HSM_PERSISTENCE_TOPIC = "crypto.key.soft"
-            const val EVENT_TOPIC = "crypto.event"
             const val HSM_CONFIGURATION_LABEL_TOPIC = "crypto.hsm.label"
-            const val HSM_CONFIGURATION_HSM_LABEL_TOPIC = "crypto.config.hsm.label"
             const val RPC_HSM_REGISTRATION_MESSAGE_TOPIC = "crypto.hsm.rpc.registration"
             val RPC_HSM_REGISTRATION_MESSAGE_RESPONSE_TOPIC = getRPCResponseTopic(RPC_HSM_REGISTRATION_MESSAGE_TOPIC)
             const val RPC_HSM_CONFIGURATION_MESSAGE_TOPIC = "crypto.hsm.rpc.configuration"
             val RPC_HSM_CONFIGURATION_MESSAGE_RESPONSE_TOPIC = getRPCResponseTopic(RPC_HSM_CONFIGURATION_MESSAGE_TOPIC)
+            const val FLOW_OPS_MESSAGE_TOPIC = "crypto.ops.flow"
+            const val RPC_OPS_MESSAGE_TOPIC = "crypto.ops.rpc"
+            val RPC_OPS_MESSAGE_RESPONSE_TOPIC = getRPCResponseTopic(RPC_OPS_MESSAGE_TOPIC)
+            const val RPC_OPS_CLIENT_TOPIC = "crypto.ops.rpc.client"
+            const val HSM_REGISTRATION_MESSAGE_TOPIC = "crypto.registration.hsm"
         }
     }
 

--- a/data/topic-schema/src/main/kotlin/net/corda/schema/Schemas.kt
+++ b/data/topic-schema/src/main/kotlin/net/corda/schema/Schemas.kt
@@ -50,21 +50,11 @@ class Schemas {
      */
     class Crypto {
         companion object {
-            const val HSM_CONFIG_TOPIC = "crypto.config.hsm"
-            const val HSM_CONFIGURATION_HSM_LABEL_TOPIC = "crypto.config.hsm.label"
-            const val MEMBER_CONFIG_TOPIC = "crypto.config.member"
-            const val SIGNING_KEY_PERSISTENCE_TOPIC = "crypto.key.info"
-            const val SOFT_HSM_PERSISTENCE_TOPIC = "crypto.key.soft"
-            const val HSM_CONFIGURATION_LABEL_TOPIC = "crypto.hsm.label"
             const val RPC_HSM_REGISTRATION_MESSAGE_TOPIC = "crypto.hsm.rpc.registration"
             val RPC_HSM_REGISTRATION_MESSAGE_RESPONSE_TOPIC = getRPCResponseTopic(RPC_HSM_REGISTRATION_MESSAGE_TOPIC)
-            const val RPC_HSM_CONFIGURATION_MESSAGE_TOPIC = "crypto.hsm.rpc.configuration"
-            val RPC_HSM_CONFIGURATION_MESSAGE_RESPONSE_TOPIC = getRPCResponseTopic(RPC_HSM_CONFIGURATION_MESSAGE_TOPIC)
             const val FLOW_OPS_MESSAGE_TOPIC = "crypto.ops.flow"
             const val RPC_OPS_MESSAGE_TOPIC = "crypto.ops.rpc"
             val RPC_OPS_MESSAGE_RESPONSE_TOPIC = getRPCResponseTopic(RPC_OPS_MESSAGE_TOPIC)
-            const val RPC_OPS_CLIENT_TOPIC = "crypto.ops.rpc.client"
-            const val HSM_REGISTRATION_MESSAGE_TOPIC = "crypto.registration.hsm"
         }
     }
 

--- a/data/topic-schema/src/main/kotlin/net/corda/schema/Schemas.kt
+++ b/data/topic-schema/src/main/kotlin/net/corda/schema/Schemas.kt
@@ -50,7 +50,6 @@ class Schemas {
      */
     class Crypto {
         companion object {
-            const val EVENT_TOPIC = "crypto.event"
             const val HSM_CONFIG_TOPIC = "crypto.config.hsm"
             const val HSM_CONFIGURATION_HSM_LABEL_TOPIC = "crypto.config.hsm.label"
             const val MEMBER_CONFIG_TOPIC = "crypto.config.member"

--- a/data/topic-schema/src/main/resources/net/corda/schema/Crypto.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/Crypto.yaml
@@ -1,9 +1,4 @@
 topics:
-  CryptoEventHSMTopic:
-    name: crypto.event
-    consumers:
-    producers:
-    config:
   CryptoConfigHSMTopic:
     name: crypto.config.hsm
     consumers:

--- a/data/topic-schema/src/main/resources/net/corda/schema/Crypto.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/Crypto.yaml
@@ -25,16 +25,18 @@ topics:
     consumers:
       - crypto
     producers:
-      - membership
       - gateway
       - link-manager
+      - membership
+      - rpc
     config:
   CryptoOpsRpcResponseTopic:
     name: crypto.ops.rpc.resp
     consumers:
-      - membership
       - gateway
       - link-manager
+      - membership
+      - rpc
     producers:
       - crypto
     config:

--- a/data/topic-schema/src/main/resources/net/corda/schema/Crypto.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/Crypto.yaml
@@ -5,11 +5,13 @@ topics:
       - crypto
     producers:
       - membership
+      - rpc
     config:
   CryptoHSMRPCRegistrationRespTopic:
     name: crypto.hsm.rpc.registration.resp
     consumers:
       - membership
+      - rpc
     producers:
       - crypto
     config:

--- a/data/topic-schema/src/main/resources/net/corda/schema/Crypto.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/Crypto.yaml
@@ -27,6 +27,7 @@ topics:
     consumers:
       - crypto
     producers:
+      - crypto
       - gateway
       - link-manager
       - membership
@@ -35,6 +36,7 @@ topics:
   CryptoOpsRpcResponseTopic:
     name: crypto.ops.rpc.resp
     consumers:
+      - crypto
       - gateway
       - link-manager
       - membership

--- a/data/topic-schema/src/main/resources/net/corda/schema/Crypto.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/Crypto.yaml
@@ -2,25 +2,39 @@ topics:
   CryptoHSMRPCRegistrationTopic:
     name: crypto.hsm.rpc.registration
     consumers:
+      - crypto
     producers:
+      - membership
     config:
   CryptoHSMRPCRegistrationRespTopic:
     name: crypto.hsm.rpc.registration.resp
     consumers:
+      - membership
     producers:
+      - crypto
     config:
   CryptoOpsFlowTopic:
     name: crypto.ops.flow
     consumers:
+      - crypto
     producers:
+      - flow
     config:
   CryptoOpsRpcTopic:
     name: crypto.ops.rpc
     consumers:
+      - crypto
     producers:
+      - membership
+      - gateway
+      - link-manager
     config:
   CryptoOpsRpcResponseTopic:
     name: crypto.ops.rpc.resp
     consumers:
+      - membership
+      - gateway
+      - link-manager
     producers:
+      - crypto
     config:

--- a/data/topic-schema/src/main/resources/net/corda/schema/Crypto.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/Crypto.yaml
@@ -1,34 +1,4 @@
 topics:
-  CryptoConfigHSMTopic:
-    name: crypto.config.hsm
-    consumers:
-    producers:
-    config:
-  CryptoConfigHSMLabelTopic:
-    name: crypto.config.hsm.label
-    consumers:
-    producers:
-    config:
-  CryptoConfigMemberTopic:
-    name: crypto.config.member
-    consumers:
-    producers:
-    config:
-  CryptoKeyInfoTopic:
-    name: crypto.key.info
-    consumers:
-    producers:
-    config:
-  CryptoKeySoftTopic:
-    name: crypto.key.soft
-    consumers:
-    producers:
-    config:
-  CryptoHSMLabelTopic:
-    name: crypto.hsm.label
-    consumers:
-    producers:
-    config:
   CryptoHSMRPCRegistrationTopic:
     name: crypto.hsm.rpc.registration
     consumers:
@@ -36,16 +6,6 @@ topics:
     config:
   CryptoHSMRPCRegistrationRespTopic:
     name: crypto.hsm.rpc.registration.resp
-    consumers:
-    producers:
-    config:
-  CryptoHSMRPCConfigurationTopic:
-    name: crypto.hsm.rpc.configuration
-    consumers:
-    producers:
-    config:
-  CryptoHSMRPCConfigurationRespTopic:
-    name: crypto.hsm.rpc.configuration.resp
     consumers:
     producers:
     config:
@@ -61,16 +21,6 @@ topics:
     config:
   CryptoOpsRpcResponseTopic:
     name: crypto.ops.rpc.resp
-    consumers:
-    producers:
-    config:
-  CryptoOpsRpcClientTopic:
-    name: crypto.ops.rpc.client
-    consumers:
-    producers:
-    config:
-  CryptoRegistrationHSMTopic:
-    name: crypto.registration.hsm
     consumers:
     producers:
     config:

--- a/data/topic-schema/src/test/java/net/corda/schema/SchemasTests.java
+++ b/data/topic-schema/src/test/java/net/corda/schema/SchemasTests.java
@@ -8,8 +8,6 @@ public class SchemasTests {
     @Test
     void cryptoTopicsShouldLookNiceInJavaApi() {
         assertNotNull(Schemas.Crypto.RPC_HSM_REGISTRATION_MESSAGE_TOPIC);
-        assertNotNull(Schemas.Crypto.RPC_HSM_CONFIGURATION_MESSAGE_TOPIC);
-        assertNotNull(Schemas.Crypto.HSM_CONFIGURATION_LABEL_TOPIC);
         assertNotNull(Schemas.Crypto.RPC_OPS_MESSAGE_TOPIC);
         assertNotNull(Schemas.Crypto.FLOW_OPS_MESSAGE_TOPIC);
     }


### PR DESCRIPTION
- removes not used crypto topics.
- assigns producers/ consumers to crypto topics.

runtime-os PR only to test runtime-os build against current changes: [#2743](https://github.com/corda/corda-runtime-os/pull/2743)