### PR TITLE
CORE-6629 Add comment to Uniqueness Checker State Ref

### DIFF
--- a/application/src/main/kotlin/net/corda/v5/application/uniqueness/model/UniquenessCheckStateRef.kt
+++ b/application/src/main/kotlin/net/corda/v5/application/uniqueness/model/UniquenessCheckStateRef.kt
@@ -9,7 +9,8 @@ import net.corda.v5.crypto.SecureHash
  * model and is agnostic to both the message bus API and any DB schema that may be used to persist data
  * by the backing store.
  *
- * T0DO CORE-6629: This class can be removed once the UTXO ledger model gets merged
+ * Please note that this class is entirely different from the Ledger specific `StateRef` class. This class represents
+ * a state ref that the uniqueness checker will process and might be different from the UTXO data model.
  */
 @CordaSerializable
 interface UniquenessCheckStateRef {

--- a/application/src/main/kotlin/net/corda/v5/application/uniqueness/model/UniquenessCheckStateRef.kt
+++ b/application/src/main/kotlin/net/corda/v5/application/uniqueness/model/UniquenessCheckStateRef.kt
@@ -9,9 +9,9 @@ import net.corda.v5.crypto.SecureHash
  * model and is agnostic to both the message bus API and any DB schema that may be used to persist data
  * by the backing store.
  *
- * Please note that this representation of a state ref is entirely different from the Ledger specific `StateRef` class.
- * This class represents a state ref that the uniqueness checker will process and might be different from the UTXO data
- * model.
+ * Please note that this representation of a state ref is entirely different from the Ledger specific
+ * [StateRef][net.corda.v5.ledger.utxo.StateRef] class. This class represents a state ref that the
+ * uniqueness checker will process and may differ from the UTXO ledger data model.
  */
 @CordaSerializable
 interface UniquenessCheckStateRef {

--- a/application/src/main/kotlin/net/corda/v5/application/uniqueness/model/UniquenessCheckStateRef.kt
+++ b/application/src/main/kotlin/net/corda/v5/application/uniqueness/model/UniquenessCheckStateRef.kt
@@ -9,8 +9,9 @@ import net.corda.v5.crypto.SecureHash
  * model and is agnostic to both the message bus API and any DB schema that may be used to persist data
  * by the backing store.
  *
- * Please note that this class is entirely different from the Ledger specific `StateRef` class. This class represents
- * a state ref that the uniqueness checker will process and might be different from the UTXO data model.
+ * Please note that this representation of a state ref is entirely different from the Ledger specific `StateRef` class.
+ * This class represents a state ref that the uniqueness checker will process and might be different from the UTXO data
+ * model.
  */
 @CordaSerializable
 interface UniquenessCheckStateRef {


### PR DESCRIPTION
### Overview

We need to make it clear that the uniqueness checker's state ref representation is different from the UTXO model.