### PR TITLE
CORE-9076 Make Uniqueness check data models serializable

### DIFF
--- a/application/src/main/kotlin/net/corda/v5/application/uniqueness/model/UniquenessCheckStateDetails.kt
+++ b/application/src/main/kotlin/net/corda/v5/application/uniqueness/model/UniquenessCheckStateDetails.kt
@@ -1,5 +1,6 @@
 package net.corda.v5.application.uniqueness.model
 
+import net.corda.v5.base.annotations.CordaSerializable
 import net.corda.v5.crypto.SecureHash
 
 /**
@@ -8,6 +9,7 @@ import net.corda.v5.crypto.SecureHash
  * client service. This representation is agnostic to both the message bus API and any
  * DB schema that may be used to persist data by the backing store.
  */
+@CordaSerializable
 interface UniquenessCheckStateDetails {
     val stateRef: UniquenessCheckStateRef
     val consumingTxId: SecureHash?

--- a/application/src/main/kotlin/net/corda/v5/application/uniqueness/model/UniquenessCheckStateRef.kt
+++ b/application/src/main/kotlin/net/corda/v5/application/uniqueness/model/UniquenessCheckStateRef.kt
@@ -1,5 +1,6 @@
 package net.corda.v5.application.uniqueness.model
 
+import net.corda.v5.base.annotations.CordaSerializable
 import net.corda.v5.crypto.SecureHash
 
 /**
@@ -10,6 +11,7 @@ import net.corda.v5.crypto.SecureHash
  *
  * T0DO CORE-6629: This class can be removed once the UTXO ledger model gets merged
  */
+@CordaSerializable
 interface UniquenessCheckStateRef {
     val txHash: SecureHash
     val stateIndex: Int


### PR DESCRIPTION
### Overview

Specific notary errors contain details about errors, like the states that were conflicting etc. These details are represented by the  `UniquenessCheckStateDetails` and `UniquenessCheckStateRef` classes. 
These classes were not corda serializable so when we are sending it back to the client from the server the send failed. This PR fixes these issues.
