### PR TITLE
CORE-8108 Add `SignatureSpec` field to `DigitalSignatureMetadata`

### DIFF
--- a/application/src/main/kotlin/net/corda/v5/application/crypto/DigitalSignatureMetadata.kt
+++ b/application/src/main/kotlin/net/corda/v5/application/crypto/DigitalSignatureMetadata.kt
@@ -1,6 +1,7 @@
 package net.corda.v5.application.crypto
 
 import net.corda.v5.base.annotations.CordaSerializable
+import net.corda.v5.crypto.SignatureSpec
 import java.time.Instant
 
 /**
@@ -12,6 +13,7 @@ import java.time.Instant
  * Note that the metadata itself is not signed over.
  *
  * @property timestamp The timestamp at which the signature was applied.
+ * @property signatureSpec The signature spec.
  * @property properties A set of properties for this signature. Content depends on API layers above `application`.
  *
  * @constructor Creates a [DigitalSignatureMetadata].
@@ -19,5 +21,6 @@ import java.time.Instant
 @CordaSerializable
 data class DigitalSignatureMetadata(
     val timestamp: Instant,
+    val signatureSpec: SignatureSpec,
     val properties: Map<String, String>
 )

--- a/crypto/src/main/kotlin/net/corda/v5/crypto/ParameterizedSignatureSpec.kt
+++ b/crypto/src/main/kotlin/net/corda/v5/crypto/ParameterizedSignatureSpec.kt
@@ -1,6 +1,5 @@
 package net.corda.v5.crypto
 
-import net.corda.v5.base.annotations.CordaSerializable
 import java.security.spec.AlgorithmParameterSpec
 
 /**

--- a/crypto/src/main/kotlin/net/corda/v5/crypto/ParameterizedSignatureSpec.kt
+++ b/crypto/src/main/kotlin/net/corda/v5/crypto/ParameterizedSignatureSpec.kt
@@ -1,5 +1,6 @@
 package net.corda.v5.crypto
 
+import net.corda.v5.base.annotations.CordaSerializable
 import java.security.spec.AlgorithmParameterSpec
 
 /**
@@ -14,6 +15,7 @@ import java.security.spec.AlgorithmParameterSpec
  * When used for signing the [signatureName] must match the corresponding key scheme, e.g. you cannot use
  * "SHA256withECDSA" with "RSA" keys.
  */
