### PR TITLE
CORE-8954 Notary Batch Signatures

### DIFF
--- a/application/src/main/kotlin/net/corda/v5/application/crypto/DigitalSignatureAndMetadata.kt
+++ b/application/src/main/kotlin/net/corda/v5/application/crypto/DigitalSignatureAndMetadata.kt
@@ -10,7 +10,7 @@ import net.corda.v5.crypto.merkle.MerkleProof
  *
  * @property signature The signature that was applied.
  * @property metadata Attached [DigitalSignatureMetadata] for this signature.
- * @property proof Attached [MerkleProof] to support batch signatures.
+ * @property proof Attached [MerkleProof] if this is a batch signature.
  * @property by The [PublicKey] that created the signature.
  *
  * @constructor Creates a [DigitalSignatureAndMetadata].

--- a/application/src/main/kotlin/net/corda/v5/application/crypto/DigitalSignatureAndMetadata.kt
+++ b/application/src/main/kotlin/net/corda/v5/application/crypto/DigitalSignatureAndMetadata.kt
@@ -3,12 +3,14 @@ package net.corda.v5.application.crypto
 import java.security.PublicKey
 import net.corda.v5.base.annotations.CordaSerializable
 import net.corda.v5.crypto.DigitalSignature
+import net.corda.v5.crypto.merkle.MerkleProof
 
 /**
  * A wrapper over the signature output accompanied by signer's public key and signature metadata.
  *
  * @property signature The signature that was applied.
  * @property metadata Attached [DigitalSignatureMetadata] for this signature.
+ * @property proof Attached [MerkleProof] to support batch signatures.
  * @property by The [PublicKey] that created the signature.
  *
  * @constructor Creates a [DigitalSignatureAndMetadata].
@@ -16,7 +18,13 @@ import net.corda.v5.crypto.DigitalSignature
 @CordaSerializable
 data class DigitalSignatureAndMetadata(
     val signature: DigitalSignature.WithKey,
-    val metadata: DigitalSignatureMetadata
+    val metadata: DigitalSignatureMetadata,
+    val proof: MerkleProof?
 ) {
+    constructor(signature: DigitalSignature.WithKey, metadata: DigitalSignatureMetadata) : this(
+        signature,
+        metadata,
+        null
+    )
     val by: PublicKey = signature.by
 }

--- a/application/src/test/java/net/corda/v5/crypto/merkle/MerkleProofJavaApiTest.java
+++ b/application/src/test/java/net/corda/v5/crypto/merkle/MerkleProofJavaApiTest.java
@@ -27,7 +27,6 @@ class MerkleProofJavaApiTest {
         final SecureHash rootHash = new SecureHash("SHA-256", "456".getBytes());
         when(merkleProof.calculateRoot(any())).thenReturn(rootHash);
 
-        final SecureHash hash = new SecureHash("SHA-256", "123".getBytes());
         final MerkleTreeHashDigest digest = mock(MerkleTreeHashDigest.class);
         final SecureHash result = merkleProof.calculateRoot(digest);
 

--- a/application/src/test/java/net/corda/v5/crypto/merkle/MerkleProofJavaApiTest.java
+++ b/application/src/test/java/net/corda/v5/crypto/merkle/MerkleProofJavaApiTest.java
@@ -22,4 +22,15 @@ class MerkleProofJavaApiTest {
 
         Assertions.assertThat(result).isEqualTo(true);
     }
+    @Test
+    void calculateRoot() {
+        final SecureHash rootHash = new SecureHash("SHA-256", "456".getBytes());
+        when(merkleProof.calculateRoot(any())).thenReturn(rootHash);
+
+        final SecureHash hash = new SecureHash("SHA-256", "123".getBytes());
+        final MerkleTreeHashDigest digest = mock(MerkleTreeHashDigest.class);
+        final SecureHash result = merkleProof.calculateRoot(digest);
+
+        Assertions.assertThat(result).isEqualTo(rootHash);
+    }
 }

--- a/crypto/src/main/kotlin/net/corda/v5/crypto/merkle/MerkleProof.kt
+++ b/crypto/src/main/kotlin/net/corda/v5/crypto/merkle/MerkleProof.kt
@@ -41,9 +41,11 @@ interface MerkleProof {
      *
      * @param digest The tree's digest.
      *
-     * @returns Root hash of the tree or null if any details are incorrect.
+     * @returns Root hash of the tree.
+     *
+     * @throws MerkleProofRebuildFailureException if the calculation of the root hash failed.
      */
     fun calculateRoot(
         digest: MerkleTreeHashDigest
-    ): SecureHash?
+    ): SecureHash
 }

