### PR TITLE
NOTICK: bump gradle ent versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,6 @@ plugins {
     id 'org.jetbrains.kotlin.plugin.allopen' apply false
     id 'org.jetbrains.kotlin.plugin.jpa' apply false
     id 'io.gitlab.arturbosch.detekt' apply false
-    id "org.gradle.test-retry" apply false
     id 'io.snyk.gradle.plugin.snykplugin'
     id 'org.ajoberstar.grgit' // used for GIT interaction (e.g. extract commit hash)
     id 'corda.root-publish'
@@ -117,8 +116,6 @@ subprojects {
             withSourcesJar()
         }
     }
-
-    apply plugin: "org.gradle.test-retry"
 
     pluginManager.withPlugin('org.jetbrains.kotlin.jvm') {
         apply plugin: 'io.gitlab.arturbosch.detekt'

--- a/gradle.properties
+++ b/gradle.properties
@@ -62,7 +62,6 @@ gradleEnterpriseVersion = 3.12.2
 gradleDataPlugin = 1.8.2
 org.gradle.caching = true
 gradleEnterpriseUrl = https://gradle.dev.r3.com
-gradleTestRetryPluginVersion = 1.5.1
 
 #snyk version
 snykVersion = 0.4

--- a/gradle.properties
+++ b/gradle.properties
@@ -58,11 +58,11 @@ bndVersion = 6.3.1
 osgiVersion = 8.0.0
 osgiScrAnnotationVersion = 1.5.0
 
-gradleEnterpriseVersion = 3.11.4
+gradleEnterpriseVersion = 3.12.2
 gradleDataPlugin = 1.8.2
 org.gradle.caching = true
 gradleEnterpriseUrl = https://gradle.dev.r3.com
-gradleTestRetryPluginVersion = 1.5.0
+gradleTestRetryPluginVersion = 1.5.1
 
 #snyk version
 snykVersion = 0.4

--- a/settings.gradle
+++ b/settings.gradle
@@ -38,7 +38,6 @@ pluginManagement {
         id 'org.jetbrains.dokka' version dokkaVersion
         id "com.github.davidmc24.gradle.plugin.avro-base" version avroGradlePluginVersion
         id 'com.github.ben-manes.versions' version dependencyCheckVersion
-        id "org.gradle.test-retry" version gradleTestRetryPluginVersion
         id "com.jfrog.artifactory" version artifactoryPluginVersion
         id 'io.snyk.gradle.plugin.snykplugin' version snykVersion
     }


### PR DESCRIPTION
Bump various plugins related to Gradle Ent - [release notes ](https://plugins.gradle.org/plugin/com.gradle.enterprise/3.12)

Note test retry plugin was removed due to the following from release notes (they are now bundled together) 

`- [NEW] Test Retry: Test retry functionality provided by the Test-Retry Gradle plugin is integrated
`