+@CordaSerializable
 class ParameterizedSignatureSpec(
     signatureName: String,
     val params: AlgorithmParameterSpec

--- a/crypto/src/main/kotlin/net/corda/v5/crypto/ParameterizedSignatureSpec.kt
+++ b/crypto/src/main/kotlin/net/corda/v5/crypto/ParameterizedSignatureSpec.kt
@@ -15,7 +15,6 @@ import java.security.spec.AlgorithmParameterSpec
  * When used for signing the [signatureName] must match the corresponding key scheme, e.g. you cannot use
  * "SHA256withECDSA" with "RSA" keys.
  */
-@CordaSerializable
 class ParameterizedSignatureSpec(
     signatureName: String,
     val params: AlgorithmParameterSpec

--- a/crypto/src/main/kotlin/net/corda/v5/crypto/SignatureSpec.kt
+++ b/crypto/src/main/kotlin/net/corda/v5/crypto/SignatureSpec.kt
@@ -45,7 +45,7 @@ open class SignatureSpec(
             signatureName = "SHA512withRSA"
         )
 
-        // TODO: The below `ParameterizedSignatureSpec`s break/ are not `CordaSerializable` due to `ParameterizedSignatureSpec.params`
+        // TODO The below `ParameterizedSignatureSpec`s break/ are not `CordaSerializable` due to `ParameterizedSignatureSpec.params`
         //  and `PSSParameterSpec.mgfSpec` both being of type `AlgorithmParameterSpec`.
         /**
          * RSASSA-PSS with SHA256 [SignatureSpec].

--- a/crypto/src/main/kotlin/net/corda/v5/crypto/SignatureSpec.kt
+++ b/crypto/src/main/kotlin/net/corda/v5/crypto/SignatureSpec.kt
@@ -1,5 +1,6 @@
 package net.corda.v5.crypto
 
+import net.corda.v5.base.annotations.CordaSerializable
 import java.security.spec.MGF1ParameterSpec
 import java.security.spec.PSSParameterSpec
 
@@ -12,6 +13,7 @@ import java.security.spec.PSSParameterSpec
  * When used for signing the [signatureName] must match the corresponding key scheme, e.g. you cannot use
  * "SHA256withECDSA" with "RSA" keys.
  */
+@CordaSerializable
 open class SignatureSpec(
     /**
      * The signature-scheme name as required to create [java.security.Signature] objects (e.g. "SHA256withECDSA").
@@ -43,6 +45,8 @@ open class SignatureSpec(
             signatureName = "SHA512withRSA"
         )
 
+        // TODO: The below `ParameterizedSignatureSpec`s break/ are not `CordaSerializable` due to `ParameterizedSignatureSpec.params`
+        //  and `PSSParameterSpec.mgfSpec` both being of type `AlgorithmParameterSpec`.
         /**
          * RSASSA-PSS with SHA256 [SignatureSpec].
          */

--- a/crypto/src/main/kotlin/net/corda/v5/crypto/SignatureSpec.kt
+++ b/crypto/src/main/kotlin/net/corda/v5/crypto/SignatureSpec.kt
@@ -45,8 +45,6 @@ open class SignatureSpec(
             signatureName = "SHA512withRSA"
         )
 
-        // TODO The below `ParameterizedSignatureSpec`s break/ are not `CordaSerializable` due to `ParameterizedSignatureSpec.params`
-        //  and `PSSParameterSpec.mgfSpec` both being of type `AlgorithmParameterSpec`.
         /**
          * RSASSA-PSS with SHA256 [SignatureSpec].
          */

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 622
+cordaApiRevision = 623
 
 # Main
 kotlinVersion = 1.7.21

--- a/ledger/ledger-consensual/src/test/java/net/corda/v5/ledger/consensual/transaction/ConsensualSignedTransactionJavaApiTest.java
+++ b/ledger/ledger-consensual/src/test/java/net/corda/v5/ledger/consensual/transaction/ConsensualSignedTransactionJavaApiTest.java
@@ -1,10 +1,10 @@
 package net.corda.v5.ledger.consensual.transaction;
 
-import kotlin.Pair;
 import net.corda.v5.application.crypto.DigitalSignatureAndMetadata;
 import net.corda.v5.application.crypto.DigitalSignatureMetadata;
 import net.corda.v5.crypto.DigitalSignature;
 import net.corda.v5.crypto.SecureHash;
+import net.corda.v5.crypto.SignatureSpec;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -12,7 +12,6 @@ import java.security.PublicKey;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -22,7 +21,8 @@ import static org.mockito.Mockito.when;
 public class ConsensualSignedTransactionJavaApiTest {
     private final ConsensualSignedTransaction consensualSignedTransaction = mock(ConsensualSignedTransaction.class);
     private final DigitalSignature.WithKey signature = new DigitalSignature.WithKey(mock(PublicKey.class), "0".getBytes(), Map.of());
-    private final DigitalSignatureMetadata signatureMetadata = new DigitalSignatureMetadata(Instant.now(), Map.of());
+    private final DigitalSignatureMetadata signatureMetadata =
+            new DigitalSignatureMetadata(Instant.now(), new SignatureSpec("dummySignatureName"), Map.of());
     private final DigitalSignatureAndMetadata signatureWithMetaData = new DigitalSignatureAndMetadata(signature, signatureMetadata);
 
     @Test

--- a/ledger/ledger-consensual/src/test/java/net/corda/v5/ledger/consensual/transaction/ConsensualTransactionBuilderJavaApiTest.java
+++ b/ledger/ledger-consensual/src/test/java/net/corda/v5/ledger/consensual/transaction/ConsensualTransactionBuilderJavaApiTest.java
@@ -3,6 +3,7 @@ package net.corda.v5.ledger.consensual.transaction;
 import net.corda.v5.application.crypto.DigitalSignatureAndMetadata;
 import net.corda.v5.application.crypto.DigitalSignatureMetadata;
 import net.corda.v5.crypto.DigitalSignature;
+import net.corda.v5.crypto.SignatureSpec;
 import net.corda.v5.ledger.consensual.ConsensualState;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -21,7 +22,8 @@ import static org.mockito.Mockito.when;
 public class ConsensualTransactionBuilderJavaApiTest {
     private final ConsensualTransactionBuilder consensualTransactionBuilder = mock(ConsensualTransactionBuilder.class);
     private final DigitalSignature.WithKey signature = new DigitalSignature.WithKey(mock(PublicKey.class), "0".getBytes(), Map.of());
-    private final DigitalSignatureMetadata signatureMetadata = new DigitalSignatureMetadata(Instant.now(), Map.of());
+    private final DigitalSignatureMetadata signatureMetadata =
+            new DigitalSignatureMetadata(Instant.now(), new SignatureSpec("dummySignatureName"), Map.of());
     private final DigitalSignatureAndMetadata signatureWithMetaData = new DigitalSignatureAndMetadata(signature, signatureMetadata);
 
     @Test

--- a/ledger/ledger-utxo/src/test/java/net/corda/v5/ledger/utxo/AbstractMockTestHarness.java
+++ b/ledger/ledger-utxo/src/test/java/net/corda/v5/ledger/utxo/AbstractMockTestHarness.java
@@ -5,6 +5,7 @@ import net.corda.v5.application.crypto.DigitalSignatureMetadata;
 import net.corda.v5.base.types.MemberX500Name;
 import net.corda.v5.crypto.DigitalSignature;
 import net.corda.v5.crypto.SecureHash;
+import net.corda.v5.crypto.SignatureSpec;
 import net.corda.v5.ledger.common.Party;
 import net.corda.v5.ledger.utxo.transaction.UtxoLedgerTransaction;
 import net.corda.v5.ledger.utxo.transaction.UtxoSignedTransaction;
@@ -111,7 +112,8 @@ public class AbstractMockTestHarness {
 
     private DigitalSignatureAndMetadata createDigitalSignature(PublicKey signatory) {
         DigitalSignature.WithKey signature = new DigitalSignature.WithKey(signatory, new byte[]{0}, Map.of());
-        DigitalSignatureMetadata metadata = new DigitalSignatureMetadata(minInstant, Map.of());
+        DigitalSignatureMetadata metadata =
+                new DigitalSignatureMetadata(minInstant, new SignatureSpec("dummySignatureName"), Map.of());
 
         return new DigitalSignatureAndMetadata(signature, metadata);
     }


### PR DESCRIPTION
- adds `SignatureSpec` field to `DigitalSignatureMetadata`.
- marks `SignatureSpec` as `CordaSerializable`.


runtime-os PR: [#2873](https://github.com/corda/corda-runtime-os/pull/2873)