### PR TITLE
NOTICK - Fix typo in description

### DIFF
--- a/data/membership-schema/src/main/resources/net/corda/schema/membership/member/dynamic/registration/1.0/corda.member.dynamic.registration.json
+++ b/data/membership-schema/src/main/resources/net/corda/schema/membership/member/dynamic/registration/1.0/corda.member.dynamic.registration.json
@@ -64,7 +64,7 @@
       ]
     },
     "corda.auth.token": {
-      "description": "Optional. A UUID string that uniquely identities the pre-auth token.",
+      "description": "Optional. A UUID string that uniquely identifies the pre-auth token.",
       "type": "string",
       "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[1-5][a-fA-F0-9]{3}-[89aAbB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}$"
     }


### PR DESCRIPTION
Fix typo in description for pre-auth tokens. Wrote 'identities' instead of 'identifies'.