### PR TITLE
CORE-9566 Fix containsAny to not use intersect

### DIFF
--- a/crypto/src/main/kotlin/net/corda/v5/crypto/CryptoUtils.kt
+++ b/crypto/src/main/kotlin/net/corda/v5/crypto/CryptoUtils.kt
@@ -97,8 +97,11 @@ fun PublicKey.isFulfilledBy(otherKeys: Iterable<PublicKey>): Boolean =
  * [otherKeys] is a [CompositeKey], this function will not find a match.</i>
  */
 fun PublicKey.containsAny(otherKeys: Iterable<PublicKey>): Boolean {
-    return if (this is CompositeKey) otherKeys.any { keys.contains(it) }
-    else this in otherKeys
+    return if (this is CompositeKey) {
+        // `keys` is exported to a standalone value here to make sure it is not evaluated in every loop tick
+        val currentKeys = keys
+        otherKeys.any { currentKeys.contains(it) }
+    } else this in otherKeys
 }
 
 /** Returns the set of all [PublicKey]s of the signatures. */

--- a/crypto/src/main/kotlin/net/corda/v5/crypto/CryptoUtils.kt
+++ b/crypto/src/main/kotlin/net/corda/v5/crypto/CryptoUtils.kt
@@ -97,7 +97,7 @@ fun PublicKey.isFulfilledBy(otherKeys: Iterable<PublicKey>): Boolean =
  * [otherKeys] is a [CompositeKey], this function will not find a match.</i>
  */
 fun PublicKey.containsAny(otherKeys: Iterable<PublicKey>): Boolean {
-    return if (this is CompositeKey) keys.intersect(otherKeys).isNotEmpty()
+    return if (this is CompositeKey) otherKeys.any { keys.contains(it) }
     else this in otherKeys
 }
 

--- a/crypto/src/test/kotlin/net/corda/v5/crypto/CryptoUtilsTests.kt
+++ b/crypto/src/test/kotlin/net/corda/v5/crypto/CryptoUtilsTests.kt
@@ -11,8 +11,11 @@ import org.junit.jupiter.api.Assertions.assertArrayEquals
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
 import java.io.ByteArrayInputStream
 import java.security.MessageDigest
 import java.security.PublicKey
@@ -120,6 +123,32 @@ class CryptoUtilsTests {
                     generateKeyPair(ECDSA_SECP256R1_SPEC).public,
                 )
             )
+        )
+    }
+
+    @Test
+    fun `containsAny should only return true if one of the provided key parameters is associated with the composite key`() {
+        val key = generateKeyPair(ECDSA_SECP256R1_SPEC).public
+        val key2 = generateKeyPair(ECDSA_SECP256R1_SPEC).public
+        val key3 = generateKeyPair(ECDSA_SECP256R1_SPEC).public
+
+        val invalidKey = generateKeyPair(ECDSA_SECP256R1_SPEC).public
+        val differentAlgoKey = generateKeyPair(RSA_SPEC).public
+
+        val compositeKey = mock<CompositeKey> {
+            on { leafKeys } doReturn setOf(key, key2, key3)
+        }
+        assertAll(
+            { assertTrue { compositeKey.containsAny(setOf(key)) } },
+            { assertTrue { compositeKey.containsAny(setOf(key, key2)) } },
+            { assertTrue { compositeKey.containsAny(setOf(key2, key3)) } },
+            { assertTrue { compositeKey.containsAny(setOf(key, key3)) } },
+            { assertTrue { compositeKey.containsAny(setOf(key2)) } },
+            { assertTrue { compositeKey.containsAny(setOf(key2, invalidKey)) } },
+            { assertTrue { compositeKey.containsAny(setOf(key3, differentAlgoKey)) } },
+            { assertFalse { compositeKey.containsAny(setOf(invalidKey)) } },
+            { assertFalse { compositeKey.containsAny(setOf(differentAlgoKey)) } },
+            { assertFalse { compositeKey.containsAny(emptySet()) } },
         )
     }
 

