### PR TITLE
CORE-9775 Automatic Token Locking

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 732
+cordaApiRevision = 730
 
 # Main
 kotlinVersion = 1.8.10

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 729
+cordaApiRevision = 732
 
 # Main
 kotlinVersion = 1.8.10

--- a/ledger/ledger-utxo/src/main/java/net/corda/v5/ledger/utxo/FinalizationResult.java
+++ b/ledger/ledger-utxo/src/main/java/net/corda/v5/ledger/utxo/FinalizationResult.java
@@ -1,0 +1,20 @@
+package net.corda.v5.ledger.utxo;
+
+import net.corda.v5.base.annotations.DoNotImplement;
+import net.corda.v5.ledger.utxo.transaction.UtxoSignedTransaction;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Defines the result of transaction finalization
+ *
+ */
+@DoNotImplement
+public interface FinalizationResult {
+    /**
+     * Gets the finalized transaction.
+     *
+     * @return An instance of {@link UtxoSignedTransaction}.
+     */
+    @NotNull
+    UtxoSignedTransaction getTransaction();
+}

--- a/ledger/ledger-utxo/src/main/java/net/corda/v5/ledger/utxo/UtxoLedgerService.java
+++ b/ledger/ledger-utxo/src/main/java/net/corda/v5/ledger/utxo/UtxoLedgerService.java
@@ -98,13 +98,14 @@ public interface UtxoLedgerService {
      * Verifies, signs, collects signatures, records and broadcasts a {@link UtxoSignedTransaction} to participants and observers.
      *
      * @param transaction The {@link UtxoSignedTransaction} to verify, finalize and record.
-     * @param sessions The {@link FlowSession} instances of the participants or observers of the transaction.
-     * @return Returns the fully signed {@link UtxoSignedTransaction} that was recorded.
+     * @param sessions    The {@link FlowSession} instances of the participants or observers of the transaction.
+     * @return Returns the {@link FinalizationResult} containing a fully signed {@link UtxoSignedTransaction} that was
+     * recorded.
      * @throws ContractVerificationException if the transaction fails contract verification.
      */
     @NotNull
     @Suspendable
-    UtxoSignedTransaction finalize(
+    FinalizationResult finalize(
             @NotNull UtxoSignedTransaction transaction,
             @NotNull List<FlowSession> sessions
     );
@@ -114,14 +115,15 @@ public interface UtxoLedgerService {
      * <p>
      * This method should be called in response to {@link #finalize(UtxoSignedTransaction, List)}.
      *
-     * @param session The {@link FlowSession} of the counter-party finalizing the {@link UtxoSignedTransaction}.
+     * @param session   The {@link FlowSession} of the counter-party finalizing the {@link UtxoSignedTransaction}.
      * @param validator Validates the received {@link UtxoSignedTransaction}.
-     * @return Returns the fully signed {@link UtxoSignedTransaction} that was received and recorded.
+     * @return Returns the {@link FinalizationResult} containing a fully signed {@link UtxoSignedTransaction} that was
+     * received and recorded.
      * @throws ContractVerificationException if the transaction failed contract verification.
      */
     @NotNull
     @Suspendable
-    UtxoSignedTransaction receiveFinality(
+    FinalizationResult receiveFinality(
             @NotNull FlowSession session,
             @NotNull UtxoTransactionValidator validator
     );


### PR DESCRIPTION
This PR changes:
 - The return type of the UTXO finalize API to potentially return a token claim as part of the response.
 - Allows the flow to specify the token claim behavior of a finalized transaction.
The purpose of this change is to allow automatic claiming of tokens output from a finalized transaction. This can be used in cases where the finalizing flow intends to immediately spend the output states from a transaction it has finalized. In this case there is a potential race condition with another flow claiming and spending the states before the original flow can. automatically locking or claiming the states during finalization prevents this. 

