### PR TITLE
NOTICK: javadocJar depends on assemble task

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,6 @@ cordaPipeline(
     runIntegrationTests: false,
     nexusAppId: 'net.corda-api-5.0',
     dependentJobsNames: ['/Corda5/corda-runtime-os-version-compatibility/release%2Fos%2F5.0'],
-    javadocJar: true,
     // always use -beta-9999999999999 for local publication as this is used for the version compatibility checks,
     //  This is a PR gate, so we want to check the "post merge" state before publication for real.
     localPublishVersionSuffixOverride: '-beta-9999999999999',

--- a/build.gradle
+++ b/build.gradle
@@ -214,8 +214,10 @@ subprojects {
             from(dokkaHtml.outputDirectory)
         }
 
-        if(project.hasProperty('generateJavaDocWithBuild')) {
-                assemble.dependsOn javadocJar
+        if (project.hasProperty('generateJavaDocWithBuild')) {
+            artifacts {
+                archives javadocJar
+            }
         }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -213,6 +213,10 @@ subprojects {
             archiveClassifier.set("javadoc")
             from(dokkaHtml.outputDirectory)
         }
+
+        if(project.hasProperty('generateJavaDocWithBuild')) {
+                assemble.dependsOn javadocJar
+        }
     }
 
     pluginManager.withPlugin('io.gitlab.arturbosch.detekt'){


### PR DESCRIPTION
add javadoc generation to assemble task to prevent the need for a separate dedicated target to be called in the CI in a effort to reduce build times (less gradle stages = less configuration overhead if we can do the work in one stage) , ./gradlew build or assemble will now produce this java doc.

`generateJavaDocWithBuild` property must be present for this, property introduced as in most cases this is not required when building locally.

Associated Shared-library PR https://github.com/corda/corda-shared-build-pipeline-steps/pull/457