--- a/crypto/src/test/kotlin/net/corda/v5/crypto/CryptoUtilsTests.kt
+++ b/crypto/src/test/kotlin/net/corda/v5/crypto/CryptoUtilsTests.kt
@@ -138,7 +138,13 @@ class CryptoUtilsTests {
         val compositeKey = mock<CompositeKey> {
             on { leafKeys } doReturn setOf(key, key2, key3)
         }
+
+        val compositeKey2 = mock<CompositeKey> {
+            on { leafKeys } doReturn setOf(key, key3)
+        }
+
         assertAll(
+            // First composite key probes
             { assertTrue { compositeKey.containsAny(setOf(key)) } },
             { assertTrue { compositeKey.containsAny(setOf(key, key2)) } },
             { assertTrue { compositeKey.containsAny(setOf(key2, key3)) } },
@@ -149,6 +155,10 @@ class CryptoUtilsTests {
             { assertFalse { compositeKey.containsAny(setOf(invalidKey)) } },
             { assertFalse { compositeKey.containsAny(setOf(differentAlgoKey)) } },
             { assertFalse { compositeKey.containsAny(emptySet()) } },
+            // Second composite key probes
+            { assertTrue { compositeKey2.containsAny(setOf(key)) } },
+            { assertTrue { compositeKey2.containsAny(setOf(key3)) } },
+            { assertFalse { compositeKey2.containsAny(setOf(key2)) } }
         )
     }
 

--- a/ledger/ledger-utxo/src/main/kotlin/net/corda/v5/ledger/utxo/uniqueness/client/LedgerUniquenessCheckerClientService.kt
+++ b/ledger/ledger-utxo/src/main/kotlin/net/corda/v5/ledger/utxo/uniqueness/client/LedgerUniquenessCheckerClientService.kt
@@ -32,7 +32,8 @@ interface LedgerUniquenessCheckerClientService {
      *
      * @param timeWindowUpperBound The latest date/time until the transaction is considered valid.
      *
-     * @param notaryServiceKeys List of notary VNode keys that belong to the selected notary service.
+     * @param notaryServiceKey The key of the notary service, might be a [net.corda.v5.crypto.CompositeKey]
+     * if there are multiple notary VNodes registered.
      */
     @Suppress("LongParameterList")
     @Suspendable
@@ -43,7 +44,7 @@ interface LedgerUniquenessCheckerClientService {
         numOutputStates: Int,
         timeWindowLowerBound: Instant?,
         timeWindowUpperBound: Instant,
-        notaryServiceKeys: List<PublicKey>
+        notaryServiceKey: PublicKey
     ): LedgerUniquenessCheckResponse
 }
 
@@ -60,7 +61,7 @@ fun LedgerUniquenessCheckerClientService.requestUniquenessCheck(
     numOutputStates: Int,
     timeWindowLowerBound: Instant?,
     timeWindowUpperBound: Instant,
-    notaryServiceKeys: List<PublicKey>
+    notaryServiceKey: PublicKey
 ) = requestUniquenessCheck(
     txId,
     inputStates.map { it.toString() },
@@ -68,5 +69,5 @@ fun LedgerUniquenessCheckerClientService.requestUniquenessCheck(
     numOutputStates,
     timeWindowLowerBound,
     timeWindowUpperBound,
-    notaryServiceKeys
+    notaryServiceKey
 )


### PR DESCRIPTION
### Overview

Before Kotlin 1.6, the intersect function was converting the parameter to a Set. 
This functionality was removed after 1.6 but it can still be applied, if the `convert_arg_to_set_in_removeAll` JVM property is set to true. 

Obviously the intersect function tries to access this property to see if it should apply the “old” logic. 

However, this JVM property cannot be accessed from flows (probably because of OSGi sandboxing) thus causing the flow to fail.
Please note that this can only be reproduced if the provided parameter is a CompositeKey because the else branch does not use intersect.

### How to reproduce

This issue was caught by @vlajos when running some new ledger tests from the `corda-e2e-tests` repository. For the first run, the network will only have one notary VNode so the notary service's key is a simple `PublicKey`. 

When running the tests for the second time, a new notary VNode is registered and the notary service's key will become a `CompositeKey`. This time the `if (this is CompositeKey) keys.intersect(otherKeys).isNotEmpty()` branch is executed and the `intersect` function is called and the tests fail with:
```
2023-01-19 10:30:55.265 [single-threaded-scheduled-executor-1] WARN  net.corda.flow.fiber.FlowFiberImpl {client_id=59653b4b-a4c0-4979-97af-5d78d189c50a, flow_id=b276b1ce-a688-4bc0-b491-4d19264ff6e0, vnode_id=0238E39C0C01} - Flow failed
java.lang.ExceptionInInitializerError: null
    at kotlin.collections.BrittleContainsOptimizationKt.safeToConvertToSet(BrittleContainsOptimization.kt:67) ~[?:?]
    at kotlin.collections.BrittleContainsOptimizationKt.convertToSetForSetOperationWith(BrittleContainsOptimization.kt:33) ~[?:?]
    at kotlin.collections.CollectionsKt__MutableCollectionsKt.retainAll(MutableCollections.kt:170) ~[?:?]
    at kotlin.collections.CollectionsKt___CollectionsKt.intersect(_Collections.kt:1674) ~[?:?]
    at net.corda.v5.crypto.CryptoUtils.containsAny(CryptoUtils.kt:100) ~[?:?]
    at net.corda.ledger.utxo.flow.impl.flows.finality.UtxoFinalityBase.verifyAndAddNotarySignature(UtxoFinalityBase.kt:78) ~[?:?]
    at net.corda.ledger.utxo.flow.impl.flows.finality.UtxoFinalityFlow.notarize(UtxoFinalityFlow.kt:182) ~[?:?]
    at net.corda.ledger.utxo.flow.impl.flows.finality.UtxoFinalityFlow.call(UtxoFinalityFlow.kt:50) ~[?:?]
    at net.corda.ledger.utxo.flow.impl.flows.finality.UtxoFinalityFlow.call(UtxoFinalityFlow.kt:22) ~[?:?]
    at net.corda.flow.application.services.FlowEngineImpl.subFlow(FlowEngineImpl.kt:52) ~[?:?]
    at net.corda.ledger.utxo.flow.impl.UtxoLedgerServiceImpl.finalize(UtxoLedgerServiceImpl.kt:101) ~[?:?]
    at net.cordapp.demo.obligation.workflow.CreateObligationFlow.call(CreateObligationFlow.kt:64) ~[?:?]
    at net.cordapp.demo.obligation.workflow.CreateObligationFlow.call(CreateObligationFlow.kt:28) ~[?:?]
    at net.corda.flow.application.services.FlowEngineImpl.subFlow(FlowEngineImpl.kt:52) ~[?:?]
    at net.cordapp.demo.obligation.workflow.CreateObligationFlow$Initiator.call(CreateObligationFlow.kt:116) ~[?:?]
    at net.corda.flow.fiber.RPCStartedFlow.invoke(RPCStartedFlow.kt:14) ~[?:?]
    at net.corda.flow.fiber.FlowFiberImpl.runFlow(FlowFiberImpl.kt:96) ~[?:?]
    at net.corda.flow.fiber.FlowFiberImpl.run(FlowFiberImpl.kt:65) ~[?:?]
    at net.corda.flow.fiber.FlowFiberImpl.run(FlowFiberImpl.kt:22) ~[?:?]
    at co.paralleluniverse.fibers.Fiber.run1(Fiber.java:1164) ~[?:?]
    at co.paralleluniverse.fibers.Fiber.exec(Fiber.java:860) ~[?:?]
    at co.paralleluniverse.fibers.RunnableFiberTask.doExec(RunnableFiberTask.java:100) ~[?:?]
    at co.paralleluniverse.fibers.RunnableFiberTask.run(RunnableFiberTask.java:91) ~[?:?]
    at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) ~[?:?]
    at java.util.concurrent.FutureTask.run(FutureTask.java:264) ~[?:?]
    at co.paralleluniverse.concurrent.util.ScheduledSingleThreadExecutor$ScheduledFutureTask.access$001(ScheduledSingleThreadExecutor.java:160) ~[?:?]
    at co.paralleluniverse.concurrent.util.ScheduledSingleThreadExecutor$ScheduledFutureTask.run(ScheduledSingleThreadExecutor.java:272) ~[?:?]
    at co.paralleluniverse.concurrent.util.ScheduledSingleThreadExecutor.work(ScheduledSingleThreadExecutor.java:119) ~[?:?]
    at java.lang.Thread.run(Thread.java:829) ~[?:?]
Caused by: java.security.AccessControlException: access denied ("java.util.PropertyPermission" "kotlin.collections.convert_arg_to_set_in_removeAll" "read")
```

### Test notes

Re-run the tests on the same combined worker multiple times, no issues after the fix.