### PR TITLE
CORE-7173 Virtual node upgrade related schema changes and avro objects

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/virtualnode/VirtualNodeAsynchronousRequest.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/virtualnode/VirtualNodeAsynchronousRequest.avsc
@@ -1,0 +1,28 @@
+{
+  "type": "record",
+  "name": "VirtualNodeAsynchronousRequest",
+  "doc": "Virtual node asynchronous request wrapper",
+  "namespace": "net.corda.data.virtualnode",
+  "fields": [
+    {
+      "name": "timestamp",
+      "type": {
+        "type": "long",
+        "logicalType": "timestamp-millis"
+      },
+      "doc": "Time ({@link java.time.Instant}) in milliseconds when the record was created."
+    },
+    {
+      "name": "requestId",
+      "type": "string",
+      "doc": "This request identifier."
+    },
+    {
+      "name": "request",
+      "doc": "The operation specific request.",
+      "type": [
+        "net.corda.data.virtualnode.VirtualNodeUpgradeRequest"
+      ]
+    }
+  ]
+}

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/virtualnode/VirtualNodeInfo.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/virtualnode/VirtualNodeInfo.avsc
@@ -48,9 +48,20 @@
       "doc": "ID of HSM connection. Null value means that HSM is not used."
     },
     {
-      "name": "virtualNodeState",
-      "type": "string",
-      "doc": "The current maintenance state of the virtual node."
+      "name": "flowP2pOperationalStatus",
+      "type": "string"
+    },
+    {
+      "name": "flowStartOperationalStatus",
+      "type": "string"
+    },
+    {
+      "name": "flowOperationalStatus",
+      "type": "string"
+    },
+    {
+      "name": "vaultDbOperationalStatus",
+      "type": "string"
     },
     {
       "name": "version",

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/virtualnode/VirtualNodeOperationStatus.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/virtualnode/VirtualNodeOperationStatus.avsc
@@ -1,0 +1,70 @@
+{
+  "type": "record",
+  "name": "VirtualNodeOperationStatus",
+  "namespace": "net.corda.data.virtualnode",
+  "fields": [
+    {
+      "name": "requestId",
+      "type": "string",
+      "doc": "ID of this Virtual Node CPI upgrade request."
+    },
+    {
+      "name": "virtualNodeShortHash",
+      "type": "string",
+      "doc": "Identifier of the virtual node this operation is on."
+    },
+    {
+      "name": "actor",
+      "type": "string",
+      "doc": "ID of RPC user that requested the virtual node creation."
+    },
+    {
+      "name": "operationData",
+      "doc": "The operation specific data.",
+      "type": [
+        "net.corda.data.virtualnode.VirtualNodeUpgradeOperationStatus"
+      ]
+    },
+    {
+      "name": "requestTimestamp",
+      "type": {
+        "type": "long",
+        "logicalType": "timestamp-millis"
+      },
+      "doc": "Time ([Instant]) in milliseconds of the request."
+    },
+    {
+      "name": "latestUpdateTimestamp",
+      "type": {
+        "type": "long",
+        "logicalType": "timestamp-millis"
+      },
+      "doc": "Time ([Instant]) in milliseconds of the latest update to the request."
+    },
+    {
+      "name": "heartbeatTimestamp",
+      "type": {
+        "type": "long",
+        "logicalType": "timestamp-millis"
+      },
+      "doc": "Time ([Instant]) in milliseconds of the latest heartbeat."
+    },
+    {
+      "name": "state",
+      "type": {
+        "type": "enum",
+        "name": "AsynchronousOperationState",
+        "symbols": ["IN_PROGRESS", "COMPLETED", "ABORTED", "EXPIRED"],
+        "doc": "Status of an asynchronous request."
+      }
+    },
+    {
+      "name": "errors",
+      "type": {
+        "type": "array",
+        "items": "net.corda.data.ExceptionEnvelope"
+      },
+      "doc": "List of any errors that occurred."
+    }
+  ]
+}

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/virtualnode/VirtualNodeStateChangeResponse.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/virtualnode/VirtualNodeStateChangeResponse.avsc
@@ -8,9 +8,24 @@
       "type": "string"
     },
     {
-      "name": "virtualNodeState",
+      "name": "flowP2pOperationalStatus",
       "type": "string",
-      "doc": "The current maintenance state of the virtual node"
+      "doc": "The current flow p2p operational status of virtual node"
+    },
+    {
+      "name": "flowStartOperationalStatus",
+      "type": "string",
+      "doc": "The current flow start operational status of virtual node"
+    },
+    {
+      "name": "flowOperationalStatus",
+      "type": "string",
+      "doc": "The current flow operational status of virtual node"
+    },
+    {
+      "name": "vaultDbOperationalStatus",
+      "type": "string",
+      "doc": "The current vault db operational status of virtual node"
     }
   ]
 }

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/virtualnode/VirtualNodeUpgradeOperationStatus.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/virtualnode/VirtualNodeUpgradeOperationStatus.avsc
@@ -1,0 +1,27 @@
+{
+  "type": "record",
+  "name": "VirtualNodeUpgradeOperationStatus",
+  "namespace": "net.corda.data.virtualnode",
+  "fields": [
+    {
+      "name": "originalCpiFileChecksum",
+      "type": "string",
+      "doc": "The original checksum of the CPI file."
+    },
+    {
+      "name": "targetCpiFileChecksum",
+      "type": "string",
+      "doc": "The request target checksum of the CPI file to upgrade this virtual node."
+    },
+    {
+      "name": "virtualNodeShortId",
+      "type": "string",
+      "doc": "The short hash of the virtual node / holding identity that this operation applies to."
+    },
+    {
+      "name": "stage",
+      "type": "string",
+      "doc": "Current stage of the upgrade process."
+    }
+  ]
+}

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/virtualnode/VirtualNodeUpgradeRequest.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/virtualnode/VirtualNodeUpgradeRequest.avsc
@@ -1,0 +1,22 @@
+{
+  "type": "record",
+  "name": "VirtualNodeUpgradeRequest",
+  "namespace": "net.corda.data.virtualnode",
+  "fields": [
+    {
+      "name": "virtualNodeShortHash",
+      "type": "string",
+      "doc": "Short hash of the virtual node / holding identity."
+    },
+    {
+      "name": "cpiFileChecksum",
+      "type": "string",
+      "doc": "The checksum of the CPI file."
+    },
+    {
+      "name": "actor",
+      "type": "string",
+      "doc": "ID of RPC user that requested the virtual node creation."
+    }
+  ]
+}

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/virtualnode/VirtualNodeUpgradeResponse.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/virtualnode/VirtualNodeUpgradeResponse.avsc
@@ -1,6 +1,6 @@
 {
   "type": "record",
-  "name": "VirtualNodeCreateResponse",
+  "name": "VirtualNodeUpgradeResponse",
   "namespace": "net.corda.data.virtualnode",
   "fields": [
     {

--- a/data/db-schema/src/main/kotlin/net/corda/db/schema/DbSchema.kt
+++ b/data/db-schema/src/main/kotlin/net/corda/db/schema/DbSchema.kt
@@ -21,7 +21,7 @@ object DbSchema {
     const val DB_CONNECTION_AUDIT_ID_SEQUENCE_ALLOC_SIZE = 1
 
     const val VNODE = "VNODE"
-    const val VNODE_INSTANCE_DB_TABLE = "virtual_node"
+    const val VIRTUAL_NODE_DB_TABLE = "virtual_node"
     const val HOLDING_IDENTITY_DB_TABLE = "holding_identity"
     const val VNODE_VAULT_DB_TABLE = "vnode_vault"
     const val VNODE_KEY_DB_TABLE = "vnode_key"

--- a/data/db-schema/src/main/kotlin/net/corda/db/schema/DbSchema.kt
+++ b/data/db-schema/src/main/kotlin/net/corda/db/schema/DbSchema.kt
@@ -21,7 +21,7 @@ object DbSchema {
     const val DB_CONNECTION_AUDIT_ID_SEQUENCE_ALLOC_SIZE = 1
 
     const val VNODE = "VNODE"
-    const val VNODE_INSTANCE_DB_TABLE = "vnode_instance"
+    const val VNODE_INSTANCE_DB_TABLE = "virtual_node"
     const val HOLDING_IDENTITY_DB_TABLE = "holding_identity"
     const val VNODE_VAULT_DB_TABLE = "vnode_vault"
     const val VNODE_KEY_DB_TABLE = "vnode_key"

--- a/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/config-creation-v1.0.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/config-creation-v1.0.xml
@@ -222,6 +222,70 @@
             <column name="mgm_group_id" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
+            <column name="hsm_connection_id" type="UUID">
+                <constraints nullable="true"/>
+            </column>
+        </createTable>
+        <addPrimaryKey columnNames="holding_identity_id" constraintName="holding_identity_pk" tableName="holding_identity"
+                       schemaName="${schema.name}"/>
+
+        <createTable tableName="virtual_node_operation" schemaName="${schema.name}">
+            <column name="id" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="request_id" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="data" type="TEXT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="request_timestamp" type="TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="latest_update_timestamp" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="true"/>
+            </column>
+            <column name="heartbeat_timestamp" type="TIMESTAMP">
+                <constraints nullable="true"/>
+            </column>
+            <column name="state" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="errors" type="TEXT">
+                <constraints nullable="true"/>
+            </column>
+            <column name="entity_version" type="INT">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+        <addPrimaryKey columnNames="id" constraintName="virtual_node_operation_pk" tableName="virtual_node_operation"
+                       schemaName="${schema.name}"/>
+
+        <createTable tableName="virtual_node" schemaName="${schema.name}">
+            <column name="holding_identity_id" type="VARCHAR(12)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="cpi_name" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="cpi_version" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="cpi_signer_summary_hash" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name = "flow_p2p_operational_status" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name = "flow_start_operational_status" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name = "flow_operational_status" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name = "vault_db_operational_status" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
             <column name="vault_ddl_connection_id" type="UUID">
                 <constraints nullable="true"/>
             </column>
@@ -238,60 +302,10 @@
                 <constraints nullable="true"/>
             </column>
             <column name="uniqueness_dml_connection_id" type="UUID">
-            <constraints nullable="true"/>
-            </column>
-            <column name="hsm_connection_id" type="UUID">
                 <constraints nullable="true"/>
             </column>
-        </createTable>
-        <addPrimaryKey columnNames="holding_identity_id" constraintName="holding_identity_pk" tableName="holding_identity"
-                       schemaName="${schema.name}"/>
-        <addForeignKeyConstraint baseTableName="holding_identity" baseColumnNames="vault_ddl_connection_id"
-                                 referencedTableName="db_connection" referencedColumnNames="connection_id"
-                                 constraintName="FK__holding_identity__vault_ddl_connection_id"
-                                 baseTableSchemaName="${schema.name}"
-                                 referencedTableSchemaName="${schema.name}"/>
-        <addForeignKeyConstraint baseTableName="holding_identity" baseColumnNames="vault_dml_connection_id"
-                                 referencedTableName="db_connection" referencedColumnNames="connection_id"
-                                 constraintName="FK__holding_identity__vault_dml_connection_id"
-                                 baseTableSchemaName="${schema.name}"
-                                 referencedTableSchemaName="${schema.name}"/>
-        <addForeignKeyConstraint baseTableName="holding_identity" baseColumnNames="crypto_ddl_connection_id"
-                                 referencedTableName="db_connection" referencedColumnNames="connection_id"
-                                 constraintName="FK__holding_identity__crypto_ddl_connection_id"
-                                 baseTableSchemaName="${schema.name}"
-                                 referencedTableSchemaName="${schema.name}"/>
-        <addForeignKeyConstraint baseTableName="holding_identity" baseColumnNames="crypto_dml_connection_id"
-                                 referencedTableName="db_connection" referencedColumnNames="connection_id"
-                                 constraintName="FK__holding_identity__crypto_dml_connection_id"
-                                 baseTableSchemaName="${schema.name}"
-                                 referencedTableSchemaName="${schema.name}"/>
-        <addForeignKeyConstraint baseTableName="holding_identity" baseColumnNames="uniqueness_ddl_connection_id"
-                                 referencedTableName="db_connection" referencedColumnNames="connection_id"
-                                 constraintName="FK__holding_identity__uniqueness_ddl_connection_id"
-                                 baseTableSchemaName="${schema.name}"
-                                 referencedTableSchemaName="${schema.name}"/>
-        <addForeignKeyConstraint baseTableName="holding_identity" baseColumnNames="uniqueness_dml_connection_id"
-                                 referencedTableName="db_connection" referencedColumnNames="connection_id"
-                                 constraintName="FK__holding_identity__uniqueness_dml_connection_id"
-                                 baseTableSchemaName="${schema.name}"
-                                 referencedTableSchemaName="${schema.name}"/>
-
-        <createTable tableName="vnode_instance" schemaName="${schema.name}">
-            <column name="holding_identity_id" type="VARCHAR(12)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="cpi_name" type="VARCHAR(255)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="cpi_version" type="VARCHAR(255)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="cpi_signer_summary_hash" type="VARCHAR(255)">
-                <constraints nullable="false"/>
-            </column>
-            <column name = "state" type="VARCHAR(255)">
-                <constraints nullable="false"/>
+            <column name="operation_in_progress" type="VARCHAR(255)">
+                <constraints nullable="true"/>
             </column>
             <!-- audit -->
             <column name="entity_version" type="INT">
@@ -304,11 +318,47 @@
                 <constraints nullable="false"/>
             </column>
         </createTable>
-        <addPrimaryKey columnNames="holding_identity_id, cpi_name, cpi_version, cpi_signer_summary_hash"
-                       constraintName="vnode_instance_pk" tableName="vnode_instance" schemaName="${schema.name}"/>
-        <addForeignKeyConstraint baseTableName="vnode_instance" baseColumnNames="cpi_name, cpi_version, cpi_signer_summary_hash"
+        <addPrimaryKey tableName="virtual_node" columnNames="holding_identity_id"
+                       constraintName="virtual_node_pk" schemaName="${schema.name}"/>
+
+        <addForeignKeyConstraint baseTableName="virtual_node" baseColumnNames="cpi_name, cpi_version, cpi_signer_summary_hash"
                                  referencedTableName="cpi" referencedColumnNames="name, version, signer_summary_hash"
-                                 constraintName="FK_vnode_instance_cpi"
+                                 constraintName="FK_virtual_node_cpi"
+                                 baseTableSchemaName="${schema.name}"
+                                 referencedTableSchemaName="${schema.name}"/>
+        <addForeignKeyConstraint baseTableName="virtual_node" baseColumnNames="vault_ddl_connection_id"
+                                 referencedTableName="db_connection" referencedColumnNames="connection_id"
+                                 constraintName="FK__virtual_node__vault_ddl_connection_id"
+                                 baseTableSchemaName="${schema.name}"
+                                 referencedTableSchemaName="${schema.name}"/>
+        <addForeignKeyConstraint baseTableName="virtual_node" baseColumnNames="vault_dml_connection_id"
+                                 referencedTableName="db_connection" referencedColumnNames="connection_id"
+                                 constraintName="FK__virtual_node__vault_dml_connection_id"
+                                 baseTableSchemaName="${schema.name}"
+                                 referencedTableSchemaName="${schema.name}"/>
+        <addForeignKeyConstraint baseTableName="virtual_node" baseColumnNames="crypto_ddl_connection_id"
+                                 referencedTableName="db_connection" referencedColumnNames="connection_id"
+                                 constraintName="FK__virtual_node__crypto_ddl_connection_id"
+                                 baseTableSchemaName="${schema.name}"
+                                 referencedTableSchemaName="${schema.name}"/>
+        <addForeignKeyConstraint baseTableName="virtual_node" baseColumnNames="crypto_dml_connection_id"
+                                 referencedTableName="db_connection" referencedColumnNames="connection_id"
+                                 constraintName="FK__virtual_node__crypto_dml_connection_id"
+                                 baseTableSchemaName="${schema.name}"
+                                 referencedTableSchemaName="${schema.name}"/>
+        <addForeignKeyConstraint baseTableName="virtual_node" baseColumnNames="uniqueness_ddl_connection_id"
+                                 referencedTableName="db_connection" referencedColumnNames="connection_id"
+                                 constraintName="FK__virtual_node__uniqueness_ddl_connection_id"
+                                 baseTableSchemaName="${schema.name}"
+                                 referencedTableSchemaName="${schema.name}"/>
+        <addForeignKeyConstraint baseTableName="virtual_node" baseColumnNames="uniqueness_dml_connection_id"
+                                 referencedTableName="db_connection" referencedColumnNames="connection_id"
+                                 constraintName="FK__virtual_node__uniqueness_dml_connection_id"
+                                 baseTableSchemaName="${schema.name}"
+                                 referencedTableSchemaName="${schema.name}"/>
+        <addForeignKeyConstraint baseTableName="virtual_node" baseColumnNames="operation_in_progress"
+                                 referencedTableName="virtual_node_operation" referencedColumnNames="id"
+                                 constraintName="FK__virtual_node_operation"
                                  baseTableSchemaName="${schema.name}"
                                  referencedTableSchemaName="${schema.name}"/>
         <createTable tableName="cluster_certificate" schemaName="${schema.name}">

--- a/data/topic-schema/src/main/kotlin/net/corda/schema/Schemas.kt
+++ b/data/topic-schema/src/main/kotlin/net/corda/schema/Schemas.kt
@@ -197,6 +197,8 @@ class Schemas {
     class VirtualNode {
         companion object {
             const val VIRTUAL_NODE_INFO_TOPIC = "virtual.node.info"
+            const val VIRTUAL_NODE_ASYNC_REQUEST_TOPIC = "virtual.node.async.request"
+            const val VIRTUAL_NODE_OPERATION_STATUS_TOPIC = "virtual.node.operation.status"
             const val VIRTUAL_NODE_CREATION_REQUEST_TOPIC = "virtual.node.creation.request"
             val VIRTUAL_NODE_CREATION_REQUEST_RESPONSE_TOPIC = getRPCResponseTopic(VIRTUAL_NODE_CREATION_REQUEST_TOPIC)
             const val CPI_INFO_TOPIC = "cpi.info"

--- a/data/topic-schema/src/main/resources/net/corda/schema/VirtualNode.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/VirtualNode.yaml
@@ -76,3 +76,17 @@ topics:
       min.compaction.lag.ms: 60000
       max.compaction.lag.ms: 604800000
       min.cleanable.dirty.ratio: 0.5
+  VirtualNodeOperationStatusTopic:
+    name: virtual.node.operation.status
+    consumers:
+      - db
+    producers:
+      - rpc
+    config:
+  VirtualNodeAsyncRequestTopic:
+    name: virtual.node.async.request
+    consumers:
+      - db
+    producers:
+      - rpc
+    config:

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 623
+cordaApiRevision = 624
 
 # Main
 kotlinVersion = 1.7.21


### PR DESCRIPTION
This PR renames the `vnode_instance` table to `virtual_node`, adding the four OperationalStatus fields needed to support CPI upgrade, as described in the [CPI upgrade design documentation](https://github.com/corda/platform-eng-design/blob/master/core/corda-5/corda-5.0/virtual-node/cpi-upgrade/database-schema-changes.md). The corresponding corda-runtime-os changes are being made in https://github.com/corda/corda-runtime-os/pull/2905.

The fields being added to VirtualNodeEntity are:
- `flow_p2p_operational_status`
- `flow_start_operational_status`
- `flow_operational_status`
- `operation_in_progress`
- `vault_db_operational_status`
- `vault_ddl_connection_id`
- `vault_dml_connection_id`
- `crypto_ddl_connection_id`
- `crypto_dml_connection_id`
- `uniqueness_ddl_connection_id`
- `uniqueness_dml_connection_id`

Additionally, the ConnectionId fields in `holding_identity `are being moved to `virtual_node`. 