### PR TITLE
CORE-7009 Change UniquenessCheckResponse to LedgerUniquenessCheckResponse

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 600
+cordaApiRevision = 601
 
 # Main
 kotlinVersion = 1.7.21

--- a/ledger/ledger-utxo/src/main/kotlin/net/corda/v5/ledger/utxo/uniqueness/client/LedgerUniquenessCheckResponse.kt
+++ b/ledger/ledger-utxo/src/main/kotlin/net/corda/v5/ledger/utxo/uniqueness/client/LedgerUniquenessCheckResponse.kt
@@ -1,6 +1,7 @@
-package net.corda.v5.application.uniqueness.model
+package net.corda.v5.ledger.utxo.uniqueness.client
 
 import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
+import net.corda.v5.application.uniqueness.model.UniquenessCheckResult
 
 /**
  * This is a response class that wraps the result of the uniqueness checking and a potential signature,
@@ -10,7 +11,7 @@ import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
  * @property signature Contains the signature provided by the uniqueness checker. Will be `null` if the
  * result is a failure.
  */
-interface UniquenessCheckResponse {
+interface LedgerUniquenessCheckResponse {
     val result: UniquenessCheckResult
     val signature: DigitalSignatureAndMetadata?
 }

--- a/ledger/ledger-utxo/src/main/kotlin/net/corda/v5/ledger/utxo/uniqueness/client/LedgerUniquenessCheckerClientService.kt
+++ b/ledger/ledger-utxo/src/main/kotlin/net/corda/v5/ledger/utxo/uniqueness/client/LedgerUniquenessCheckerClientService.kt
@@ -2,7 +2,6 @@ package net.corda.v5.ledger.utxo.uniqueness.client
 
 import net.corda.v5.base.annotations.DoNotImplement
 import net.corda.v5.base.annotations.Suspendable
-import net.corda.v5.application.uniqueness.model.UniquenessCheckResponse
 import net.corda.v5.application.uniqueness.model.UniquenessCheckStateRef
 import java.time.Instant
 import java.util.concurrent.Future
@@ -41,7 +40,7 @@ interface LedgerUniquenessCheckerClientService {
         numOutputStates: Int,
         timeWindowLowerBound: Instant?,
         timeWindowUpperBound: Instant
-    ): UniquenessCheckResponse
+    ): LedgerUniquenessCheckResponse
 }
 
 /**


### PR DESCRIPTION
### Overview

The client service for the uniqueness checker has been renamed to `LedgerUniquenessCheckerClientService`. However, the response it produces remained `UniquenessCheckResponse` which is quite misleading. This PR will rename it to `LedgerUniquenessCheckResponse` to align with the service's name.