### PR TITLE
CORE-8610 - change primary key of cpk related tables

### DIFF
--- a/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/cpx-creation-v1.0.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/cpx-creation-v1.0.xml
@@ -127,10 +127,10 @@
             <column name="file_path" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="content" type="TEXT">
+            <column name="changeset_id" type="UUID">
                 <constraints nullable="false"/>
             </column>
-            <column name="changeset_id" type="UUID">
+            <column name="content" type="TEXT">
                 <constraints nullable="false"/>
             </column>
             <!-- audit -->
@@ -146,7 +146,7 @@
             </column>
         </createTable>
 
-        <addPrimaryKey tableName="cpk_db_change_log" columnNames="cpk_file_checksum, file_path"
+        <addPrimaryKey tableName="cpk_db_change_log" columnNames="cpk_file_checksum, file_path, changeset_id"
                        constraintName="cpk_db_change_log_pk" schemaName="${schema.name}"/>
 
         <addForeignKeyConstraint baseTableName="cpk_db_change_log" baseColumnNames="cpk_file_checksum"

--- a/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/cpx-creation-v1.0.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/cpx-creation-v1.0.xml
@@ -156,6 +156,15 @@
                                  referencedTableSchemaName="${schema.name}"/>
         <!-- Append only audit table. Unlike cpk_db_change_logs which will be updated during CPI update process. -->
         <createTable tableName="cpk_db_change_log_audit" schemaName="${schema.name}">
+            <column name="changeset_id" type="UUID">
+                <constraints nullable="false"/>
+            </column>
+            <column name="cpk_file_checksum" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="file_path" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
             <column name="cpi_name" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
@@ -165,19 +174,7 @@
             <column name="cpi_signer_summary_hash" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="cpk_file_checksum" type="VARCHAR(255)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="file_path" type="VARCHAR(255)">
-                <constraints nullable="false"/>
-            </column>
             <column name="content" type="TEXT">
-                <constraints nullable="false"/>
-            </column>
-            <column name="changeset_id" type="UUID">
-                <constraints nullable="false"/>
-            </column>
-            <column name="entity_version" type="INT">
                 <constraints nullable="false"/>
             </column>
             <column name="is_deleted" type="BOOLEAN">
@@ -189,7 +186,7 @@
             </column>
         </createTable>
 
-        <addPrimaryKey tableName="cpk_db_change_log_audit" columnNames="cpi_name, cpi_version, cpi_signer_summary_hash, cpk_file_checksum, changeset_id, entity_version, file_path"
+        <addPrimaryKey tableName="cpk_db_change_log_audit" columnNames="changeset_id, cpk_file_checksum, file_path"
                        constraintName="cpk_db_change_log_audit_pk" schemaName="${schema.name}"/>
 
         <createTable tableName="cpi_cpk" schemaName="${schema.name}">

--- a/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/cpx-creation-v1.0.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/cpx-creation-v1.0.xml
@@ -127,9 +127,6 @@
             <column name="file_path" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="changeset_id" type="UUID">
-                <constraints nullable="false"/>
-            </column>
             <column name="content" type="TEXT">
                 <constraints nullable="false"/>
             </column>
@@ -146,7 +143,7 @@
             </column>
         </createTable>
 
-        <addPrimaryKey tableName="cpk_db_change_log" columnNames="cpk_file_checksum, file_path, changeset_id"
+        <addPrimaryKey tableName="cpk_db_change_log" columnNames="cpk_file_checksum, file_path"
                        constraintName="cpk_db_change_log_pk" schemaName="${schema.name}"/>
 
         <addForeignKeyConstraint baseTableName="cpk_db_change_log" baseColumnNames="cpk_file_checksum"
@@ -156,22 +153,13 @@
                                  referencedTableSchemaName="${schema.name}"/>
         <!-- Append only audit table. Unlike cpk_db_change_logs which will be updated during CPI update process. -->
         <createTable tableName="cpk_db_change_log_audit" schemaName="${schema.name}">
-            <column name="changeset_id" type="UUID">
+            <column name="id" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
             <column name="cpk_file_checksum" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
             <column name="file_path" type="VARCHAR(255)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="cpi_name" type="VARCHAR(255)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="cpi_version" type="VARCHAR(255)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="cpi_signer_summary_hash" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
             <column name="content" type="TEXT">
