### PR TITLE
NOTICK: use correct downstream job for beta1 branch in compatibility job

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 cordaPipeline(
     runIntegrationTests: false,
     nexusAppId: 'net.corda-api-5.0',
-    dependentJobsNames: ['/Corda5/corda-runtime-os-version-compatibility/release%2Fos%2F5.0'],
+    dependentJobsNames: ['/Corda5/corda-runtime-os-version-compatibility/release%2Fos%2F5.0-Beta1'],
     javadocJar: true,
     // always use -beta-9999999999999 for local publication as this is used for the version compatibility checks,
     //  This is a PR gate, so we want to check the "post merge" state before publication for real.


### PR DESCRIPTION
Ensure we trigger the corresponding branch for runtime-os