### PR TITLE
CORE-9063 - Add pre-auth token to context schema

### DIFF
--- a/data/membership-schema/src/main/resources/net/corda/schema/membership/member/dynamic/registration/1.0/corda.member.dynamic.registration.json
+++ b/data/membership-schema/src/main/resources/net/corda/schema/membership/member/dynamic/registration/1.0/corda.member.dynamic.registration.json
@@ -66,6 +66,7 @@
     "corda.auth.token": {
       "description": "Optional. A UUID string that uniquely identities the pre-auth token.",
       "type": "string",
+      "minLength": 36,
       "maxLength": 36
     }
   },

--- a/data/membership-schema/src/main/resources/net/corda/schema/membership/member/dynamic/registration/1.0/corda.member.dynamic.registration.json
+++ b/data/membership-schema/src/main/resources/net/corda/schema/membership/member/dynamic/registration/1.0/corda.member.dynamic.registration.json
@@ -66,7 +66,7 @@
     "corda.auth.token": {
       "description": "Optional. A UUID string that uniquely identities the pre-auth token.",
       "type": "string",
-      "pattern": "[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}$"
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[1-5][a-fA-F0-9]{3}-[89aAbB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}$"
     }
   },
   "minProperties": 4,

--- a/data/membership-schema/src/main/resources/net/corda/schema/membership/member/dynamic/registration/1.0/corda.member.dynamic.registration.json
+++ b/data/membership-schema/src/main/resources/net/corda/schema/membership/member/dynamic/registration/1.0/corda.member.dynamic.registration.json
@@ -66,8 +66,7 @@
     "corda.auth.token": {
       "description": "Optional. A UUID string that uniquely identities the pre-auth token.",
       "type": "string",
-      "minLength": 36,
-      "maxLength": 36
+      "pattern": "[a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12}$"
     }
   },
   "minProperties": 4,

--- a/data/membership-schema/src/main/resources/net/corda/schema/membership/member/dynamic/registration/1.0/corda.member.dynamic.registration.json
+++ b/data/membership-schema/src/main/resources/net/corda/schema/membership/member/dynamic/registration/1.0/corda.member.dynamic.registration.json
@@ -62,6 +62,11 @@
       "examples": [
         "net.corda.notary.MyNotaryService"
       ]
+    },
+    "corda.auth.token": {
+      "description": "Optional. A UUID string that uniquely identities the pre-auth token.",
+      "type": "string",
+      "maxLength": 36
     }
   },
   "minProperties": 4,


### PR DESCRIPTION
**Description**
The registration context has a schema defined in the corda-api. This needs to be updated so that a pre-auth token can be included in the dynamic member’s registration context.

**Testing**

1) UUID too long
![Screenshot 2022-12-30 at 14 58 13](https://user-images.githubusercontent.com/61757742/210084052-e35cf6e8-4774-4b0f-b9cd-b2e885ee840a.png)

2) UUID is random string
![Screenshot 2022-12-30 at 14 58 25](https://user-images.githubusercontent.com/61757742/210084106-0bf0d324-99aa-444d-8b9c-f452815c5f79.png)

3) UUID is empty string
![Screenshot 2022-12-30 at 14 58 37](https://user-images.githubusercontent.com/61757742/210084135-a0c311f0-2d79-4ac6-96b2-44c6a4540250.png)

4) Wrong key used
![Screenshot 2022-12-30 at 14 58 50](https://user-images.githubusercontent.com/61757742/210084193-e707906c-cebf-4c29-8d2f-bc35a2f10db0.png)

5) UUID too short
![Screenshot 2022-12-30 at 14 59 08](https://user-images.githubusercontent.com/61757742/210084270-ce1a8d63-c340-4e88-b9cb-5de4262c46f3.png)

6) Valid UUID
![Screenshot 2022-12-30 at 14 59 17](https://user-images.githubusercontent.com/61757742/210084332-c3f24632-36db-4a38-86f8-880556781733.png)

