### PR TITLE
CORE-8989 Removed unused non-nullable field that was causing the toke…

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/ledger/utxo/token/selection/state/TokenCachePoolState.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/ledger/utxo/token/selection/state/TokenCachePoolState.avsc
@@ -5,11 +5,6 @@
   "doc": "The current state of a token cache pool",
   "fields": [
     {
-      "name": "holdingIdentity",
-      "type": "net.corda.data.identity.HoldingIdentity",
-      "doc": "The holding identity the state is for"
-    },
-    {
       "name": "poolKey",
       "type": "net.corda.data.ledger.utxo.token.selection.key.TokenPoolCacheKey",
       "doc": "The key of the cache pool the state is for"


### PR DESCRIPTION
BUG FIX:
Removing a field that was added by mistake in a previous commit, this field was causing the token cache to fail.
