### PR TITLE
CORE-8972: bump api version prior to cutting release branch to avoid potential clash

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 522
+cordaApiRevision = 600
 
 # Main
 kotlinVersion = 1.7.21


### PR DESCRIPTION
reset cordaApiRevision at 600 due to scheduled creation of Beta1 release branch 