### PR TITLE
CORE-7331 - Validation error too generic

### DIFF
--- a/data/membership-schema/src/main/resources/net/corda/schema/membership/member/dynamic/registration/1.0/corda.member.dynamic.registration.json
+++ b/data/membership-schema/src/main/resources/net/corda/schema/membership/member/dynamic/registration/1.0/corda.member.dynamic.registration.json
@@ -64,7 +64,6 @@
       ]
     }
   },
-  "minProperties": 4,
   "required": [
     "corda.session.key.id"
   ],

--- a/data/membership-schema/src/main/resources/net/corda/schema/membership/mgm/registration/1.0/corda.mgm.registration.json
+++ b/data/membership-schema/src/main/resources/net/corda/schema/membership/mgm/registration/1.0/corda.mgm.registration.json
@@ -88,7 +88,6 @@
       ]
     }
   },
-  "minProperties": 12,
   "required": [
     "corda.session.key.id",
     "corda.ecdh.key.id",


### PR DESCRIPTION
**Description of the issue**
using single cluster deployment, when register MGM with missing  "corda.endpoints.0.connectionURL"  validation error is too general
`Onboarding MGM failed. The registration context is invalid: Exception when validating membership schema.. Failed to validate against schema \"corda.mgm.registration\" due to the following error(s): [$: should have a minimum of 12 properties]"`

Runtime os PR: https://github.com/corda/corda-runtime-os/pull/2832

**Solution**
Removed `minProperties` check to let the registration fail later on the context check in `runtime-os`, because we can't add patterned properties to required fields in JSON schema validator.

**Test Scenarios**

**For MGM:**

1) Missing endpoint url
![Screenshot 2022-12-28 at 15 04 03](https://user-images.githubusercontent.com/61757742/209831869-50fb2572-2b86-4a07-8c9f-b873fc6adb80.png)

2) Missing endpoint protocol version
![Screenshot 2022-12-28 at 15 04 19](https://user-images.githubusercontent.com/61757742/209831928-013021c0-c4c1-41b9-9c8e-ae1bc7ef810d.png)

3) Missing TLS trust store
![Screenshot 2022-12-28 at 15 04 28](https://user-images.githubusercontent.com/61757742/209832026-db59a059-7c42-4a65-bad7-8acb51460dec.png)

4) Missing session trust store
![Screenshot 2022-12-28 at 15 07 33](https://user-images.githubusercontent.com/61757742/209832245-3e3d5ec4-01e0-41a3-acf2-81a78989d7fd.png)

_All of these checks were already there in runtime-os, we just didn't get there, because the JSON validation failed first due to not having 12 min properties._

**For member:**

1) Missing endpoint url
![Screenshot 2022-12-29 at 11 06 12](https://user-images.githubusercontent.com/61757742/209961726-000a8044-93f2-4be0-b3d1-8b5713e54cc1.png)

2) Missing endpoint protocol version
![Screenshot 2022-12-29 at 11 07 06](https://user-images.githubusercontent.com/61757742/209961789-72f34452-0a04-4cbb-af1f-67c1fc23324f.png)

3) Missing ledger key
![Screenshot 2022-12-29 at 11 08 01](https://user-images.githubusercontent.com/61757742/209961853-8e7e56a9-4689-4d15-be50-71046ec3f941.png)

4) Missing session key
![Screenshot 2022-12-29 at 11 12 04](https://user-images.githubusercontent.com/61757742/209961914-9946850a-469b-44e3-8872-381e111b01c6.png)

5) Missing service name
![Screenshot 2022-12-29 at 11 17 02](https://user-images.githubusercontent.com/61757742/209962029-172801ce-2b07-42d4-8732-ae4eeb6256ee.png)

_All of these checks were already there in runtime-os, we just didn't get there, because the JSON validation failed first due to not having 4 min properties._

**The only check that had to be added in the runtime-os PR (https://github.com/corda/corda-runtime-os/pull/2832) was for notaries: we checked for the missing notary keys in StartRegistrationHandler, but I moved it forward to the registration service, so we can fail much faster and avoid having an invalid request submitted.**
![Screenshot 2022-12-29 at 13 37 51](https://user-images.githubusercontent.com/61757742/209962304-609dcc36-8158-4cce-be26-9c7c32dd0286.png)

 
