### PR TITLE
CORE-9504: Delete CpkMetadata.dependencies

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/packaging/CpkMetadata.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/packaging/CpkMetadata.avsc
@@ -20,10 +20,6 @@
       "type": { "type": "array", "items": "string" }
     },
     {
-      "name": "dependencies",
-      "type": { "type": "array", "items": "net.corda.data.packaging.CpkIdentifier" }
-    },
-    {
       "name": "corDappManifest",
       "type": "net.corda.data.packaging.CorDappManifest"
     },

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 619
+cordaApiRevision = 620
 
 # Main
 kotlinVersion = 1.7.21


### PR DESCRIPTION
Delete `CpkMetadata.dependencies`. This property is unused, the dependencies are checked on CPI upload, this property is set after that check and never used outside of tests.