### PR TITLE
CORE-6173 Add notary keys to the member info

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 608
+cordaApiRevision = 609
 
 # Main
 kotlinVersion = 1.7.21

--- a/membership/src/main/kotlin/net/corda/v5/membership/MemberInfo.kt
+++ b/membership/src/main/kotlin/net/corda/v5/membership/MemberInfo.kt
@@ -47,6 +47,8 @@ import java.security.PublicKey
  * @property ledgerKeys List of current and previous (rotated) ledger keys, which member can still use to sign unspent
  * transactions on ledger.
  * Key at index 0 is always the latest added ledger key.
+ * @property notaryKeys List of current and previous (rotated) notary keys. Key at index 0 is always the latest added
+ * notary key. Might be an empty list if the member is not a notary VNode.
  * @property platformVersion Corda platform version that the member is running on.
  * @property serial An arbitrary number incremented each time the [MemberInfo] is changed.
  * @property isActive True if the member is active. Otherwise, false.
@@ -58,6 +60,7 @@ interface MemberInfo {
     val name: MemberX500Name
     val sessionInitiationKey: PublicKey
     val ledgerKeys: List<PublicKey>
+    val notaryKeys: List<PublicKey>
     val platformVersion: Int
     val serial: Long
     val isActive: Boolean


### PR DESCRIPTION
### Overview

Add a new property to the `MemberInfo` which is called `notaryKeys`. This will return the keys that belong to the given Notary VNode (**NOT the service**).

If the VNode is not a Notary VNode it will return an empty list as there are no keys registered under `corda.notary.keys`.