### PR TITLE
CORE-7995 Make sign and verify operation APIs more symmetric 

### DIFF
--- a/application/src/main/kotlin/net/corda/v5/application/crypto/DigitalSignatureVerificationService.kt
+++ b/application/src/main/kotlin/net/corda/v5/application/crypto/DigitalSignatureVerificationService.kt
@@ -28,5 +28,18 @@ interface DigitalSignatureVerificationService {
      */
     fun verify(publicKey: PublicKey, signatureSpec: SignatureSpec, signatureData: ByteArray, clearData: ByteArray)
 
+    /**
+     * Verifies a digital signature by using [signatureSpec].
+     * Always throws an exception if verification fails.
+     *
+     * @param publicKey The signer's [PublicKey].
+     * @param signatureSpec The signature spec.
+     * @param signature The signature on a message.
+     * @param clearData The clear data/message that was signed (usually the Merkle root).
+     *
+     * @throws CryptoSignatureException If verification of the digital signature fails.
+     * @throws IllegalArgumentException If the signature scheme is not supported or if any of the clear or signature
+     * data is empty.
+     */
     fun verify(publicKey: PublicKey, signatureSpec: SignatureSpec, signature: DigitalSignature, clearData: ByteArray)
 }

--- a/application/src/main/kotlin/net/corda/v5/application/crypto/DigitalSignatureVerificationService.kt
+++ b/application/src/main/kotlin/net/corda/v5/application/crypto/DigitalSignatureVerificationService.kt
@@ -29,16 +29,16 @@ interface DigitalSignatureVerificationService {
     fun verify(publicKey: PublicKey, signatureSpec: SignatureSpec, signatureData: ByteArray, clearData: ByteArray)
 
     /**
-     * Verifies a digital signature for the specified [signatureSpec]. Throws [CryptoSignatureException] if verification fails.
+     * Verifies a digital signature against some data. Throws [CryptoSignatureException] if verification fails.
      *
      * @param publicKey The signer's [PublicKey].
      * @param signatureSpec The signature spec.
-     * @param signature The signature on a message.
-     * @param clearData The clear data/message that was signed (usually the Merkle root).
+     * @param signature A signature on some data.
+     * @param originalData The data that was signed (usually the Merkle root).
      *
      * @throws CryptoSignatureException If verification of the digital signature fails.
      * @throws IllegalArgumentException If the signature scheme is not supported or if any of the clear or signature
      * data is empty.
      */
-    fun verify(publicKey: PublicKey, signatureSpec: SignatureSpec, signature: DigitalSignature, clearData: ByteArray)
+    fun verify(publicKey: PublicKey, signatureSpec: SignatureSpec, signature: DigitalSignature, originalData: ByteArray)
 }

--- a/application/src/main/kotlin/net/corda/v5/application/crypto/DigitalSignatureVerificationService.kt
+++ b/application/src/main/kotlin/net/corda/v5/application/crypto/DigitalSignatureVerificationService.kt
@@ -13,6 +13,7 @@ import java.security.PublicKey
  */
 @DoNotImplement
 interface DigitalSignatureVerificationService {
+    // TODO The following `verify` overload should be aligned with the other one as per: https://r3-cev.atlassian.net/browse/CORE-9332
     /**
      * Verifies a digital signature by using [signatureSpec].
      * Always throws an exception if verification fails.

--- a/application/src/main/kotlin/net/corda/v5/application/crypto/DigitalSignatureVerificationService.kt
+++ b/application/src/main/kotlin/net/corda/v5/application/crypto/DigitalSignatureVerificationService.kt
@@ -1,6 +1,7 @@
 package net.corda.v5.application.crypto
 
 import net.corda.v5.base.annotations.DoNotImplement
+import net.corda.v5.crypto.DigitalSignature
 import net.corda.v5.crypto.SignatureSpec
 import net.corda.v5.crypto.exceptions.CryptoSignatureException
 import java.security.PublicKey
@@ -26,4 +27,6 @@ interface DigitalSignatureVerificationService {
      * data is empty.
      */
     fun verify(publicKey: PublicKey, signatureSpec: SignatureSpec, signatureData: ByteArray, clearData: ByteArray)
+
+    fun verify(publicKey: PublicKey, signatureSpec: SignatureSpec, signature: DigitalSignature, clearData: ByteArray)
 }

