### PR TITLE
CORE-9164 Rename transactionHash to transactionId

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/ledger/utxo/StateRef.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/ledger/utxo/StateRef.avsc
@@ -7,7 +7,7 @@
     {
       "name": "transactionId",
       "type": "net.corda.data.crypto.SecureHash",
-      "doc": "The hash of the transaction in which the referenced state was created."
+      "doc": "The id of the transaction in which the referenced state was created."
     },
     {
       "name": "index",

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/ledger/utxo/StateRef.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/ledger/utxo/StateRef.avsc
@@ -5,7 +5,7 @@
   "doc": "StateRef",
   "fields": [
     {
-      "name": "transactionHash",
+      "name": "transactionId",
       "type": "net.corda.data.crypto.SecureHash",
       "doc": "The hash of the transaction in which the referenced state was created."
     },

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 637
+cordaApiRevision = 638
 
 # Main
 kotlinVersion = 1.8.10

--- a/ledger/ledger-utxo/src/main/kotlin/net/corda/v5/ledger/utxo/StateRef.kt
+++ b/ledger/ledger-utxo/src/main/kotlin/net/corda/v5/ledger/utxo/StateRef.kt
@@ -7,10 +7,10 @@ import net.corda.v5.crypto.SecureHash
  * Defines a reference to a [ContractState].
  *
  * @property index The index of the state in the transaction's outputs in which the referenced state was created.
- * @property transactionHash The hash of the transaction in which the referenced state was created.
+ * @property transactionId The hash of the transaction in which the referenced state was created.
  */
 @CordaSerializable
-data class StateRef(val transactionHash: SecureHash, val index: Int) {
+data class StateRef(val transactionId: SecureHash, val index: Int) {
 
     companion object {
 
@@ -48,6 +48,6 @@ data class StateRef(val transactionHash: SecureHash, val index: Int) {
      * @return Returns the [String] representation of the current object.
      */
     override fun toString(): String {
-        return "$transactionHash:$index"
+        return "$transactionId:$index"
     }
 }

--- a/ledger/ledger-utxo/src/main/kotlin/net/corda/v5/ledger/utxo/StateRef.kt
+++ b/ledger/ledger-utxo/src/main/kotlin/net/corda/v5/ledger/utxo/StateRef.kt
@@ -7,7 +7,7 @@ import net.corda.v5.crypto.SecureHash
  * Defines a reference to a [ContractState].
  *
  * @property index The index of the state in the transaction's outputs in which the referenced state was created.
- * @property transactionId The hash of the transaction in which the referenced state was created.
+ * @property transactionId The id of the transaction in which the referenced state was created.
  */
 @CordaSerializable
 data class StateRef(val transactionId: SecureHash, val index: Int) {
@@ -19,7 +19,7 @@ data class StateRef(val transactionId: SecureHash, val index: Int) {
          *
          * @param value The value to parse into a [StateRef] instance.
          * @return Returns a new [StateRef] instance.
-         * @throws IllegalArgumentException if either the transaction hash, or index components cannot be parsed.
+         * @throws IllegalArgumentException if either the transaction id, or index components cannot be parsed.
          */
         @JvmStatic
         fun parse(value: String): StateRef {
@@ -35,7 +35,7 @@ data class StateRef(val transactionId: SecureHash, val index: Int) {
                 )
             } catch (ex: IllegalArgumentException) {
                 throw IllegalArgumentException(
-                    "Failed to parse a StateRef from the specified value. The transaction hash is malformed: $value.",
+                    "Failed to parse a StateRef from the specified value. The transaction id is malformed: $value.",
                     ex
                 )
             }

--- a/ledger/ledger-utxo/src/test/java/net/corda/v5/ledger/utxo/StateRefJavaApiTests.java
+++ b/ledger/ledger-utxo/src/test/java/net/corda/v5/ledger/utxo/StateRefJavaApiTests.java
@@ -9,7 +9,7 @@ public final class StateRefJavaApiTests extends AbstractMockTestHarness {
     @Test
     public void parseShouldReturnTheExpectedValue() {
         StateRef value = StateRef.parse(hash + ":123");
-        Assertions.assertEquals(hash, value.getTransactionHash());
+        Assertions.assertEquals(hash, value.getTransactionId());
         Assertions.assertEquals(123, value.getIndex());
     }
 
@@ -47,7 +47,7 @@ public final class StateRefJavaApiTests extends AbstractMockTestHarness {
 
     @Test
     public void getTransactionShouldReturnTheExpectedValue() {
-        SecureHash value = stateRef.getTransactionHash();
+        SecureHash value = stateRef.getTransactionId();
         Assertions.assertEquals(hash, value);
     }
 }

--- a/ledger/ledger-utxo/src/test/java/net/corda/v5/ledger/utxo/StateRefJavaApiTests.java
+++ b/ledger/ledger-utxo/src/test/java/net/corda/v5/ledger/utxo/StateRefJavaApiTests.java
@@ -21,7 +21,7 @@ public final class StateRefJavaApiTests extends AbstractMockTestHarness {
         );
 
         Assertions.assertEquals(
-                "Failed to parse a StateRef from the specified value. The transaction hash is malformed: INVALID_TRANSACTION_HASH:123.",
+                "Failed to parse a StateRef from the specified value. The transaction id is malformed: INVALID_TRANSACTION_HASH:123.",
                 exception.getMessage()
         );
     }

--- a/ledger/ledger-utxo/src/test/java/net/corda/v5/ledger/utxo/transaction/UtxoFilteredTransactionJavaApiTest.java
+++ b/ledger/ledger-utxo/src/test/java/net/corda/v5/ledger/utxo/transaction/UtxoFilteredTransactionJavaApiTest.java
@@ -59,6 +59,6 @@ public class UtxoFilteredTransactionJavaApiTest {
                 = (UtxoFilteredData.Audit<StateRef>) txInputs;
         Assertions.assertThat(auditInputs.getSize()).isEqualTo(2);
         Assertions.assertThat(auditInputs.getValues()).hasSize(1);
-        Assertions.assertThat(auditInputs.getValues().get(1).getTransactionHash()).isEqualTo(hash);
+        Assertions.assertThat(auditInputs.getValues().get(1).getTransactionId()).isEqualTo(hash);
     }
 }


### PR DESCRIPTION
Rename the field transactionHash on StateRef to transactionId as it is the transaction ID the stateRef is dealing with, the fact that it's a hash is an implementation detail.

runtime PR: https://github.com/corda/corda-runtime-os/pull/3075