### PR TITLE
CORE-8873: Allow membership worker to read the locally hosted identeties

### DIFF
--- a/data/topic-schema/src/main/resources/net/corda/schema/P2P.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/P2P.yaml
@@ -47,6 +47,7 @@ topics:
     name: p2p.hosted.identities
     consumers:
       - link-manager
+      - membership
     producers:
       - rpc # Dynamic Network registration
       - membership # Static Network registration


### PR DESCRIPTION
This PR should allow the membership worker to read from the locally hosted identities topic. It will be used to identify the identity client TLS certificate (to add the subject to the member info so it will be used in mutual TLS).

I think it should not break anything, so I didn't change the API version.