--- a/application/src/main/kotlin/net/corda/v5/application/crypto/DigitalSignatureVerificationService.kt
+++ b/application/src/main/kotlin/net/corda/v5/application/crypto/DigitalSignatureVerificationService.kt
@@ -29,10 +29,10 @@ interface DigitalSignatureVerificationService {
     fun verify(publicKey: PublicKey, signatureSpec: SignatureSpec, signatureData: ByteArray, clearData: ByteArray)
 
     /**
-     * Verifies a digital signature against some data. Throws [CryptoSignatureException] if verification fails.
+     * Verifies a digital signature against data. Throws [CryptoSignatureException] if verification fails.
      *
-     * @param signature A digital signature on some data.
      * @param originalData The original data on which the signature was applied (usually the Merkle root).
+     * @param signature The digital signature.
      * @param publicKey The signer's [PublicKey].
      * @param signatureSpec The signature spec.
      *
@@ -40,5 +40,5 @@ interface DigitalSignatureVerificationService {
      * @throws IllegalArgumentException If the signature scheme is not supported or if any of the clear or signature
      * data is empty.
      */
-    fun verify(signature: DigitalSignature, originalData: ByteArray, publicKey: PublicKey, signatureSpec: SignatureSpec)
+    fun verify(originalData: ByteArray, signature: DigitalSignature, publicKey: PublicKey, signatureSpec: SignatureSpec)
 }

--- a/application/src/main/kotlin/net/corda/v5/application/crypto/DigitalSignatureVerificationService.kt
+++ b/application/src/main/kotlin/net/corda/v5/application/crypto/DigitalSignatureVerificationService.kt
@@ -31,7 +31,7 @@ interface DigitalSignatureVerificationService {
     /**
      * Verifies a digital signature against some data. Throws [CryptoSignatureException] if verification fails.
      *
-     * @param signature A signature on some data.
+     * @param signature A digital signature on some data.
      * @param originalData The original data on which the signature was applied (usually the Merkle root).
      * @param publicKey The signer's [PublicKey].
      * @param signatureSpec The signature spec.

--- a/application/src/main/kotlin/net/corda/v5/application/crypto/DigitalSignatureVerificationService.kt
+++ b/application/src/main/kotlin/net/corda/v5/application/crypto/DigitalSignatureVerificationService.kt
@@ -29,8 +29,7 @@ interface DigitalSignatureVerificationService {
     fun verify(publicKey: PublicKey, signatureSpec: SignatureSpec, signatureData: ByteArray, clearData: ByteArray)
 
     /**
-     * Verifies a digital signature by using [signatureSpec].
-     * Always throws an exception if verification fails.
+     * Verifies a digital signature for the specified [signatureSpec]. Throws [CryptoSignatureException] if verification fails.
      *
      * @param publicKey The signer's [PublicKey].
      * @param signatureSpec The signature spec.

--- a/application/src/main/kotlin/net/corda/v5/application/crypto/DigitalSignatureVerificationService.kt
+++ b/application/src/main/kotlin/net/corda/v5/application/crypto/DigitalSignatureVerificationService.kt
@@ -31,14 +31,14 @@ interface DigitalSignatureVerificationService {
     /**
      * Verifies a digital signature against some data. Throws [CryptoSignatureException] if verification fails.
      *
-     * @param publicKey The signer's [PublicKey].
-     * @param signatureSpec The signature spec.
      * @param signature A signature on some data.
      * @param originalData The data that was signed (usually the Merkle root).
+     * @param publicKey The signer's [PublicKey].
+     * @param signatureSpec The signature spec.
      *
      * @throws CryptoSignatureException If verification of the digital signature fails.
      * @throws IllegalArgumentException If the signature scheme is not supported or if any of the clear or signature
      * data is empty.
      */
-    fun verify(publicKey: PublicKey, signatureSpec: SignatureSpec, signature: DigitalSignature, originalData: ByteArray)
+    fun verify(signature: DigitalSignature, originalData: ByteArray, publicKey: PublicKey, signatureSpec: SignatureSpec)
 }

--- a/application/src/main/kotlin/net/corda/v5/application/crypto/DigitalSignatureVerificationService.kt
+++ b/application/src/main/kotlin/net/corda/v5/application/crypto/DigitalSignatureVerificationService.kt
@@ -32,7 +32,7 @@ interface DigitalSignatureVerificationService {
      * Verifies a digital signature against some data. Throws [CryptoSignatureException] if verification fails.
      *
      * @param signature A signature on some data.
-     * @param originalData The data that was signed (usually the Merkle root).
+     * @param originalData The original data on which the signature was applied (usually the Merkle root).
      * @param publicKey The signer's [PublicKey].
      * @param signatureSpec The signature spec.
      *

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 609
+cordaApiRevision = 610
 
 # Main
 kotlinVersion = 1.7.21


### PR DESCRIPTION
- adds verify overload taking `DigitalSignature` instead of `ByteArray` as the signature to be more symmetric with sign operation which returns `DigitalSignature.WithKey` (extends `DigitalSignature`).

runtime-os PR: [#2875](https://github.com/corda/corda-runtime-os/pull/2875)