### PR TITLE
CORE-8868: Add Holding identity to the Gateway TLS certificates

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/GatewayTlsCertificates.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/GatewayTlsCertificates.avsc
@@ -9,6 +9,11 @@
       "type": "string"
     },
     {
+      "doc": "The holding identity that the certificate belongs to",
+      "name": "holdingIdentity",
+      "type": "net.corda.data.identity.HoldingIdentity"
+    },
+    {
       "doc": "Collection of certificates in PEM format",
       "name": "tlsCertificates",
       "type": {

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/GatewayTlsCertificates.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/GatewayTlsCertificates.avsc
@@ -9,7 +9,7 @@
       "type": "string"
     },
     {
-      "doc": "The holding identity that the certificate belongs to",
+      "doc": "The holding identity that the certificate is used by.",
       "name": "holdingIdentity",
       "type": "net.corda.data.identity.HoldingIdentity"
     },

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 607
+cordaApiRevision = 606
 
 # Main
 kotlinVersion = 1.7.21

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 602
+cordaApiRevision = 607
 
 # Main
 kotlinVersion = 1.7.21


### PR DESCRIPTION
Runtime PR in https://github.com/corda/corda-runtime-os/pull/2846

This change adds the holding identity to the Gateway TLS certificates (to be used as client certificates)