### PR TITLE
CORE-9550 Add full public key id for signing keys in crypto worker

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/SecureHashes.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/SecureHashes.avsc
@@ -1,7 +1,7 @@
 {
   "type": "record",
   "name": "SecureHashes",
-  "doc": "List of short hashes. For short hash form see {@link net.corda.data.crypto.SecureHash}",
+  "doc": "List of secure hashes. For secure hash form see {@link net.corda.data.crypto.SecureHash}",
   "namespace": "net.corda.data.crypto",
   "fields": [
     {

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/SecureHashes.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/SecureHashes.avsc
@@ -1,0 +1,15 @@
+{
+  "type": "record",
+  "name": "SecureHashes",
+  "doc": "List of short hashes. For short hash form see {@link net.corda.data.crypto.SecureHash}"
+  "namespace": "net.corda.data.crypto",
+  "fields": [
+    {
+      "name": "hashes",
+      "type": {
+        "type": "array",
+        "items": "SecureHash"
+      }
+    }
+  ]
+}

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/SecureHashes.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/SecureHashes.avsc
@@ -1,7 +1,7 @@
 {
   "type": "record",
   "name": "SecureHashes",
-  "doc": "List of short hashes. For short hash form see {@link net.corda.data.crypto.SecureHash}"
+  "doc": "List of short hashes. For short hash form see {@link net.corda.data.crypto.SecureHash}",
   "namespace": "net.corda.data.crypto",
   "fields": [
     {

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/ShortHashes.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/ShortHashes.avsc
@@ -1,0 +1,15 @@
+{
+  "type": "record",
+  "name": "ShortHashes",
+  "doc": "List of short hashes. A short hash is the first 12 characters of a hex string",
+  "namespace": "net.corda.data.crypto",
+  "fields": [
+    {
+      "name": "hashes",
+      "type": {
+        "type": "array",
+        "items": "string"
+        }
+    }
+  ]
+}

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/ShortHashes.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/ShortHashes.avsc
@@ -1,7 +1,7 @@
 {
   "type": "record",
   "name": "ShortHashes",
-  "doc": "List of short hashes. A short hash is the first 12 characters of the hex string form of the hash",
+  "doc": "List of short hashes. A short hash is the first 12 characters of the hex string form of the hash. Short hashes should be used with care as it could lead to collisions",
   "namespace": "net.corda.data.crypto",
   "fields": [
     {

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/ShortHashes.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/ShortHashes.avsc
@@ -1,7 +1,7 @@
 {
   "type": "record",
   "name": "ShortHashes",
-  "doc": "List of short hashes. A short hash is the first 12 characters of the hex string form of the hash. Short hashes should be used with care as it could lead to collisions",
+  "doc": "List of short hashes. A short hash is the first 12 characters of the hex string form of the hash. Short hashes should be used with care as it could lead to collisions.",
   "namespace": "net.corda.data.crypto",
   "fields": [
     {

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/ShortHashes.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/ShortHashes.avsc
@@ -1,7 +1,7 @@
 {
   "type": "record",
   "name": "ShortHashes",
-  "doc": "List of short hashes. A short hash is the first 12 characters of a hex string",
+  "doc": "List of short hashes. A short hash is the first 12 characters of the hex string form of the hash",
   "namespace": "net.corda.data.crypto",
   "fields": [
     {

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/ops/flow/queries/ByIdsFlowQuery.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/ops/flow/queries/ByIdsFlowQuery.avsc
@@ -2,14 +2,14 @@
   "type": "record",
   "name": "ByIdsFlowQuery",
   "namespace": "net.corda.data.crypto.wire.ops.flow.queries",
-  "doc": "Request to lookup for keys by their ids",
+  "doc": "Request to lookup for keys by their ids. Ids can be either short or full key ids. The maximum number of items is 20",
   "fields": [
     {
       "name": "keyIds",
-      "type": {
-        "type": "array",
-        "items": "string"
-      },
+      "type": [
+        "net.corda.data.crypto.ShortHashes",
+        "net.corda.data.crypto.SecureHashes"
+        ],
       "doc": "List of key ids"
     }
   ]

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/ops/flow/queries/ByIdsFlowQuery.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/ops/flow/queries/ByIdsFlowQuery.avsc
@@ -2,14 +2,11 @@
   "type": "record",
   "name": "ByIdsFlowQuery",
   "namespace": "net.corda.data.crypto.wire.ops.flow.queries",
-  "doc": "Request to lookup for keys by their ids. Ids can be either short or full key ids. The maximum number of items is 20",
+  "doc": "Request to lookup for keys by their ids (full ids). The maximum number of items is 20",
   "fields": [
     {
       "name": "keyIds",
-      "type": [
-        "net.corda.data.crypto.ShortHashes",
-        "net.corda.data.crypto.SecureHashes"
-      ],
+      "type": "net.corda.data.crypto.SecureHashes",
       "doc": "List of key ids"
     }
   ]

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/ops/flow/queries/ByIdsFlowQuery.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/ops/flow/queries/ByIdsFlowQuery.avsc
@@ -2,12 +2,12 @@
   "type": "record",
   "name": "ByIdsFlowQuery",
   "namespace": "net.corda.data.crypto.wire.ops.flow.queries",
-  "doc": "Request to lookup for keys by their ids (full ids). The maximum number of items is 20",
+  "doc": "Request to lookup for keys by their full key ids. The maximum number of items is 20",
   "fields": [
     {
-      "name": "keyIds",
+      "name": "fullKeyIds",
       "type": "net.corda.data.crypto.SecureHashes",
-      "doc": "List of key ids"
+      "doc": "List of full key ids"
     }
   ]
 }

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/ops/flow/queries/ByIdsFlowQuery.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/ops/flow/queries/ByIdsFlowQuery.avsc
@@ -9,7 +9,7 @@
       "type": [
         "net.corda.data.crypto.ShortHashes",
         "net.corda.data.crypto.SecureHashes"
-        ],
+      ],
       "doc": "List of key ids"
     }
   ]

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/ops/rpc/queries/ByIdsRpcQuery.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/ops/rpc/queries/ByIdsRpcQuery.avsc
@@ -5,12 +5,12 @@
   "doc": "Request to lookup for keys by their ids, the maximum number of items is 20.",
   "fields": [
     {
-      "name": "keys",
+      "name": "keyIds",
       "type": {
         "type": "array",
         "items": "string"
       },
-      "doc": "List of key ids."
+      "doc": "List of key ids"
     }
   ]
 }

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/ops/rpc/queries/ByIdsRpcQuery.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/ops/rpc/queries/ByIdsRpcQuery.avsc
@@ -2,14 +2,14 @@
   "type": "record",
   "name": "ByIdsRpcQuery",
   "namespace": "net.corda.data.crypto.wire.ops.rpc.queries",
-  "doc": "Request to lookup for keys by their ids, the maximum number of items is 20.",
+  "doc": "Request to lookup for keys by their ids. Ids can be either short or full key ids. The maximum number of items is 20",
   "fields": [
     {
       "name": "keyIds",
-      "type": {
-        "type": "array",
-        "items": "string"
-      },
+      "type": [
+        "net.corda.data.crypto.ShortHashes",
+        "net.corda.data.crypto.SecureHashes"
+        ],
       "doc": "List of key ids"
     }
   ]

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/ops/rpc/queries/ByIdsRpcQuery.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/ops/rpc/queries/ByIdsRpcQuery.avsc
@@ -9,7 +9,7 @@
       "type": [
         "net.corda.data.crypto.ShortHashes",
         "net.corda.data.crypto.SecureHashes"
-        ],
+      ],
       "doc": "List of key ids"
     }
   ]

--- a/data/db-schema/src/main/resources/net/corda/db/schema/vnode-crypto/migration/vnode-crypto-creation-v1.0.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/vnode-crypto/migration/vnode-crypto-creation-v1.0.xml
@@ -58,9 +58,6 @@
             <column name="tenant_id"/>
             <column name="full_key_id"/>
         </createIndex>
-        <addUniqueConstraint columnNames="tenant_id, full_key_id"
-                             tableName="crypto_signing_key"
-                             constraintName="crypto_signing_key_full_key_uc"/>
         <createIndex indexName="crypto_signing_key_tenant_idx"
                      tableName="crypto_signing_key">
             <column name="tenant_id"/>

--- a/data/db-schema/src/main/resources/net/corda/db/schema/vnode-crypto/migration/vnode-crypto-creation-v1.0.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/vnode-crypto/migration/vnode-crypto-creation-v1.0.xml
@@ -58,6 +58,9 @@
             <column name="tenant_id"/>
             <column name="short_key_id"/>
         </createIndex>
+        <addUniqueConstraint columnNames="tenant_id, short_key_id"
+                             tableName="crypto_signing_key"
+                             constraintName="crypto_signing_key_short_key_uc"/>
         <createIndex indexName="crypto_signing_key_tenant_idx"
                      tableName="crypto_signing_key">
             <column name="tenant_id"/>

--- a/data/db-schema/src/main/resources/net/corda/db/schema/vnode-crypto/migration/vnode-crypto-creation-v1.0.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/vnode-crypto/migration/vnode-crypto-creation-v1.0.xml
@@ -50,6 +50,7 @@
                 <constraints nullable="false"/>
             </column>
         </createTable>
+        <!-- TODO Change PK to be tenant_id + full_key_id -->
         <addPrimaryKey constraintName="crypto_signing_key_pk"
                        tableName="crypto_signing_key"
                        columnNames="tenant_id, key_id"/>

--- a/data/db-schema/src/main/resources/net/corda/db/schema/vnode-crypto/migration/vnode-crypto-creation-v1.0.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/vnode-crypto/migration/vnode-crypto-creation-v1.0.xml
@@ -7,10 +7,10 @@
             <column name="tenant_id" type="VARCHAR(12)">
                 <constraints nullable="false"/>
             </column>
-            <column name="key_id" type="VARCHAR(255)">
+            <column name="full_key_id" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="short_key_id" type="CHAR(12)">
+            <column name="key_id" type="CHAR(12)">
                 <constraints nullable="false"/>
             </column>
             <column name="timestamp" type="TIMESTAMP">
@@ -52,11 +52,11 @@
         </createTable>
         <addPrimaryKey constraintName="crypto_signing_key_pk"
                        tableName="crypto_signing_key"
-                       columnNames="tenant_id, key_id"/>
+                       columnNames="tenant_id, full_key_id"/>
         <createIndex indexName="crypto_signing_key_short_key_idx"
                      tableName="crypto_signing_key">
             <column name="tenant_id"/>
-            <column name="short_key_id"/>
+            <column name="key_id"/>
         </createIndex>
         <addUniqueConstraint columnNames="tenant_id, short_key_id"
                              tableName="crypto_signing_key"

--- a/data/db-schema/src/main/resources/net/corda/db/schema/vnode-crypto/migration/vnode-crypto-creation-v1.0.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/vnode-crypto/migration/vnode-crypto-creation-v1.0.xml
@@ -55,6 +55,7 @@
                        columnNames="tenant_id, key_id"/>
         <createIndex indexName="crypto_signing_key_full_key_idx"
                      tableName="crypto_signing_key">
+            <column name="tenant_id"/>
             <column name="full_key_id"/>
         </createIndex>
         <createIndex indexName="crypto_signing_key_tenant_idx"

--- a/data/db-schema/src/main/resources/net/corda/db/schema/vnode-crypto/migration/vnode-crypto-creation-v1.0.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/vnode-crypto/migration/vnode-crypto-creation-v1.0.xml
@@ -7,10 +7,10 @@
             <column name="tenant_id" type="VARCHAR(12)">
                 <constraints nullable="false"/>
             </column>
-            <column name="key_id" type="CHAR(12)">
+            <column name="full_key_id" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="full_key_id" type="VARCHAR(255)">
+            <column name="key_id" type="CHAR(12)">
                 <constraints nullable="false"/>
             </column>
             <column name="timestamp" type="TIMESTAMP">
@@ -50,14 +50,13 @@
                 <constraints nullable="false"/>
             </column>
         </createTable>
-        <!-- TODO Change PK to be tenant_id + full_key_id -->
         <addPrimaryKey constraintName="crypto_signing_key_pk"
                        tableName="crypto_signing_key"
-                       columnNames="tenant_id, key_id"/>
-        <createIndex indexName="crypto_signing_key_full_key_idx"
+                       columnNames="tenant_id, full_key_id"/>
+        <createIndex indexName="crypto_signing_key_short_key_idx"
                      tableName="crypto_signing_key">
             <column name="tenant_id"/>
-            <column name="full_key_id"/>
+            <column name="key_id"/>
         </createIndex>
         <createIndex indexName="crypto_signing_key_tenant_idx"
                      tableName="crypto_signing_key">

--- a/data/db-schema/src/main/resources/net/corda/db/schema/vnode-crypto/migration/vnode-crypto-creation-v1.0.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/vnode-crypto/migration/vnode-crypto-creation-v1.0.xml
@@ -7,10 +7,10 @@
             <column name="tenant_id" type="VARCHAR(12)">
                 <constraints nullable="false"/>
             </column>
-            <column name="full_key_id" type="VARCHAR(255)">
+            <column name="key_id" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="key_id" type="CHAR(12)">
+            <column name="short_key_id" type="CHAR(12)">
                 <constraints nullable="false"/>
             </column>
             <column name="timestamp" type="TIMESTAMP">
@@ -52,11 +52,11 @@
         </createTable>
         <addPrimaryKey constraintName="crypto_signing_key_pk"
                        tableName="crypto_signing_key"
-                       columnNames="tenant_id, full_key_id"/>
+                       columnNames="tenant_id, key_id"/>
         <createIndex indexName="crypto_signing_key_short_key_idx"
                      tableName="crypto_signing_key">
             <column name="tenant_id"/>
-            <column name="key_id"/>
+            <column name="short_key_id"/>
         </createIndex>
         <createIndex indexName="crypto_signing_key_tenant_idx"
                      tableName="crypto_signing_key">

--- a/data/db-schema/src/main/resources/net/corda/db/schema/vnode-crypto/migration/vnode-crypto-creation-v1.0.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/vnode-crypto/migration/vnode-crypto-creation-v1.0.xml
@@ -7,10 +7,10 @@
             <column name="tenant_id" type="VARCHAR(12)">
                 <constraints nullable="false"/>
             </column>
-            <column name="full_key_id" type="VARCHAR(255)">
+            <column name="key_id" type="CHAR(12)">
                 <constraints nullable="false"/>
             </column>
-            <column name="key_id" type="CHAR(12)">
+            <column name="full_key_id" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
             <column name="timestamp" type="TIMESTAMP">
@@ -52,15 +52,15 @@
         </createTable>
         <addPrimaryKey constraintName="crypto_signing_key_pk"
                        tableName="crypto_signing_key"
-                       columnNames="tenant_id, full_key_id"/>
-        <createIndex indexName="crypto_signing_key_short_key_idx"
+                       columnNames="tenant_id, key_id"/>
+        <createIndex indexName="crypto_signing_key_full_key_idx"
                      tableName="crypto_signing_key">
             <column name="tenant_id"/>
-            <column name="key_id"/>
+            <column name="full_key_id"/>
         </createIndex>
-        <addUniqueConstraint columnNames="tenant_id, short_key_id"
+        <addUniqueConstraint columnNames="tenant_id, full_key_id"
                              tableName="crypto_signing_key"
-                             constraintName="crypto_signing_key_short_key_uc"/>
+                             constraintName="crypto_signing_key_full_key_uc"/>
         <createIndex indexName="crypto_signing_key_tenant_idx"
                      tableName="crypto_signing_key">
             <column name="tenant_id"/>

--- a/data/db-schema/src/main/resources/net/corda/db/schema/vnode-crypto/migration/vnode-crypto-creation-v1.0.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/vnode-crypto/migration/vnode-crypto-creation-v1.0.xml
@@ -10,6 +10,9 @@
             <column name="key_id" type="CHAR(12)">
                 <constraints nullable="false"/>
             </column>
+            <column name="full_key_id" type="VARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
             <column name="timestamp" type="TIMESTAMP">
                 <constraints nullable="false"/>
             </column>
@@ -50,6 +53,10 @@
         <addPrimaryKey constraintName="crypto_signing_key_pk"
                        tableName="crypto_signing_key"
                        columnNames="tenant_id, key_id"/>
+        <createIndex indexName="crypto_signing_key_full_key_idx"
+                     tableName="crypto_signing_key">
+            <column name="full_key_id"/>
+        </createIndex>
         <createIndex indexName="crypto_signing_key_tenant_idx"
                      tableName="crypto_signing_key">
             <column name="tenant_id"/>

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 649
+cordaApiRevision = 650
 
 # Main
 kotlinVersion = 1.8.10


### PR DESCRIPTION
The reason for this change is potential clashes in short key ids during keys look up, which could lead in returning a key which is not owned by the caller.

- adds full key id in `crypto_signing_key` DB table.
- introduces avro types for short and full key ids (`ShortHashes` for short key ids and `SecureHashes` for full key ids)

runtime-os PR: [#3091](https://github.com/corda/corda-runtime-os/pull/3091)