--- a/crypto/src/main/kotlin/net/corda/v5/crypto/merkle/MerkleProof.kt
+++ b/crypto/src/main/kotlin/net/corda/v5/crypto/merkle/MerkleProof.kt
@@ -35,4 +35,15 @@ interface MerkleProof {
         root: SecureHash,
         digest: MerkleTreeHashDigest
     ): Boolean
+
+    /**
+     * Rebuilds the [MerkleTree] from the [MerkleProof] and returns its root [SecureHash].
+     *
+     * @param digest The tree's digest.
+     *
+     * @returns Root hash of the tree or null if any details are incorrect.
+     */
+    fun calculateRoot(
+        digest: MerkleTreeHashDigest
+    ): SecureHash?
 }

--- a/crypto/src/main/kotlin/net/corda/v5/crypto/merkle/MerkleProofRebuildFailureException.kt
+++ b/crypto/src/main/kotlin/net/corda/v5/crypto/merkle/MerkleProofRebuildFailureException.kt
@@ -1,0 +1,8 @@
+package net.corda.v5.crypto.merkle
+
+import net.corda.v5.base.exceptions.CordaRuntimeException
+
+/**
+ * Indicates that the calculation of the root hash of a [MerkleProof] failed.
+ */
+class MerkleProofRebuildFailureException(message: String) : CordaRuntimeException(message, null)

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 632
+cordaApiRevision = 633
 
 # Main
 kotlinVersion = 1.7.21

