### PR TITLE
CORE-9732 - Deprecate `contextLogger` before removing it.

### DIFF
--- a/base/src/main/kotlin/net/corda/v5/base/util/KotlinUtils.kt
+++ b/base/src/main/kotlin/net/corda/v5/base/util/KotlinUtils.kt
@@ -28,12 +28,20 @@ infix fun Long.exactAdd(b: Long): Long = Math.addExact(this, b)
  *
  * `private val log = loggerFor<MyClass>()`
  */
+@Deprecated(
+    "Will be removed from api library",
+    ReplaceWith("LoggerFactory.getLogger(this::class.java)", "org.slf4j.LoggerFactory")
+)
 inline fun <reified T : Any> loggerFor(): Logger = LoggerFactory.getLogger(T::class.java)
 
 /** Returns the logger used for detailed logging. */
 fun detailedLogger(): Logger = LoggerFactory.getLogger("DetailedInfo")
 
 /** When called from a companion object, returns the logger for the enclosing class. */
+@Deprecated(
+    "Will be removed from api library",
+    ReplaceWith("LoggerFactory.getLogger(this::class.java.enclosingClass)", "org.slf4j.LoggerFactory")
+)
 fun Any.contextLogger(): Logger = LoggerFactory.getLogger(javaClass.enclosingClass)
 
 /** Log a TRACE level message produced by evaluating the given lambda, but only if TRACE logging is enabled. */
@@ -75,7 +83,6 @@ val Int.seconds: Duration get() = Duration.ofSeconds(toLong())
  * @see Duration.ofMillis
  */
 val Int.millis: Duration get() = Duration.ofMillis(toLong())
-
 
 @Suppress("UNCHECKED_CAST")
 fun <T, U : T> uncheckedCast(obj: T) = obj as U

--- a/data/config-schema/src/main/kotlin/net/corda/schema/configuration/provider/impl/SchemaProviderImpl.kt
+++ b/data/config-schema/src/main/kotlin/net/corda/schema/configuration/provider/impl/SchemaProviderImpl.kt
@@ -2,16 +2,16 @@ package net.corda.schema.configuration.provider.impl
 
 import net.corda.schema.configuration.provider.ConfigSchemaException
 import net.corda.schema.configuration.provider.SchemaProvider
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.v5.base.util.trace
 import net.corda.v5.base.versioning.Version
+import org.slf4j.LoggerFactory
 import java.io.InputStream
 
 internal class SchemaProviderImpl : SchemaProvider {
 
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java)
 
         private const val RESOURCE_ROOT = "net/corda/schema/configuration"
         private const val SCHEMA_EXTENSION = ".json"

--- a/data/membership-schema/src/main/kotlin/net/corda/schema/membership/provider/impl/MembershipSchemaProviderImpl.kt
+++ b/data/membership-schema/src/main/kotlin/net/corda/schema/membership/provider/impl/MembershipSchemaProviderImpl.kt
@@ -3,16 +3,16 @@ package net.corda.schema.membership.provider.impl
 import net.corda.schema.membership.MembershipSchema
 import net.corda.schema.membership.provider.MembershipSchemaException
 import net.corda.schema.membership.provider.MembershipSchemaProvider
-import net.corda.v5.base.util.contextLogger
 import net.corda.v5.base.util.debug
 import net.corda.v5.base.util.trace
 import net.corda.v5.base.versioning.Version
+import org.slf4j.LoggerFactory
 import java.io.InputStream
 
 internal class MembershipSchemaProviderImpl : MembershipSchemaProvider {
 
     companion object {
-        private val logger = contextLogger()
+        private val logger = LoggerFactory.getLogger(this::class.java)
 
         private const val RESOURCE_ROOT = "net/corda/schema/membership"
         private const val SCHEMA_EXTENSION = ".json"

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 626
+cordaApiRevision = 627
 
 # Main
 kotlinVersion = 1.7.21


### PR DESCRIPTION
Deprecate `contextLogger` as it shouldn't be in the API library.

runtime-os change: https://github.com/corda/corda-runtime-os/pull/2996