### PR TITLE
NOTICK - Adjust schema documentation for registration status requests

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/rpc/request/RegistrationStatusRpcRequest.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/rpc/request/RegistrationStatusRpcRequest.avsc
@@ -6,7 +6,7 @@
   "fields": [
     {
       "name": "holdingIdentityId",
-      "doc": "ID of the holding identity whose registration status we want to check.",
+      "doc": "ID of the holding identity whose view of the registration status we want to check.",
       "type": "string"
     }
   ]

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/rpc/request/RegistrationStatusSpecificRpcRequest.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/rpc/request/RegistrationStatusSpecificRpcRequest.avsc
@@ -6,7 +6,7 @@
   "fields": [
     {
       "name": "holdingIdentityId",
-      "doc": "ID of the holding identity whose registration status we want to check.",
+      "doc": "ID of the holding identity whose view of the registration status we want to check.",
       "type": "string"
     },
     {


### PR DESCRIPTION
Slight adjustment to the docs for some Avro schemas used to check registration status to reflect the holding identity corresponds to the identity on behalf of which progress is checked (not the identity the registration corresponds to).