@@ -186,7 +174,7 @@
             </column>
         </createTable>
 
-        <addPrimaryKey tableName="cpk_db_change_log_audit" columnNames="changeset_id, cpk_file_checksum, file_path"
+        <addPrimaryKey tableName="cpk_db_change_log_audit" columnNames="id"
                        constraintName="cpk_db_change_log_audit_pk" schemaName="${schema.name}"/>
 
         <createTable tableName="cpi_cpk" schemaName="${schema.name}">

--- a/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/cpx-creation-v1.0.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/cpx-creation-v1.0.xml
@@ -88,22 +88,10 @@
             </column>
         </createTable>
 
-        <addPrimaryKey tableName="cpk_metadata" columnNames="cpk_name, cpk_version, cpk_signer_summary_hash" constraintName="cpk_metadata_pk"
+        <addPrimaryKey tableName="cpk_metadata" columnNames="file_checksum" constraintName="cpk_metadata_pk"
                        schemaName="${schema.name}"/>
 
-        <addUniqueConstraint tableName="cpk_metadata" columnNames="file_checksum" constraintName="db_cpk_metadata_uc1"
-                             schemaName="${schema.name}"/>
-
         <createTable tableName="cpk_file" schemaName="${schema.name}">
-            <column name="cpk_name" type="VARCHAR(255)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="cpk_version" type="VARCHAR(255)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="cpk_signer_summary_hash" type="VARCHAR(255)">
-                <constraints nullable="false"/>
-            </column>
             <column name="file_checksum" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
@@ -123,28 +111,16 @@
             </column>
         </createTable>
 
-        <addPrimaryKey tableName="cpk_file" columnNames="cpk_name, cpk_version, cpk_signer_summary_hash" constraintName="cpk_file_pk"
+        <addPrimaryKey tableName="cpk_file" columnNames="file_checksum" constraintName="cpk_file_pk"
                        schemaName="${schema.name}"/>
 
-        <addForeignKeyConstraint baseTableName="cpk_file" baseColumnNames="cpk_name, cpk_version, cpk_signer_summary_hash"
-                                 referencedTableName="cpk_metadata" referencedColumnNames="cpk_name, cpk_version, cpk_signer_summary_hash"
+        <addForeignKeyConstraint baseTableName="cpk_file" baseColumnNames="file_checksum"
+                                 referencedTableName="cpk_metadata" referencedColumnNames="file_checksum"
                                  constraintName="FK_cpk_file_cpk_metadata"
                                  baseTableSchemaName="${schema.name}"
                                  referencedTableSchemaName="${schema.name}"/>
 
-        <addUniqueConstraint tableName="cpk_file" columnNames="file_checksum" constraintName="db_cpk_file_uc1"
-                             schemaName="${schema.name}"/>
-
         <createTable tableName="cpk_db_change_log" schemaName="${schema.name}">
-            <column name="cpk_name" type="VARCHAR(255)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="cpk_version" type="VARCHAR(255)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="cpk_signer_summary_hash" type="VARCHAR(255)">
-                <constraints nullable="false"/>
-            </column>
             <column name="cpk_file_checksum" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
@@ -170,25 +146,16 @@
             </column>
         </createTable>
 
-        <addPrimaryKey tableName="cpk_db_change_log" columnNames="cpk_name, cpk_version, cpk_signer_summary_hash, file_path"
+        <addPrimaryKey tableName="cpk_db_change_log" columnNames="cpk_file_checksum, file_path"
                        constraintName="cpk_db_change_log_pk" schemaName="${schema.name}"/>
 
-        <addForeignKeyConstraint baseTableName="cpk_db_change_log" baseColumnNames="cpk_name, cpk_version, cpk_signer_summary_hash"
-                                 referencedTableName="cpk_metadata" referencedColumnNames="cpk_name, cpk_version, cpk_signer_summary_hash"
+        <addForeignKeyConstraint baseTableName="cpk_db_change_log" baseColumnNames="cpk_file_checksum"
+                                 referencedTableName="cpk_metadata" referencedColumnNames="file_checksum"
                                  constraintName="FK_cpk_db_change_log_cpk_metadata"
                                  baseTableSchemaName="${schema.name}"
                                  referencedTableSchemaName="${schema.name}"/>
         <!-- Append only audit table. Unlike cpk_db_change_logs which will be updated during CPI update process. -->
         <createTable tableName="cpk_db_change_log_audit" schemaName="${schema.name}">
