### PR TITLE
CORE-9149 Remove temporary methods for backchain testing

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 523-Fox
+cordaApiRevision = 524-Fox
 
 
 # Main

--- a/ledger/ledger-utxo/src/main/kotlin/net/corda/v5/ledger/utxo/UtxoLedgerService.kt
+++ b/ledger/ledger-utxo/src/main/kotlin/net/corda/v5/ledger/utxo/UtxoLedgerService.kt
@@ -120,18 +120,4 @@ interface UtxoLedgerService {
         session: FlowSession,
         validator: UtxoTransactionValidator
     ): UtxoSignedTransaction
-
-    // TODO CORE-7327 Add verify(signedTx) verify(ledgerTx)
-
-    @Deprecated("Temporary until finality flow is completed")
-    @Suspendable
-    fun persistTransaction(signedTransaction: UtxoSignedTransaction)
-
-    @Deprecated("Temporary until finality flow is completed")
-    @Suspendable
-    fun resolveBackchain(signedTransaction: UtxoSignedTransaction, session: FlowSession)
-
-    @Deprecated("Temporary until finality flow is completed")
-    @Suspendable
-    fun sendBackchain(session: FlowSession)
 }


### PR DESCRIPTION
These methods are no longer needed and should exist on the API.