### PR TITLE
CORE-8861: Add TLS type to member group policy file

### DIFF
--- a/data/membership-schema/src/main/resources/net/corda/schema/membership/group/policy/1.0/corda.group.policy.json
+++ b/data/membership-schema/src/main/resources/net/corda/schema/membership/group/policy/1.0/corda.group.policy.json
@@ -172,7 +172,8 @@
         "tlsTrustRoots",
         "tlsPki",
         "tlsVersion",
-        "protocolMode"
+        "protocolMode",
+        "tlsType"
       ],
       "properties": {
         "sessionTrustRoots": {
@@ -218,6 +219,13 @@
           "enum": [
             "Authentication",
             "Authenticated_Encryption"
+          ]
+        },
+        "tlsType": {
+          "description": "What kind of TLS connections the group supports.",
+          "enum": [
+            "OneWay",
+            "Mutual"
           ]
         }
       },

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 602
+cordaApiRevision = 607
 
 # Main
 kotlinVersion = 1.7.21


### PR DESCRIPTION
Adds the TLS type to the group policy file.

Runtime PR in https://github.com/corda/corda-runtime-os/pull/2836