-            <column name="cpk_name" type="VARCHAR(255)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="cpk_version" type="VARCHAR(255)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="cpk_signer_summary_hash" type="VARCHAR(255)">
-                <constraints nullable="false"/>
-            </column>
             <column name="cpk_file_checksum" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
@@ -213,7 +180,7 @@
             </column>
         </createTable>
 
-        <addPrimaryKey tableName="cpk_db_change_log_audit" columnNames="cpk_name, cpk_version, cpk_signer_summary_hash, cpk_file_checksum, changeset_id, entity_version, file_path"
+        <addPrimaryKey tableName="cpk_db_change_log_audit" columnNames="cpk_file_checksum, changeset_id, entity_version, file_path"
                        constraintName="cpk_db_change_log_audit_pk" schemaName="${schema.name}"/>
 
         <createTable tableName="cpi_cpk" schemaName="${schema.name}">
@@ -224,15 +191,6 @@
                 <constraints nullable="false"/>
             </column>
             <column name="cpi_signer_summary_hash" type="VARCHAR(255)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="cpk_name" type="VARCHAR(255)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="cpk_version" type="VARCHAR(255)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="cpk_signer_summary_hash" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
             <column name="cpk_file_checksum" type="VARCHAR(255)">
@@ -263,8 +221,8 @@
                                  baseTableSchemaName="${schema.name}"
                                  referencedTableSchemaName="${schema.name}"/>
 
-        <addForeignKeyConstraint baseTableName="cpi_cpk" baseColumnNames="cpk_name, cpk_version, cpk_signer_summary_hash"
-                                 referencedTableName="cpk_metadata" referencedColumnNames="cpk_name, cpk_version, cpk_signer_summary_hash"
+        <addForeignKeyConstraint baseTableName="cpi_cpk" baseColumnNames="cpk_file_checksum"
+                                 referencedTableName="cpk_metadata" referencedColumnNames="file_checksum"
                                  constraintName="FK_cpi_cpk_cpk_metadata"
                                  baseTableSchemaName="${schema.name}"
                                  referencedTableSchemaName="${schema.name}"/>

--- a/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/cpx-creation-v1.0.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/cpx-creation-v1.0.xml
@@ -156,6 +156,15 @@
                                  referencedTableSchemaName="${schema.name}"/>
         <!-- Append only audit table. Unlike cpk_db_change_logs which will be updated during CPI update process. -->
         <createTable tableName="cpk_db_change_log_audit" schemaName="${schema.name}">
+            <column name="cpi_name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="cpi_version" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="cpi_signer_summary_hash" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
             <column name="cpk_file_checksum" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
@@ -180,7 +189,7 @@
             </column>
         </createTable>
 
-        <addPrimaryKey tableName="cpk_db_change_log_audit" columnNames="cpk_file_checksum, changeset_id, entity_version, file_path"
+        <addPrimaryKey tableName="cpk_db_change_log_audit" columnNames="cpi_name, cpi_version, cpi_signer_summary_hash, cpk_file_checksum, changeset_id, entity_version, file_path"
                        constraintName="cpk_db_change_log_audit_pk" schemaName="${schema.name}"/>
 
         <createTable tableName="cpi_cpk" schemaName="${schema.name}">

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 621
+cordaApiRevision = 622
 
 # Main
 kotlinVersion = 1.7.21


### PR DESCRIPTION
Runtime OS change: https://github.com/corda/corda-runtime-os/pull/2804

Changing PK of CPK entities to be the CPK's file checksum rather than its name, version, signerSummaryHash.

Consequences of this change mean we no longer need to update existing CPK entities if we force upload a CPI that changes some CPKs, because they will have a different checksum therefore different row in CPK tables.

That means we don't need to track versions of CPKs in the audit trail, then reference these to get the content during rollback of migrations (force-resync REST endpoint). Instead, we just get the changelogs from `cpk_db_change_log` table as we can reference these by the checksum. When running migrations we tag the changelogs with the CPK file checksum they came from. If we are rolling back, we use this to find the changelogs we need to roll back.

The audit table becomes a simple append-only trail of CPK related changes. Possible future improvement of this table is to add some sort of "operationType" that records what happened in each audit row, for example, `FORCE_UPLOAD_CPI` or `UPLOAD_CPI`. 