### PR TITLE
CORE-9451: fix config field name

### DIFF
--- a/crypto/src/main/kotlin/net/corda/v5/crypto/exceptions/CryptoException.kt
+++ b/crypto/src/main/kotlin/net/corda/v5/crypto/exceptions/CryptoException.kt
@@ -4,11 +4,11 @@ import net.corda.v5.base.annotations.CordaSerializable
 import net.corda.v5.base.exceptions.CordaRuntimeException
 
 /**
- * Base exception for all Crypto Library specific exception. Note that the library may throw common exceptions
+ * Base exception for all Crypto specific exceptions. Note that the library may throw common exceptions
  * such as [IllegalArgumentException], [IllegalStateException] and others as well. This base class is only
  * for the specific cases when a site throwing exception can provide some useful context about the operation.
  *
- * Note that the approach for the Crypto Library is to use the existing exception where appropriate and use
+ * Note that the approach for the Crypto Processor is to use the existing exception where appropriate and use
  * the specific Crypto Library exceptions only to convey additional context about the conditions which lead to
  * the exception.
  *

--- a/data/config-schema/src/main/kotlin/net/corda/schema/configuration/ConfigKeys.kt
+++ b/data/config-schema/src/main/kotlin/net/corda/schema/configuration/ConfigKeys.kt
@@ -6,7 +6,7 @@ object ConfigKeys {
     // publishing changes to one of the config sections defined by a key, and readers will use the keys to
     // determine which config section a given update is for.
     const val BOOT_CONFIG = "corda.boot"
-    const val CRYPTO_CONFIG = "corda.cryptoLibrary"
+    const val CRYPTO_CONFIG = "corda.crypto"
     const val DB_CONFIG = "corda.db"
     const val FLOW_CONFIG = "corda.flow"
     const val MESSAGING_CONFIG = "corda.messaging"

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/crypto/1.0/corda.crypto.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/crypto/1.0/corda.crypto.json
@@ -1,8 +1,8 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://corda.r3.com/net/corda/schema/configuration/cryptoLibrary/1.0/corda.cryptoLibrary.json",
-  "title": "Corda Crypto Library Configuration Schema",
-  "description": "Configuration schema for the crypto library subsection.",
+  "$id": "https://corda.r3.com/net/corda/schema/configuration/crypto/1.0/corda.crypto.json",
+  "title": "Corda Crypto Configuration Schema",
+  "description": "Configuration schema for the crypto subsection.",
   "type": "object",
   "properties": {
     "cryptoConnectionFactory": {

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 626
+cordaApiRevision = 627
 
 # Main
 kotlinVersion = 1.7.21


### PR DESCRIPTION
Align the two different places we describe  the configuration key for crypto. We need this change to allow the crypto configuration to be overridable via the boot configuration mechanism.