### PR TITLE
CORE-9578: Create topic for Worker info (version heartbeats)

### DIFF
--- a/data/topic-schema/src/main/kotlin/net/corda/schema/Schemas.kt
+++ b/data/topic-schema/src/main/kotlin/net/corda/schema/Schemas.kt
@@ -207,4 +207,13 @@ class Schemas {
             const val CPK_FILE_TOPIC = "cpk.file"
         }
     }
+
+    /**
+     * Cluster local schema
+     */
+    class Cluster {
+        companion object {
+            const val CLUSTER_WORKER_INFO_TOPIC = "cluster.worker.info"
+        }
+    }
 }

--- a/data/topic-schema/src/main/resources/net/corda/schema/Cluster.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/Cluster.yaml
@@ -1,0 +1,18 @@
+topics:
+  ClusterWorkerInfo:
+    name: cluster.worker.info
+    consumers:
+      - crypto
+      - db
+      - flow
+      - membership
+      - link-manager
+      - rpc
+    producers:
+      - crypto
+      - db
+      - flow
+      - membership
+      - link-manager
+      - rpc
+    config:


### PR DESCRIPTION
Create the topic for workers to send heartbeat information.  To start, this will be version information, but I'm leaving the topic more generic in case we find other use for these messages.