### PR TITLE
CORE-8016 - renaming 'http rpc' to 'rest' in corda-api

### DIFF
--- a/data/config-schema/src/main/kotlin/net/corda/schema/configuration/ConfigKeys.kt
+++ b/data/config-schema/src/main/kotlin/net/corda/schema/configuration/ConfigKeys.kt
@@ -20,7 +20,7 @@ object ConfigKeys {
     const val MEMBERSHIP_CONFIG = "corda.membership"
     const val SECURITY_CONFIG = "corda.security"
 
-    //  RPC
+    //  REST
     const val REST_ADDRESS = "address"
     const val REST_CONTEXT_DESCRIPTION = "context.description"
     const val REST_CONTEXT_TITLE = "context.title"

--- a/data/config-schema/src/main/kotlin/net/corda/schema/configuration/ConfigKeys.kt
+++ b/data/config-schema/src/main/kotlin/net/corda/schema/configuration/ConfigKeys.kt
@@ -13,7 +13,7 @@ object ConfigKeys {
     const val UTXO_LEDGER_CONFIG = "corda.ledger.utxo"
     const val P2P_LINK_MANAGER_CONFIG = "corda.p2p.linkManager"
     const val P2P_GATEWAY_CONFIG = "corda.p2p.gateway"
-    const val RPC_CONFIG = "corda.rpc"
+    const val REST_CONFIG = "corda.rest"
     const val SECRETS_CONFIG = "corda.secrets"
     const val SANDBOX_CONFIG = "corda.sandbox"
     const val RECONCILIATION_CONFIG = "corda.reconciliation"
@@ -21,15 +21,15 @@ object ConfigKeys {
     const val SECURITY_CONFIG = "corda.security"
 
     //  RPC
-    const val RPC_ADDRESS = "address"
-    const val RPC_CONTEXT_DESCRIPTION = "context.description"
-    const val RPC_CONTEXT_TITLE = "context.title"
-    const val RPC_ENDPOINT_TIMEOUT_MILLIS = "endpoint.timeoutMs"
-    const val RPC_MAX_CONTENT_LENGTH = "maxContentLength"
-    const val RPC_AZUREAD_CLIENT_ID = "sso.azureAd.clientId"
-    const val RPC_AZUREAD_CLIENT_SECRET = "sso.azureAd.clientSecret"
-    const val RPC_AZUREAD_TENANT_ID = "sso.azureAd.tenantId"
-    const val RPC_WEBSOCKET_CONNECTION_IDLE_TIMEOUT_MS = "websocket.idleTimeoutMs"
+    const val REST_ADDRESS = "address"
+    const val REST_CONTEXT_DESCRIPTION = "context.description"
+    const val REST_CONTEXT_TITLE = "context.title"
+    const val REST_ENDPOINT_TIMEOUT_MILLIS = "endpoint.timeoutMs"
+    const val REST_MAX_CONTENT_LENGTH = "maxContentLength"
+    const val REST_AZUREAD_CLIENT_ID = "sso.azureAd.clientId"
+    const val REST_AZUREAD_CLIENT_SECRET = "sso.azureAd.clientSecret"
+    const val REST_AZUREAD_TENANT_ID = "sso.azureAd.tenantId"
+    const val REST_WEBSOCKET_CONNECTION_IDLE_TIMEOUT_MS = "websocket.idleTimeoutMs"
 
     // Secrets Service
     const val SECRETS_PASSPHRASE = "passphrase"

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/rest/1.0/corda.rest.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/rest/1.0/corda.rest.json
@@ -1,8 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://corda.r3.com/net/corda/schema/configuration/rpc/1.0/corda.rpc.json",
-  "title": "Corda RPC Configuration Schema",
-  "description": "Configuration schema for the RPC subsection.",
+  "$id": "https://corda.r3.com/net/corda/schema/configuration/rest/1.0/corda.rest.json",
+  "title": "Corda REST Configuration Schema",
+  "description": "Configuration schema for the REST subsection.",
   "type": "object",
   "default": {},
   "properties": {
@@ -19,12 +19,12 @@
         "description": {
           "description": "",
           "type": "string",
-          "default": "Exposing RPCOps interfaces as OpenAPI WebServices"
+          "default": "Exposing REST interfaces as OpenAPI WebServices"
         },
         "title": {
           "description": "",
           "type": "string",
-          "default": "HTTP RPC"
+          "default": "REST"
         }
       }
     },
@@ -41,7 +41,7 @@
       "default": {},
       "properties": {
         "timeoutMs": {
-          "description": "Amount of time in milliseconds to wait for response on Kafka bus for a remote operation before timing out the HTTP RPC call.",
+          "description": "Amount of time in milliseconds to wait for response on backend message bus for a remote operation before timing out the REST call.",
           "type": "integer",
           "minimum": 100,
           "maximum": 2147483647,

--- a/data/config-schema/src/test/kotlin/net/corda/schema/configuration/provider/impl/SchemaProviderImplTest.kt
+++ b/data/config-schema/src/test/kotlin/net/corda/schema/configuration/provider/impl/SchemaProviderImplTest.kt
@@ -8,7 +8,7 @@ import net.corda.schema.configuration.ConfigKeys.MESSAGING_CONFIG
 import net.corda.schema.configuration.ConfigKeys.P2P_GATEWAY_CONFIG
 import net.corda.schema.configuration.ConfigKeys.P2P_LINK_MANAGER_CONFIG
 import net.corda.schema.configuration.ConfigKeys.RECONCILIATION_CONFIG
-import net.corda.schema.configuration.ConfigKeys.RPC_CONFIG
+import net.corda.schema.configuration.ConfigKeys.REST_CONFIG
 import net.corda.schema.configuration.ConfigKeys.SANDBOX_CONFIG
 import net.corda.schema.configuration.ConfigKeys.SECRETS_CONFIG
 import net.corda.schema.configuration.ConfigKeys.UTXO_LEDGER_CONFIG
@@ -35,7 +35,7 @@ class SchemaProviderImplTest {
             UTXO_LEDGER_CONFIG,
             P2P_LINK_MANAGER_CONFIG,
             P2P_GATEWAY_CONFIG,
-            RPC_CONFIG,
+            REST_CONFIG,
             SECRETS_CONFIG,
             SANDBOX_CONFIG,
             RECONCILIATION_CONFIG,

--- a/data/db-schema/src/main/kotlin/net/corda/db/schema/DbSchema.kt
+++ b/data/db-schema/src/main/kotlin/net/corda/db/schema/DbSchema.kt
@@ -6,7 +6,7 @@ package net.corda.db.schema
  * For more information, please see [here](https://docs.liquibase.com/concepts/advanced/liquibase-schema-name-parameter.html).
  */
 object DbSchema {
-    const val REST_RBAC = "REST_RBAC"
+    const val RBAC = "RBAC"
 
     const val CONFIG = "CONFIG"
     const val CONFIG_TABLE = "config"

--- a/data/db-schema/src/main/kotlin/net/corda/db/schema/DbSchema.kt
+++ b/data/db-schema/src/main/kotlin/net/corda/db/schema/DbSchema.kt
@@ -6,7 +6,7 @@ package net.corda.db.schema
  * For more information, please see [here](https://docs.liquibase.com/concepts/advanced/liquibase-schema-name-parameter.html).
  */
 object DbSchema {
-    const val RPC_RBAC = "RPC_RBAC"
+    const val REST_RBAC = "REST_RBAC"
 
     const val CONFIG = "CONFIG"
     const val CONFIG_TABLE = "config"

--- a/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/config-creation-v1.0.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/config-creation-v1.0.xml
@@ -88,7 +88,7 @@
         </insert>
 
         <insert tableName="config" schemaName="${schema.name}">
-            <column name="section" value="corda.rpc"/>
+            <column name="section" value="corda.rest"/>
             <column name="config" value=""/>
             <column name="schema_version_major" value="1"/>
             <column name="schema_version_minor" value="0"/>

--- a/data/db-schema/src/main/resources/net/corda/db/schema/rbac/db.changelog-master.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/rbac/db.changelog-master.xml
@@ -2,5 +2,5 @@
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
-    <include file="net/corda/db/schema/rbac/migration/rest-rbac-creation-v1.0.xml"/>
+    <include file="net/corda/db/schema/rbac/migration/rbac-creation-v1.0.xml"/>
 </databaseChangeLog>

--- a/data/db-schema/src/main/resources/net/corda/db/schema/rbac/db.changelog-master.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/rbac/db.changelog-master.xml
@@ -2,5 +2,5 @@
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
-    <include file="net/corda/db/schema/rbac/migration/rpc-rbac-creation-v1.0.xml"/>
+    <include file="net/corda/db/schema/rbac/migration/rest-rbac-creation-v1.0.xml"/>
 </databaseChangeLog>

--- a/data/db-schema/src/main/resources/net/corda/db/schema/rbac/migration/rbac-creation-v1.0.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/rbac/migration/rbac-creation-v1.0.xml
@@ -3,15 +3,15 @@
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
 
-    <property name="schema.name" value="REST_RBAC" global="false"/>
+    <property name="schema.name" value="RBAC" global="false"/>
 
     <changeSet author="vkolomeyko" id="rest-perm-creation-v1.0">
 
         <sql>
-            CREATE SCHEMA IF NOT EXISTS REST_RBAC;
+            CREATE SCHEMA IF NOT EXISTS RBAC;
         </sql>
 
-        <createTable tableName="rest_user" schemaName="${schema.name}">
+        <createTable tableName="rbac_user" schemaName="${schema.name}">
             <column name="id" type="VARCHAR(36)">
                 <constraints nullable="false"/>
             </column>
@@ -43,12 +43,12 @@
                 <constraints nullable="true"/>
             </column>
         </createTable>
-        <addPrimaryKey tableName="rest_user" columnNames="id" constraintName="rest_user_pkey"
+        <addPrimaryKey tableName="rbac_user" columnNames="id" constraintName="rbac_user_pkey"
                        schemaName="${schema.name}"/>
-        <addUniqueConstraint tableName="rest_user" columnNames="login_name" constraintName="rest_user_uc1"
+        <addUniqueConstraint tableName="rbac_user" columnNames="login_name" constraintName="rbac_user_uc1"
                              schemaName="${schema.name}"/>
 
-        <createTable tableName="rest_user_props" schemaName="${schema.name}"
+        <createTable tableName="rbac_user_props" schemaName="${schema.name}"
                      remarks="Holds properties for an individual user">
             <column name="id" type="VARCHAR(36)">
                 <constraints nullable="false"/>
@@ -69,19 +69,19 @@
                 <constraints nullable="false"/>
             </column>
         </createTable>
-        <addPrimaryKey tableName="rest_user_props" columnNames="id" constraintName="rest_user_props_pkey"
+        <addPrimaryKey tableName="rbac_user_props" columnNames="id" constraintName="rbac_user_props_pkey"
                        schemaName="${schema.name}"/>
-        <addUniqueConstraint tableName="rest_user_props" columnNames="user_ref, key" constraintName="rest_user_props_uc1"
+        <addUniqueConstraint tableName="rbac_user_props" columnNames="user_ref, key" constraintName="rbac_user_props_uc1"
                              schemaName="${schema.name}"/>
 
-        <addForeignKeyConstraint baseTableName="rest_user_props" baseColumnNames="user_ref"
-                                 referencedTableName="rest_user" referencedColumnNames="id"
-                                 constraintName="FK__rest_user_props__user_ref"
+        <addForeignKeyConstraint baseTableName="rbac_user_props" baseColumnNames="user_ref"
+                                 referencedTableName="rbac_user" referencedColumnNames="id"
+                                 constraintName="FK__rbac_user_props__user_ref"
                                  onDelete="CASCADE"
                                  baseTableSchemaName="${schema.name}"
                                  referencedTableSchemaName="${schema.name}"/>
 
-        <createTable tableName="rest_group" schemaName="${schema.name}">
+        <createTable tableName="rbac_group" schemaName="${schema.name}">
             <column name="id" type="VARCHAR(36)">
                 <constraints nullable="false"/>
             </column>
@@ -98,26 +98,26 @@
                 <constraints nullable="true"/>
             </column>
         </createTable>
-        <addPrimaryKey tableName="rest_group" columnNames="id" constraintName="rest_group_pkey"
+        <addPrimaryKey tableName="rbac_group" columnNames="id" constraintName="rbac_group_pkey"
                        schemaName="${schema.name}"/>
-        <addUniqueConstraint tableName="rest_group" columnNames="name, parent_group" constraintName="rest_group_uc1"
+        <addUniqueConstraint tableName="rbac_group" columnNames="name, parent_group" constraintName="rbac_group_uc1"
                              schemaName="${schema.name}"/>
 
-        <addForeignKeyConstraint baseTableName="rest_group" baseColumnNames="parent_group"
-                                 referencedTableName="rest_group" referencedColumnNames="id"
-                                 constraintName="FK__rest_gr__parent_gr"
+        <addForeignKeyConstraint baseTableName="rbac_group" baseColumnNames="parent_group"
+                                 referencedTableName="rbac_group" referencedColumnNames="id"
+                                 constraintName="FK__rbac_gr__parent_gr"
                                  onDelete="SET NULL"
                                  baseTableSchemaName="${schema.name}"
                                  referencedTableSchemaName="${schema.name}"/>
 
-        <addForeignKeyConstraint baseTableName="rest_user" baseColumnNames="parent_group"
-                                 referencedTableName="rest_group" referencedColumnNames="id"
-                                 constraintName="FK__rest_user__parent_group"
+        <addForeignKeyConstraint baseTableName="rbac_user" baseColumnNames="parent_group"
+                                 referencedTableName="rbac_group" referencedColumnNames="id"
+                                 constraintName="FK__rbac_user__parent_group"
                                  onDelete="SET NULL"
                                  baseTableSchemaName="${schema.name}"
                                  referencedTableSchemaName="${schema.name}"/>
 
-        <createTable tableName="rest_group_props" remarks="Holds properties of the group" schemaName="${schema.name}">
+        <createTable tableName="rbac_group_props" remarks="Holds properties of the group" schemaName="${schema.name}">
             <column name="id" type="VARCHAR(36)">
                 <constraints nullable="false"/>
             </column>
@@ -137,20 +137,20 @@
                 <constraints nullable="false"/>
             </column>
         </createTable>
-        <addPrimaryKey tableName="rest_group_props" columnNames="id" constraintName="rest_group_props_pkey"
+        <addPrimaryKey tableName="rbac_group_props" columnNames="id" constraintName="rbac_group_props_pkey"
                        schemaName="${schema.name}"/>
-        <addUniqueConstraint tableName="rest_group_props" columnNames="group_ref, key"
-                             constraintName="rest_group_props_uc1"
+        <addUniqueConstraint tableName="rbac_group_props" columnNames="group_ref, key"
+                             constraintName="rbac_group_props_uc1"
                              schemaName="${schema.name}"/>
 
-        <addForeignKeyConstraint baseTableName="rest_group_props" baseColumnNames="group_ref"
-                                 referencedTableName="rest_group" referencedColumnNames="id"
-                                 constraintName="FK__rest_group_props__group_ref"
+        <addForeignKeyConstraint baseTableName="rbac_group_props" baseColumnNames="group_ref"
+                                 referencedTableName="rbac_group" referencedColumnNames="id"
+                                 constraintName="FK__rbac_group_props__group_ref"
                                  onDelete="CASCADE"
                                  baseTableSchemaName="${schema.name}"
                                  referencedTableSchemaName="${schema.name}"/>
 
-        <createTable tableName="rest_change_audit" schemaName="${schema.name}">
+        <createTable tableName="rbac_change_audit" schemaName="${schema.name}">
             <column name="id" type="VARCHAR(36)">
                 <constraints nullable="false"/>
             </column>
@@ -167,10 +167,10 @@
                 <constraints nullable="false"/>
             </column>
         </createTable>
-        <addPrimaryKey tableName="rest_change_audit" columnNames="id" constraintName="rest_change_audit_pkey"
+        <addPrimaryKey tableName="rbac_change_audit" columnNames="id" constraintName="rbac_change_audit_pkey"
                        schemaName="${schema.name}"/>
 
-        <createTable tableName="rest_role" schemaName="${schema.name}">
+        <createTable tableName="rbac_role" schemaName="${schema.name}">
             <column name="id" type="VARCHAR(36)">
                 <constraints nullable="false"/>
             </column>
@@ -188,22 +188,22 @@
                 <constraints nullable="true"/>
             </column>
         </createTable>
-        <addPrimaryKey tableName="rest_role" columnNames="id" constraintName="rest_role_pkey"
+        <addPrimaryKey tableName="rbac_role" columnNames="id" constraintName="rbac_role_pkey"
                        schemaName="${schema.name}"/>
-        <addUniqueConstraint tableName="rest_role" columnNames="name, group_vis" constraintName="rest_role_uc1"
+        <addUniqueConstraint tableName="rbac_role" columnNames="name, group_vis" constraintName="rbac_role_uc1"
                              schemaName="${schema.name}"/>
-        <createIndex tableName="rest_role" indexName="rest_role__group_vis__idx" schemaName="${schema.name}">
+        <createIndex tableName="rbac_role" indexName="rbac_role__group_vis__idx" schemaName="${schema.name}">
             <column name="group_vis"/>
         </createIndex>
 
-        <addForeignKeyConstraint baseTableName="rest_role" baseColumnNames="group_vis"
-                                 referencedTableName="rest_group" referencedColumnNames="id"
-                                 constraintName="FK__rest_role__group_vis"
+        <addForeignKeyConstraint baseTableName="rbac_role" baseColumnNames="group_vis"
+                                 referencedTableName="rbac_group" referencedColumnNames="id"
+                                 constraintName="FK__rbac_role__group_vis"
                                  onDelete="CASCADE"
                                  baseTableSchemaName="${schema.name}"
                                  referencedTableSchemaName="${schema.name}"/>
 
-        <createTable tableName="rest_role_user_rel" schemaName="${schema.name}"
+        <createTable tableName="rbac_role_user_rel" schemaName="${schema.name}"
                      remarks="Represents 1-n relationship between user and roles">
             <column name="id" type="VARCHAR(36)">
                 <constraints nullable="false"/>
@@ -218,26 +218,26 @@
                 <constraints nullable="false"/>
             </column>
         </createTable>
-        <addPrimaryKey tableName="rest_role_user_rel" columnNames="id" constraintName="rest_role_user_rel_pkey"
+        <addPrimaryKey tableName="rbac_role_user_rel" columnNames="id" constraintName="rbac_role_user_rel_pkey"
                        schemaName="${schema.name}"/>
-        <addUniqueConstraint tableName="rest_role_user_rel" columnNames="user_id, role_id"
-                             constraintName="rest_role_user_rel_uc1" schemaName="${schema.name}"/>
+        <addUniqueConstraint tableName="rbac_role_user_rel" columnNames="user_id, role_id"
+                             constraintName="rbac_role_user_rel_uc1" schemaName="${schema.name}"/>
 
-        <addForeignKeyConstraint baseTableName="rest_role_user_rel" baseColumnNames="user_id"
-                                 referencedTableName="rest_user" referencedColumnNames="id"
-                                 constraintName="FK__rest_role_user_rel__user_id"
+        <addForeignKeyConstraint baseTableName="rbac_role_user_rel" baseColumnNames="user_id"
+                                 referencedTableName="rbac_user" referencedColumnNames="id"
+                                 constraintName="FK__rbac_role_user_rel__user_id"
                                  onDelete="CASCADE"
                                  baseTableSchemaName="${schema.name}"
                                  referencedTableSchemaName="${schema.name}"/>
 
-        <addForeignKeyConstraint baseTableName="rest_role_user_rel" baseColumnNames="role_id"
-                                 referencedTableName="rest_role" referencedColumnNames="id"
-                                 constraintName="FK__rest_role_user_rel__role_id"
+        <addForeignKeyConstraint baseTableName="rbac_role_user_rel" baseColumnNames="role_id"
+                                 referencedTableName="rbac_role" referencedColumnNames="id"
+                                 constraintName="FK__rbac_role_user_rel__role_id"
                                  onDelete="CASCADE"
                                  baseTableSchemaName="${schema.name}"
                                  referencedTableSchemaName="${schema.name}"/>
 
-        <createTable tableName="rest_role_group_rel" schemaName="${schema.name}"
+        <createTable tableName="rbac_role_group_rel" schemaName="${schema.name}"
                      remarks="Represents 1-n relationship between group and roles">
             <column name="id" type="VARCHAR(36)">
                 <constraints nullable="false"/>
@@ -252,26 +252,26 @@
                 <constraints nullable="false"/>
             </column>
         </createTable>
-        <addPrimaryKey tableName="rest_role_group_rel" columnNames="id" constraintName="rest_role_group_rel_pkey"
+        <addPrimaryKey tableName="rbac_role_group_rel" columnNames="id" constraintName="rbac_role_group_rel_pkey"
                        schemaName="${schema.name}"/>
-        <addUniqueConstraint tableName="rest_role_group_rel" columnNames="group_id, role_id"
-                             constraintName="rest_role_group_rel_uc1" schemaName="${schema.name}"/>
+        <addUniqueConstraint tableName="rbac_role_group_rel" columnNames="group_id, role_id"
+                             constraintName="rbac_role_group_rel_uc1" schemaName="${schema.name}"/>
 
-        <addForeignKeyConstraint baseTableName="rest_role_group_rel" baseColumnNames="group_id"
-                                 referencedTableName="rest_group" referencedColumnNames="id"
-                                 constraintName="FK__rest_role_group_rel__group_id"
+        <addForeignKeyConstraint baseTableName="rbac_role_group_rel" baseColumnNames="group_id"
+                                 referencedTableName="rbac_group" referencedColumnNames="id"
+                                 constraintName="FK__rbac_role_group_rel__group_id"
                                  onDelete="CASCADE"
                                  baseTableSchemaName="${schema.name}"
                                  referencedTableSchemaName="${schema.name}"/>
 
-        <addForeignKeyConstraint baseTableName="rest_role_group_rel" baseColumnNames="role_id"
-                                 referencedTableName="rest_role" referencedColumnNames="id"
-                                 constraintName="FK__rest_role_group_rel__role_id"
+        <addForeignKeyConstraint baseTableName="rbac_role_group_rel" baseColumnNames="role_id"
+                                 referencedTableName="rbac_role" referencedColumnNames="id"
+                                 constraintName="FK__rbac_role_group_rel__role_id"
                                  onDelete="CASCADE"
                                  baseTableSchemaName="${schema.name}"
                                  referencedTableSchemaName="${schema.name}"/>
 
-        <createTable tableName="rest_perm" schemaName="${schema.name}">
+        <createTable tableName="rbac_perm" schemaName="${schema.name}">
             <column name="id" type="VARCHAR(36)">
                 <constraints nullable="false"/>
             </column>
@@ -295,20 +295,20 @@
                 <constraints nullable="false"/>
             </column>
         </createTable>
-        <addPrimaryKey tableName="rest_perm" columnNames="id" constraintName="rest_perm_pkey"
+        <addPrimaryKey tableName="rbac_perm" columnNames="id" constraintName="rbac_perm_pkey"
                        schemaName="${schema.name}"/>
-        <createIndex tableName="rest_perm" indexName="rest_perm__group_vis__idx" schemaName="${schema.name}">
+        <createIndex tableName="rbac_perm" indexName="rbac_perm__group_vis__idx" schemaName="${schema.name}">
             <column name="group_vis"/>
         </createIndex>
 
-        <addForeignKeyConstraint baseTableName="rest_perm" baseColumnNames="group_vis"
-                                 referencedTableName="rest_group" referencedColumnNames="id"
-                                 constraintName="FK__rest_perm__group_vis"
+        <addForeignKeyConstraint baseTableName="rbac_perm" baseColumnNames="group_vis"
+                                 referencedTableName="rbac_group" referencedColumnNames="id"
+                                 constraintName="FK__rbac_perm__group_vis"
                                  onDelete="CASCADE"
                                  baseTableSchemaName="${schema.name}"
                                  referencedTableSchemaName="${schema.name}"/>
 
-        <createTable tableName="rest_role_perm_rel" schemaName="${schema.name}"
+        <createTable tableName="rbac_role_perm_rel" schemaName="${schema.name}"
                      remarks="Represents n-n relationship between roles and permissions">
             <column name="id" type="VARCHAR(36)">
                 <constraints nullable="false"/>
@@ -323,21 +323,21 @@
                 <constraints nullable="false"/>
             </column>
         </createTable>
-        <addPrimaryKey tableName="rest_role_perm_rel" columnNames="id" constraintName="rest_role_perm_rel_pkey"
+        <addPrimaryKey tableName="rbac_role_perm_rel" columnNames="id" constraintName="rbac_role_perm_rel_pkey"
                        schemaName="${schema.name}"/>
-        <addUniqueConstraint tableName="rest_role_perm_rel" columnNames="role_id, perm_id"
-                             constraintName="rest_role_perm_rel_uc1" schemaName="${schema.name}"/>
+        <addUniqueConstraint tableName="rbac_role_perm_rel" columnNames="role_id, perm_id"
+                             constraintName="rbac_role_perm_rel_uc1" schemaName="${schema.name}"/>
 
-        <addForeignKeyConstraint baseTableName="rest_role_perm_rel" baseColumnNames="role_id"
-                                 referencedTableName="rest_role" referencedColumnNames="id"
-                                 constraintName="FK__rest_role_perm_rel__role_id"
+        <addForeignKeyConstraint baseTableName="rbac_role_perm_rel" baseColumnNames="role_id"
+                                 referencedTableName="rbac_role" referencedColumnNames="id"
+                                 constraintName="FK__rbac_role_perm_rel__role_id"
                                  onDelete="CASCADE"
                                  baseTableSchemaName="${schema.name}"
                                  referencedTableSchemaName="${schema.name}"/>
 
-        <addForeignKeyConstraint baseTableName="rest_role_perm_rel" baseColumnNames="perm_id"
-                                 referencedTableName="rest_perm" referencedColumnNames="id"
-                                 constraintName="FK__rest_role_perm_rel__perm_id"
+        <addForeignKeyConstraint baseTableName="rbac_role_perm_rel" baseColumnNames="perm_id"
+                                 referencedTableName="rbac_perm" referencedColumnNames="id"
+                                 constraintName="FK__rbac_role_perm_rel__perm_id"
                                  onDelete="CASCADE"
                                  baseTableSchemaName="${schema.name}"
                                  referencedTableSchemaName="${schema.name}"/>

--- a/data/db-schema/src/main/resources/net/corda/db/schema/rbac/migration/rest-rbac-creation-v1.0.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/rbac/migration/rest-rbac-creation-v1.0.xml
@@ -3,15 +3,15 @@
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
 
-    <property name="schema.name" value="RPC_RBAC" global="false"/>
+    <property name="schema.name" value="REST_RBAC" global="false"/>
 
-    <changeSet author="vkolomeyko" id="rpc-perm-creation-v1.0">
+    <changeSet author="vkolomeyko" id="rest-perm-creation-v1.0">
 
         <sql>
-            CREATE SCHEMA IF NOT EXISTS RPC_RBAC;
+            CREATE SCHEMA IF NOT EXISTS REST_RBAC;
         </sql>
 
-        <createTable tableName="rpc_user" schemaName="${schema.name}">
+        <createTable tableName="rest_user" schemaName="${schema.name}">
             <column name="id" type="VARCHAR(36)">
                 <constraints nullable="false"/>
             </column>
@@ -43,12 +43,12 @@
                 <constraints nullable="true"/>
             </column>
         </createTable>
-        <addPrimaryKey tableName="rpc_user" columnNames="id" constraintName="rpc_user_pkey"
+        <addPrimaryKey tableName="rest_user" columnNames="id" constraintName="rest_user_pkey"
                        schemaName="${schema.name}"/>
-        <addUniqueConstraint tableName="rpc_user" columnNames="login_name" constraintName="rpc_user_uc1"
+        <addUniqueConstraint tableName="rest_user" columnNames="login_name" constraintName="rest_user_uc1"
                              schemaName="${schema.name}"/>
 
-        <createTable tableName="rpc_user_props" schemaName="${schema.name}"
+        <createTable tableName="rest_user_props" schemaName="${schema.name}"
                      remarks="Holds properties for an individual user">
             <column name="id" type="VARCHAR(36)">
                 <constraints nullable="false"/>
@@ -69,19 +69,19 @@
                 <constraints nullable="false"/>
             </column>
         </createTable>
-        <addPrimaryKey tableName="rpc_user_props" columnNames="id" constraintName="rpc_user_props_pkey"
+        <addPrimaryKey tableName="rest_user_props" columnNames="id" constraintName="rest_user_props_pkey"
                        schemaName="${schema.name}"/>
-        <addUniqueConstraint tableName="rpc_user_props" columnNames="user_ref, key" constraintName="rpc_user_props_uc1"
+        <addUniqueConstraint tableName="rest_user_props" columnNames="user_ref, key" constraintName="rest_user_props_uc1"
                              schemaName="${schema.name}"/>
 
-        <addForeignKeyConstraint baseTableName="rpc_user_props" baseColumnNames="user_ref"
-                                 referencedTableName="rpc_user" referencedColumnNames="id"
-                                 constraintName="FK__rpc_user_props__user_ref"
+        <addForeignKeyConstraint baseTableName="rest_user_props" baseColumnNames="user_ref"
+                                 referencedTableName="rest_user" referencedColumnNames="id"
+                                 constraintName="FK__rest_user_props__user_ref"
                                  onDelete="CASCADE"
                                  baseTableSchemaName="${schema.name}"
                                  referencedTableSchemaName="${schema.name}"/>
 
-        <createTable tableName="rpc_group" schemaName="${schema.name}">
+        <createTable tableName="rest_group" schemaName="${schema.name}">
             <column name="id" type="VARCHAR(36)">
                 <constraints nullable="false"/>
             </column>
@@ -98,26 +98,26 @@
                 <constraints nullable="true"/>
             </column>
         </createTable>
-        <addPrimaryKey tableName="rpc_group" columnNames="id" constraintName="rpc_group_pkey"
+        <addPrimaryKey tableName="rest_group" columnNames="id" constraintName="rest_group_pkey"
                        schemaName="${schema.name}"/>
-        <addUniqueConstraint tableName="rpc_group" columnNames="name, parent_group" constraintName="rpc_group_uc1"
+        <addUniqueConstraint tableName="rest_group" columnNames="name, parent_group" constraintName="rest_group_uc1"
                              schemaName="${schema.name}"/>
 
-        <addForeignKeyConstraint baseTableName="rpc_group" baseColumnNames="parent_group"
-                                 referencedTableName="rpc_group" referencedColumnNames="id"
-                                 constraintName="FK__rpc_gr__parent_gr"
+        <addForeignKeyConstraint baseTableName="rest_group" baseColumnNames="parent_group"
+                                 referencedTableName="rest_group" referencedColumnNames="id"
+                                 constraintName="FK__rest_gr__parent_gr"
                                  onDelete="SET NULL"
                                  baseTableSchemaName="${schema.name}"
                                  referencedTableSchemaName="${schema.name}"/>
 
-        <addForeignKeyConstraint baseTableName="rpc_user" baseColumnNames="parent_group"
-                                 referencedTableName="rpc_group" referencedColumnNames="id"
-                                 constraintName="FK__rpc_user__parent_group"
+        <addForeignKeyConstraint baseTableName="rest_user" baseColumnNames="parent_group"
+                                 referencedTableName="rest_group" referencedColumnNames="id"
+                                 constraintName="FK__rest_user__parent_group"
                                  onDelete="SET NULL"
                                  baseTableSchemaName="${schema.name}"
                                  referencedTableSchemaName="${schema.name}"/>
 
-        <createTable tableName="rpc_group_props" remarks="Holds properties of the group" schemaName="${schema.name}">
+        <createTable tableName="rest_group_props" remarks="Holds properties of the group" schemaName="${schema.name}">
             <column name="id" type="VARCHAR(36)">
                 <constraints nullable="false"/>
             </column>
@@ -137,20 +137,20 @@
                 <constraints nullable="false"/>
             </column>
         </createTable>
-        <addPrimaryKey tableName="rpc_group_props" columnNames="id" constraintName="rpc_group_props_pkey"
+        <addPrimaryKey tableName="rest_group_props" columnNames="id" constraintName="rest_group_props_pkey"
                        schemaName="${schema.name}"/>
-        <addUniqueConstraint tableName="rpc_group_props" columnNames="group_ref, key"
-                             constraintName="rpc_group_props_uc1"
+        <addUniqueConstraint tableName="rest_group_props" columnNames="group_ref, key"
+                             constraintName="rest_group_props_uc1"
                              schemaName="${schema.name}"/>
 
-        <addForeignKeyConstraint baseTableName="rpc_group_props" baseColumnNames="group_ref"
-                                 referencedTableName="rpc_group" referencedColumnNames="id"
-                                 constraintName="FK__rpc_group_props__group_ref"
+        <addForeignKeyConstraint baseTableName="rest_group_props" baseColumnNames="group_ref"
+                                 referencedTableName="rest_group" referencedColumnNames="id"
+                                 constraintName="FK__rest_group_props__group_ref"
                                  onDelete="CASCADE"
                                  baseTableSchemaName="${schema.name}"
                                  referencedTableSchemaName="${schema.name}"/>
 
-        <createTable tableName="rpc_change_audit" schemaName="${schema.name}">
+        <createTable tableName="rest_change_audit" schemaName="${schema.name}">
             <column name="id" type="VARCHAR(36)">
                 <constraints nullable="false"/>
             </column>
@@ -167,10 +167,10 @@
                 <constraints nullable="false"/>
             </column>
         </createTable>
-        <addPrimaryKey tableName="rpc_change_audit" columnNames="id" constraintName="rpc_change_audit_pkey"
+        <addPrimaryKey tableName="rest_change_audit" columnNames="id" constraintName="rest_change_audit_pkey"
                        schemaName="${schema.name}"/>
 
-        <createTable tableName="rpc_role" schemaName="${schema.name}">
+        <createTable tableName="rest_role" schemaName="${schema.name}">
             <column name="id" type="VARCHAR(36)">
                 <constraints nullable="false"/>
             </column>
@@ -188,22 +188,22 @@
                 <constraints nullable="true"/>
             </column>
         </createTable>
-        <addPrimaryKey tableName="rpc_role" columnNames="id" constraintName="rpc_role_pkey"
+        <addPrimaryKey tableName="rest_role" columnNames="id" constraintName="rest_role_pkey"
                        schemaName="${schema.name}"/>
-        <addUniqueConstraint tableName="rpc_role" columnNames="name, group_vis" constraintName="rpc_role_uc1"
+        <addUniqueConstraint tableName="rest_role" columnNames="name, group_vis" constraintName="rest_role_uc1"
                              schemaName="${schema.name}"/>
-        <createIndex tableName="rpc_role" indexName="rpc_role__group_vis__idx" schemaName="${schema.name}">
+        <createIndex tableName="rest_role" indexName="rest_role__group_vis__idx" schemaName="${schema.name}">
             <column name="group_vis"/>
         </createIndex>
 
-        <addForeignKeyConstraint baseTableName="rpc_role" baseColumnNames="group_vis"
-                                 referencedTableName="rpc_group" referencedColumnNames="id"
-                                 constraintName="FK__rpc_role__group_vis"
+        <addForeignKeyConstraint baseTableName="rest_role" baseColumnNames="group_vis"
+                                 referencedTableName="rest_group" referencedColumnNames="id"
+                                 constraintName="FK__rest_role__group_vis"
                                  onDelete="CASCADE"
                                  baseTableSchemaName="${schema.name}"
                                  referencedTableSchemaName="${schema.name}"/>
 
-        <createTable tableName="rpc_role_user_rel" schemaName="${schema.name}"
+        <createTable tableName="rest_role_user_rel" schemaName="${schema.name}"
                      remarks="Represents 1-n relationship between user and roles">
             <column name="id" type="VARCHAR(36)">
                 <constraints nullable="false"/>
@@ -218,26 +218,26 @@
                 <constraints nullable="false"/>
             </column>
         </createTable>
-        <addPrimaryKey tableName="rpc_role_user_rel" columnNames="id" constraintName="rpc_role_user_rel_pkey"
+        <addPrimaryKey tableName="rest_role_user_rel" columnNames="id" constraintName="rest_role_user_rel_pkey"
                        schemaName="${schema.name}"/>
-        <addUniqueConstraint tableName="rpc_role_user_rel" columnNames="user_id, role_id"
-                             constraintName="rpc_role_user_rel_uc1" schemaName="${schema.name}"/>
+        <addUniqueConstraint tableName="rest_role_user_rel" columnNames="user_id, role_id"
+                             constraintName="rest_role_user_rel_uc1" schemaName="${schema.name}"/>
 
-        <addForeignKeyConstraint baseTableName="rpc_role_user_rel" baseColumnNames="user_id"
-                                 referencedTableName="rpc_user" referencedColumnNames="id"
-                                 constraintName="FK__rpc_role_user_rel__user_id"
+        <addForeignKeyConstraint baseTableName="rest_role_user_rel" baseColumnNames="user_id"
+                                 referencedTableName="rest_user" referencedColumnNames="id"
+                                 constraintName="FK__rest_role_user_rel__user_id"
                                  onDelete="CASCADE"
                                  baseTableSchemaName="${schema.name}"
                                  referencedTableSchemaName="${schema.name}"/>
 
-        <addForeignKeyConstraint baseTableName="rpc_role_user_rel" baseColumnNames="role_id"
-                                 referencedTableName="rpc_role" referencedColumnNames="id"
-                                 constraintName="FK__rpc_role_user_rel__role_id"
+        <addForeignKeyConstraint baseTableName="rest_role_user_rel" baseColumnNames="role_id"
+                                 referencedTableName="rest_role" referencedColumnNames="id"
+                                 constraintName="FK__rest_role_user_rel__role_id"
                                  onDelete="CASCADE"
                                  baseTableSchemaName="${schema.name}"
                                  referencedTableSchemaName="${schema.name}"/>
 
-        <createTable tableName="rpc_role_group_rel" schemaName="${schema.name}"
+        <createTable tableName="rest_role_group_rel" schemaName="${schema.name}"
                      remarks="Represents 1-n relationship between group and roles">
             <column name="id" type="VARCHAR(36)">
                 <constraints nullable="false"/>
@@ -252,26 +252,26 @@
                 <constraints nullable="false"/>
             </column>
         </createTable>
-        <addPrimaryKey tableName="rpc_role_group_rel" columnNames="id" constraintName="rpc_role_group_rel_pkey"
+        <addPrimaryKey tableName="rest_role_group_rel" columnNames="id" constraintName="rest_role_group_rel_pkey"
                        schemaName="${schema.name}"/>
-        <addUniqueConstraint tableName="rpc_role_group_rel" columnNames="group_id, role_id"
-                             constraintName="rpc_role_group_rel_uc1" schemaName="${schema.name}"/>
+        <addUniqueConstraint tableName="rest_role_group_rel" columnNames="group_id, role_id"
+                             constraintName="rest_role_group_rel_uc1" schemaName="${schema.name}"/>
 
-        <addForeignKeyConstraint baseTableName="rpc_role_group_rel" baseColumnNames="group_id"
-                                 referencedTableName="rpc_group" referencedColumnNames="id"
-                                 constraintName="FK__rpc_role_group_rel__group_id"
+        <addForeignKeyConstraint baseTableName="rest_role_group_rel" baseColumnNames="group_id"
+                                 referencedTableName="rest_group" referencedColumnNames="id"
+                                 constraintName="FK__rest_role_group_rel__group_id"
                                  onDelete="CASCADE"
                                  baseTableSchemaName="${schema.name}"
                                  referencedTableSchemaName="${schema.name}"/>
 
-        <addForeignKeyConstraint baseTableName="rpc_role_group_rel" baseColumnNames="role_id"
-                                 referencedTableName="rpc_role" referencedColumnNames="id"
-                                 constraintName="FK__rpc_role_group_rel__role_id"
+        <addForeignKeyConstraint baseTableName="rest_role_group_rel" baseColumnNames="role_id"
+                                 referencedTableName="rest_role" referencedColumnNames="id"
+                                 constraintName="FK__rest_role_group_rel__role_id"
                                  onDelete="CASCADE"
                                  baseTableSchemaName="${schema.name}"
                                  referencedTableSchemaName="${schema.name}"/>
 
-        <createTable tableName="rpc_perm" schemaName="${schema.name}">
+        <createTable tableName="rest_perm" schemaName="${schema.name}">
             <column name="id" type="VARCHAR(36)">
                 <constraints nullable="false"/>
             </column>
@@ -295,20 +295,20 @@
                 <constraints nullable="false"/>
             </column>
         </createTable>
-        <addPrimaryKey tableName="rpc_perm" columnNames="id" constraintName="rpc_perm_pkey"
+        <addPrimaryKey tableName="rest_perm" columnNames="id" constraintName="rest_perm_pkey"
                        schemaName="${schema.name}"/>
-        <createIndex tableName="rpc_perm" indexName="rpc_perm__group_vis__idx" schemaName="${schema.name}">
+        <createIndex tableName="rest_perm" indexName="rest_perm__group_vis__idx" schemaName="${schema.name}">
             <column name="group_vis"/>
         </createIndex>
 
-        <addForeignKeyConstraint baseTableName="rpc_perm" baseColumnNames="group_vis"
-                                 referencedTableName="rpc_group" referencedColumnNames="id"
-                                 constraintName="FK__rpc_perm__group_vis"
+        <addForeignKeyConstraint baseTableName="rest_perm" baseColumnNames="group_vis"
+                                 referencedTableName="rest_group" referencedColumnNames="id"
+                                 constraintName="FK__rest_perm__group_vis"
                                  onDelete="CASCADE"
                                  baseTableSchemaName="${schema.name}"
                                  referencedTableSchemaName="${schema.name}"/>
 
-        <createTable tableName="rpc_role_perm_rel" schemaName="${schema.name}"
+        <createTable tableName="rest_role_perm_rel" schemaName="${schema.name}"
                      remarks="Represents n-n relationship between roles and permissions">
             <column name="id" type="VARCHAR(36)">
                 <constraints nullable="false"/>
@@ -323,21 +323,21 @@
                 <constraints nullable="false"/>
             </column>
         </createTable>
-        <addPrimaryKey tableName="rpc_role_perm_rel" columnNames="id" constraintName="rpc_role_perm_rel_pkey"
+        <addPrimaryKey tableName="rest_role_perm_rel" columnNames="id" constraintName="rest_role_perm_rel_pkey"
                        schemaName="${schema.name}"/>
-        <addUniqueConstraint tableName="rpc_role_perm_rel" columnNames="role_id, perm_id"
-                             constraintName="rpc_role_perm_rel_uc1" schemaName="${schema.name}"/>
+        <addUniqueConstraint tableName="rest_role_perm_rel" columnNames="role_id, perm_id"
+                             constraintName="rest_role_perm_rel_uc1" schemaName="${schema.name}"/>
 
-        <addForeignKeyConstraint baseTableName="rpc_role_perm_rel" baseColumnNames="role_id"
-                                 referencedTableName="rpc_role" referencedColumnNames="id"
-                                 constraintName="FK__rpc_role_perm_rel__role_id"
+        <addForeignKeyConstraint baseTableName="rest_role_perm_rel" baseColumnNames="role_id"
+                                 referencedTableName="rest_role" referencedColumnNames="id"
+                                 constraintName="FK__rest_role_perm_rel__role_id"
                                  onDelete="CASCADE"
                                  baseTableSchemaName="${schema.name}"
                                  referencedTableSchemaName="${schema.name}"/>
 
-        <addForeignKeyConstraint baseTableName="rpc_role_perm_rel" baseColumnNames="perm_id"
-                                 referencedTableName="rpc_perm" referencedColumnNames="id"
-                                 constraintName="FK__rpc_role_perm_rel__perm_id"
+        <addForeignKeyConstraint baseTableName="rest_role_perm_rel" baseColumnNames="perm_id"
+                                 referencedTableName="rest_perm" referencedColumnNames="id"
+                                 constraintName="FK__rest_role_perm_rel__perm_id"
                                  onDelete="CASCADE"
                                  baseTableSchemaName="${schema.name}"
                                  referencedTableSchemaName="${schema.name}"/>

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 613
+cordaApiRevision = 614
 
 # Main
 kotlinVersion = 1.7.21

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 612
+cordaApiRevision = 613
 
 # Main
 kotlinVersion = 1.7.21


### PR DESCRIPTION
Initial work on renaming our 'http rpc' service to 'rest'

More information can be found in CORE-7040

please advise on the following file:
https://github.com/corda/corda-api/blob/e618fc70bb20237d39f6f416cba17631d509ce7e/data/topic-schema/src/main/resources/net/corda/schema/RPC.yaml
