### PR TITLE
CORE-8860: Add TLS type to Mgm registration context

### DIFF
--- a/data/membership-schema/src/main/resources/net/corda/schema/membership/mgm/registration/1.0/corda.mgm.registration.json
+++ b/data/membership-schema/src/main/resources/net/corda/schema/membership/mgm/registration/1.0/corda.mgm.registration.json
@@ -80,7 +80,7 @@
       ]
     },
     "corda.group.tls.type": {
-      "description": "The TLS type. Default to OneWay",
+      "description": "What kind of TLS connections to establish between the gateways in our cluster and gateways in other clusters. This setting MUST be the same on all Gateways that need to communicate via HTTPS. The default value is OneWay",
       "type": "string",
       "examples": [
         "Mutual",

--- a/data/membership-schema/src/main/resources/net/corda/schema/membership/mgm/registration/1.0/corda.mgm.registration.json
+++ b/data/membership-schema/src/main/resources/net/corda/schema/membership/mgm/registration/1.0/corda.mgm.registration.json
@@ -79,6 +79,13 @@
         "1.3"
       ]
     },
+    "corda.group.tls.type": {
+      "description": "The TLS type. Default to OneWay",
+      "enum":  [
+        "Mutual",
+        "OneWay"
+      ]
+    },
     "corda.group.protocol.p2p.mode": {
       "description": "The protocol mode which the P2P layer should use.",
       "type": "string",

--- a/data/membership-schema/src/main/resources/net/corda/schema/membership/mgm/registration/1.0/corda.mgm.registration.json
+++ b/data/membership-schema/src/main/resources/net/corda/schema/membership/mgm/registration/1.0/corda.mgm.registration.json
@@ -81,7 +81,8 @@
     },
     "corda.group.tls.type": {
       "description": "The TLS type. Default to OneWay",
-      "enum":  [
+      "type": "string",
+      "examples": [
         "Mutual",
         "OneWay"
       ]

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 608
+cordaApiRevision = 611
 
 # Main
 kotlinVersion = 1.7.21


### PR DESCRIPTION
Adds `corda.group.tls.type` to Mgm registration context

The runtime pull request is in https://github.com/corda/corda-runtime-os/pull/2890