--- a/ledger/ledger-common/src/main/kotlin/net/corda/v5/ledger/common/transaction/TransactionMetadata.kt
+++ b/ledger/ledger-common/src/main/kotlin/net/corda/v5/ledger/common/transaction/TransactionMetadata.kt
@@ -53,7 +53,7 @@ interface TransactionMetadata {
      *
      * @return The digest settings as map.
      */
-    fun getDigestSettings(): LinkedHashMap<String, Any>
+    fun getDigestSettings(): Map<String, String>
 
     /**
      * Gets the version of the metadata JSON schema to parse this metadata entity.

--- a/ledger/ledger-common/src/main/kotlin/net/corda/v5/ledger/common/transaction/TransactionNoAvailableKeysException.kt
+++ b/ledger/ledger-common/src/main/kotlin/net/corda/v5/ledger/common/transaction/TransactionNoAvailableKeysException.kt
@@ -1,0 +1,8 @@
+package net.corda.v5.ledger.common.transaction
+
+import net.corda.v5.base.exceptions.CordaRuntimeException
+
+/**
+ * Indicates that the signing attempt failed due to no available signing keys.
+ */
+class TransactionNoAvailableKeysException(message: String, cause: Throwable?) : CordaRuntimeException(message, cause)

--- a/ledger/ledger-common/src/main/kotlin/net/corda/v5/ledger/common/transaction/TransactionSignatureService.kt
+++ b/ledger/ledger-common/src/main/kotlin/net/corda/v5/ledger/common/transaction/TransactionSignatureService.kt
@@ -3,7 +3,6 @@ package net.corda.v5.ledger.common.transaction
 import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.application.crypto.DigitalSignatureVerificationService
 import net.corda.v5.base.annotations.Suspendable
-import net.corda.v5.crypto.SecureHash
 import net.corda.v5.crypto.merkle.MerkleProof
 import java.security.PublicKey
 
@@ -16,15 +15,15 @@ interface TransactionSignatureService {
     /**
      * Signs a transaction id with all the available keys.
      *
-     * @param transactionId The transaction id to be signed.
-     * @param publicKeys The keys which should be tried to sign with.
+     * @param transaction The transaction to be signed.
+     * @param publicKeys Public keys that correspond to the private keys which should be attempted to sign with.
      *
      * @returns Resulting signatures.
      *
      * @throws TransactionNoAvailableKeysException If none of the keys are available.
      */
     @Suspendable
-    fun sign(transactionId: SecureHash, publicKeys: Iterable<PublicKey>): List<DigitalSignatureAndMetadata>
+    fun sign(transaction: TransactionWithMetadata, publicKeys: Iterable<PublicKey>): List<DigitalSignatureAndMetadata>
 
     /**
      * Signs a list of transactions with each the available keys.
@@ -32,14 +31,15 @@ interface TransactionSignatureService {
      * Then returns the signatures for each transaction with a [MerkleProof] to prove that they are included in the batch.
      *
      * @param transactions The transactions to be signed.
-     * @param publicKeys The keys which should be tried to sign with.
+     * @param publicKeys Public keys that correspond to the private keys which should be attempted to sign with.
      *
-     * @returns Resulting signatures.
+     * @returns List of signatures for each supplied transaction.
+     *          The outer list will always be of the same size and in the same order as the supplied [transactions].
      *
      * @throws TransactionNoAvailableKeysException If none of the keys are available.
      */
     @Suspendable
-    fun sign(
+    fun signBatch(
         transactions: List<TransactionWithMetadata>,
         publicKeys: Iterable<PublicKey>
     ): List<List<DigitalSignatureAndMetadata>>

--- a/ledger/ledger-common/src/main/kotlin/net/corda/v5/ledger/common/transaction/TransactionSignatureService.kt
+++ b/ledger/ledger-common/src/main/kotlin/net/corda/v5/ledger/common/transaction/TransactionSignatureService.kt
@@ -1,0 +1,57 @@
+package net.corda.v5.ledger.common.transaction
+
+import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
+import net.corda.v5.application.crypto.DigitalSignatureVerificationService
+import net.corda.v5.base.annotations.Suspendable
+import net.corda.v5.crypto.SecureHash
+import net.corda.v5.crypto.merkle.MerkleProof
+import java.security.PublicKey
+
+/**
+ * TransactionSignatureService can be used to sign and verify transaction signatures.
+ * It supports both single and batch signatures.
+ */
+
+interface TransactionSignatureService {
+    /**
+     * Signs a transaction id with all the available keys.
+     *
+     * @param transactionId The transaction id to be signed.
+     * @param publicKeys The keys which should be tried to sign with.
+     *
+     * @returns Resulting signatures.
+     *
+     * @throws TransactionNoAvailableKeysException If none of the keys are available.
+     */
+    @Suspendable
+    fun sign(transactionId: SecureHash, publicKeys: Iterable<PublicKey>): List<DigitalSignatureAndMetadata>
+
+    /**
+     * Signs a list of transactions with each the available keys.
+     * It creates one batch signature for each available keys.
+     * Then returns the signatures for each transaction with a [MerkleProof] to prove that they are included in the batch.
+     *
+     * @param transactions The transactions to be signed.
+     * @param publicKeys The keys which should be tried to sign with.
+     *
+     * @returns Resulting signatures.
+     *
+     * @throws TransactionNoAvailableKeysException If none of the keys are available.
+     */
+    @Suspendable
+    fun sign(
+        transactions: List<TransactionWithMetadata>,
+        publicKeys: Iterable<PublicKey>
+    ): List<List<DigitalSignatureAndMetadata>>
+
+    /**
+     * Verifies a signature against a transaction.
+     * The underlying verification service signals the verification failures with different exceptions.
+     * [DigitalSignatureVerificationService]
+     *
+     * @param transaction The original transaction.
+     * @param signatureWithMetadata The signature to be verified.
+     *
+     */
+    fun verifySignature(transaction: TransactionWithMetadata, signatureWithMetadata: DigitalSignatureAndMetadata)
+}

--- a/ledger/ledger-common/src/main/kotlin/net/corda/v5/ledger/common/transaction/TransactionWithMetadata.kt
+++ b/ledger/ledger-common/src/main/kotlin/net/corda/v5/ledger/common/transaction/TransactionWithMetadata.kt
@@ -1,0 +1,22 @@
+package net.corda.v5.ledger.common.transaction
+
+import net.corda.v5.base.annotations.DoNotImplement
+import net.corda.v5.crypto.SecureHash
+
+/**
+ * TransactionWithMetadata lets access metadata properties of the different transactions of different ledger implementations.
+ *
+ * * @property signature The signature that was applied.
+ */
+@DoNotImplement
+interface TransactionWithMetadata {
+    /**
+     * @property id The ID of the transaction.
+     */
+    val id: SecureHash
+
+    /**
+     * @property metadata The metadata for this transaction.
+     */
+    val metadata: TransactionMetadata
+}

--- a/ledger/ledger-common/src/main/kotlin/net/corda/v5/ledger/common/transaction/TransactionWithMetadata.kt
+++ b/ledger/ledger-common/src/main/kotlin/net/corda/v5/ledger/common/transaction/TransactionWithMetadata.kt
@@ -4,7 +4,7 @@ import net.corda.v5.base.annotations.DoNotImplement
 import net.corda.v5.crypto.SecureHash
 
 /**
- * TransactionWithMetadata lets access metadata properties of the different transactions of different ledger implementations.
+ * TransactionWithMetadata contains metadata properties of transactions common across different ledger implementations.
  *
  * * @property signature The signature that was applied.
  */

--- a/ledger/ledger-consensual/src/main/kotlin/net/corda/v5/ledger/consensual/transaction/ConsensualSignedTransaction.kt
+++ b/ledger/ledger-consensual/src/main/kotlin/net/corda/v5/ledger/consensual/transaction/ConsensualSignedTransaction.kt
@@ -2,7 +2,7 @@ package net.corda.v5.ledger.consensual.transaction
 
 import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.base.annotations.DoNotImplement
-import net.corda.v5.crypto.SecureHash
+import net.corda.v5.ledger.common.transaction.TransactionWithMetadata
 
 /**
  * Defines a signed Consensual transaction.
@@ -23,12 +23,7 @@ import net.corda.v5.crypto.SecureHash
  * Thus adding or removing a signature does not change it.
  */
 @DoNotImplement
-interface ConsensualSignedTransaction {
-    /**
-     * @property id The ID of the transaction.
-     */
-    val id: SecureHash
-
+interface ConsensualSignedTransaction: TransactionWithMetadata {
     /**
      * @property signatures The signatures that have been applied to the transaction.
      */

--- a/ledger/ledger-consensual/src/main/kotlin/net/corda/v5/ledger/consensual/transaction/ConsensualTransactionBuilder.kt
+++ b/ledger/ledger-consensual/src/main/kotlin/net/corda/v5/ledger/consensual/transaction/ConsensualTransactionBuilder.kt
@@ -3,7 +3,7 @@ package net.corda.v5.ledger.consensual.transaction
 import net.corda.v5.base.annotations.DoNotImplement
 import net.corda.v5.ledger.consensual.ConsensualState
 import net.corda.v5.base.annotations.Suspendable
-import net.corda.v5.base.exceptions.CordaRuntimeException
+import net.corda.v5.ledger.common.transaction.TransactionNoAvailableKeysException
 
 /**
  * Defines a builder for [ConsensualSignedTransaction]s.
@@ -38,7 +38,7 @@ interface ConsensualTransactionBuilder {
      *
      * @throws IllegalStateException when called a second time on the same object to prevent
      *      unintentional duplicate transactions.
-     * @throws CordaRuntimeException if none of the required keys are available to sign the transaction.
+     * @throws TransactionNoAvailableKeysException if none of the required keys are available to sign the transaction.
      */
     @Suspendable
     fun toSignedTransaction(): ConsensualSignedTransaction

--- a/ledger/ledger-utxo/src/main/kotlin/net/corda/v5/ledger/utxo/transaction/UtxoSignedTransaction.kt
+++ b/ledger/ledger-utxo/src/main/kotlin/net/corda/v5/ledger/utxo/transaction/UtxoSignedTransaction.kt
@@ -3,9 +3,8 @@ package net.corda.v5.ledger.utxo.transaction
 import net.corda.v5.application.crypto.DigitalSignatureAndMetadata
 import net.corda.v5.base.annotations.DoNotImplement
 import net.corda.v5.base.annotations.Suspendable
-import net.corda.v5.crypto.SecureHash
 import net.corda.v5.ledger.common.Party
-import net.corda.v5.ledger.common.transaction.TransactionMetadata
+import net.corda.v5.ledger.common.transaction.TransactionWithMetadata
 import net.corda.v5.ledger.utxo.Command
 import net.corda.v5.ledger.utxo.StateAndRef
 import net.corda.v5.ledger.utxo.StateRef
@@ -31,12 +30,7 @@ import java.security.PublicKey
  * Thus adding or removing a signature does not change it.
  */
 @DoNotImplement
-interface UtxoSignedTransaction {
-    /**
-     * @property id The ID of the transaction.
-     */
-    val id: SecureHash
-
+interface UtxoSignedTransaction: TransactionWithMetadata {
     /**
      * @property signatures The signatures that have been applied to the transaction.
      */
@@ -66,11 +60,6 @@ interface UtxoSignedTransaction {
      * @property timeWindow The validity time window for completing/notarising this transaction
      */
     val timeWindow: TimeWindow
-
-    /**
-     * @property metadata The metadata for this transaction
-     */
-    val metadata: TransactionMetadata
 
     /**
      * @property commands The list of commands for this transaction

--- a/ledger/ledger-utxo/src/main/kotlin/net/corda/v5/ledger/utxo/transaction/UtxoTransactionBuilder.kt
+++ b/ledger/ledger-utxo/src/main/kotlin/net/corda/v5/ledger/utxo/transaction/UtxoTransactionBuilder.kt
@@ -3,9 +3,9 @@ package net.corda.v5.ledger.utxo.transaction
 import net.corda.v5.base.annotations.CordaSerializable
 import net.corda.v5.base.annotations.DoNotImplement
 import net.corda.v5.base.annotations.Suspendable
-import net.corda.v5.base.exceptions.CordaRuntimeException
 import net.corda.v5.crypto.SecureHash
 import net.corda.v5.ledger.common.Party
+import net.corda.v5.ledger.common.transaction.TransactionNoAvailableKeysException
 import net.corda.v5.ledger.utxo.Attachment
 import net.corda.v5.ledger.utxo.Command
 import net.corda.v5.ledger.utxo.ContractState
@@ -191,7 +191,7 @@ interface UtxoTransactionBuilder {
      *
      * @throws IllegalStateException when called a second time on the same object to prevent
      *      unintentional duplicate transactions.
-     * @throws CordaRuntimeException if none of the required keys are available to sign the transaction.
+     * @throws TransactionNoAvailableKeysException if none of the required keys are available to sign the transaction.
      */
     @Suspendable
     fun toSignedTransaction(): UtxoSignedTransaction


### PR DESCRIPTION
Introduce Batch Signature creation and verification through `TransactionSignatureService` with extending 
`DigitalSignatureAndMetadata` with an optional `MerkleProof` field to handle single and batch signatures the same way.

* And a few other supporting changes:
  * Add `MerkleProof.calculateRoot()` to `MerkleProof`s to support Batch Signature verification. (To let us extract the root which got signed from the proof.) 
  * Remove the now obsolete `verifyNotarySignature()` from `TransactionSignatureService`.
  * Change `TransactionMetadata.getDigestSettings()` to return String values.
  * Introduce `TransactionWithMetadata` to let us handle properties required for Batch Signing consistently.

Runtime-os: https://github.com/corda/corda-runtime-os/pull/2958