### PR TITLE
CORE-9469 Use PublicKey instead of collection in uniqueness client service

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 624
+cordaApiRevision = 625
 
 # Main
 kotlinVersion = 1.7.21

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 621
+cordaApiRevision = 622
 
 # Main
 kotlinVersion = 1.7.21

--- a/ledger/ledger-utxo/src/main/kotlin/net/corda/v5/ledger/utxo/uniqueness/client/LedgerUniquenessCheckerClientService.kt
+++ b/ledger/ledger-utxo/src/main/kotlin/net/corda/v5/ledger/utxo/uniqueness/client/LedgerUniquenessCheckerClientService.kt
@@ -32,7 +32,8 @@ interface LedgerUniquenessCheckerClientService {
      *
      * @param timeWindowUpperBound The latest date/time until the transaction is considered valid.
      *
-     * @param notaryServiceKeys List of notary VNode keys that belong to the selected notary service.
+     * @param notaryServiceKey The key of the notary service, might be a [net.corda.v5.crypto.CompositeKey]
+     * if there are multiple notary VNodes registered.
      */
     @Suppress("LongParameterList")
     @Suspendable
@@ -43,7 +44,7 @@ interface LedgerUniquenessCheckerClientService {
         numOutputStates: Int,
         timeWindowLowerBound: Instant?,
         timeWindowUpperBound: Instant,
-        notaryServiceKeys: List<PublicKey>
+        notaryServiceKey: PublicKey
     ): LedgerUniquenessCheckResponse
 }
 
@@ -60,7 +61,7 @@ fun LedgerUniquenessCheckerClientService.requestUniquenessCheck(
     numOutputStates: Int,
     timeWindowLowerBound: Instant?,
     timeWindowUpperBound: Instant,
-    notaryServiceKeys: List<PublicKey>
+    notaryServiceKey: PublicKey
 ) = requestUniquenessCheck(
     txId,
     inputStates.map { it.toString() },
@@ -68,5 +69,5 @@ fun LedgerUniquenessCheckerClientService.requestUniquenessCheck(
     numOutputStates,
     timeWindowLowerBound,
     timeWindowUpperBound,
-    notaryServiceKeys
+    notaryServiceKey
 )


### PR DESCRIPTION
### Overview

Since the Crypto API we are calling from the implementation of the `LedgerUniquenessCheckerClientService` can handle composite `PublicKey` as an input we no longer need to extract the leaf keys into a collection. 

We can simply can use the type of `PublicKey` because `CompositeKey` is a subtype of `PublicKey` and the Crypto implementation will do the rest.

Test notes have been added to the runtime-os PR: https://github.com/corda/corda-runtime-os/pull/2960