### PR TITLE
CORE-10198: Upgrade to Kotlin 1.8.10.

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -7,7 +7,7 @@ plugins {
 description 'Corda Application'
 
 dependencies {
-    api 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    api 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     api 'javax.persistence:javax.persistence-api'
 
     api platform(project(':corda-api'))

--- a/base/build.gradle
+++ b/base/build.gradle
@@ -8,7 +8,7 @@ description 'Corda Base'
 
 dependencies {
     implementation platform(project(':corda-api'))
-    api 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    api 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     // Concluded this is the one acceptable dependency in addition to kotlin.
     // We are also returning `Logger` from extensions methods like `Any.contextLogger()` hance "api"
     api 'org.slf4j:slf4j-api'

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,6 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import static org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
+import static org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_1_8
 import static org.gradle.api.JavaVersion.VERSION_11
 import static org.gradle.jvm.toolchain.JavaLanguageVersion.of
 
@@ -58,8 +60,8 @@ def revision = {
 void configureKotlinForOSGi(Configuration configuration) {
     configuration.resolutionStrategy {
         dependencySubstitution {
-            substitute module('org.jetbrains.kotlin:kotlin-stdlib-jdk8') with module("net.corda.kotlin:kotlin-stdlib-jdk8-osgi:$kotlinVersion")
-            substitute module('org.jetbrains.kotlin:kotlin-stdlib-jdk7') with module("net.corda.kotlin:kotlin-stdlib-jdk7-osgi:$kotlinVersion")
+            substitute module('org.jetbrains.kotlin:kotlin-stdlib-jdk8') with module("org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlinVersion")
+            substitute module('org.jetbrains.kotlin:kotlin-stdlib-jdk7') with module("org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlinVersion")
             substitute module('org.jetbrains.kotlin:kotlin-stdlib-common') with module("org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlinVersion")
             substitute module('org.jetbrains.kotlin:kotlin-stdlib') with module("org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlinVersion")
             substitute module('org.jetbrains.kotlin:kotlin-reflect') with module("org.jetbrains.kotlin:kotlin-osgi-bundle:$kotlinVersion")
@@ -160,16 +162,16 @@ subprojects {
         }
 
         tasks.withType(KotlinCompile).configureEach {
-            kotlinOptions {
+            compilerOptions {
                 allWarningsAsErrors = true
-                languageVersion = '1.7'
-                apiVersion = '1.7'
+                languageVersion = KOTLIN_1_8
+                apiVersion = KOTLIN_1_8
                 verbose = true
-                jvmTarget = javaVersion
-                freeCompilerArgs += [
-                    "-Xjvm-default=all",
-                    "-java-parameters"
-                ]
+                jvmTarget = JVM_11
+                javaParameters = true   // Useful for reflection.
+                freeCompilerArgs.addAll([
+                    "-Xjvm-default=all"
+                ])
             }
         }
 

--- a/corda-api/build.gradle
+++ b/corda-api/build.gradle
@@ -31,14 +31,14 @@ dependencies {
                 require javaxPersistenceApiVersion
             }
         }
-        api('net.corda.kotlin:kotlin-stdlib-jdk8-osgi') {
+        api('org.jetbrains.kotlin:kotlin-osgi-bundle') {
             version {
                 require kotlinVersion
             }
         }
-        api('net.corda.kotlin:kotlin-stdlib-jdk7-osgi') {
+        api('org.jetbrains:annotations') {
             version {
-                require kotlinVersion
+                require jetbrainsAnnotationsVersion
             }
         }
         api('org.osgi:osgi.annotation') {

--- a/cordapp-configuration/src/main/java/net/corda/cordapp/ConfigurationPlugin.java
+++ b/cordapp-configuration/src/main/java/net/corda/cordapp/ConfigurationPlugin.java
@@ -17,6 +17,9 @@ import java.util.Properties;
 import static java.util.Arrays.asList;
 import static java.util.Collections.unmodifiableList;
 
+/**
+ * Gradle plugin to ensure that the CPK and CPB Gradle plugins are correctly configured.
+ */
 @SuppressWarnings("unused")
 public final class ConfigurationPlugin implements Plugin<Project> {
     private static final String MINIMUM_PLUGIN_VERSION_PROPERTY = "Minimum-Corda-Plugins-Version";

--- a/crypto-extensions/build.gradle
+++ b/crypto-extensions/build.gradle
@@ -7,7 +7,7 @@ plugins {
 description 'Corda Crypto Extensions API'
 
 dependencies {
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
     compileOnly 'org.osgi:osgi.annotation'
 

--- a/crypto/build.gradle
+++ b/crypto/build.gradle
@@ -7,7 +7,7 @@ plugins {
 description 'Corda Crypto'
 
 dependencies {
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation 'org.slf4j:slf4j-api'
 
     compileOnly 'org.osgi:osgi.annotation'

--- a/data/avro-schema/build.gradle
+++ b/data/avro-schema/build.gradle
@@ -15,7 +15,7 @@ dependencies {
 
     implementation platform(project(':corda-api'))
     implementation project(":base")
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
     compileOnly 'org.osgi:osgi.annotation'
     compileOnly 'org.osgi:osgi.core'

--- a/data/config-schema/build.gradle
+++ b/data/config-schema/build.gradle
@@ -7,7 +7,7 @@ plugins {
 description 'Schema Definition for Configuration'
 
 dependencies {
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation platform(project(':corda-api'))
     implementation project(":base")
 

--- a/data/db-schema/build.gradle
+++ b/data/db-schema/build.gradle
@@ -7,7 +7,7 @@ plugins {
 description 'Definition of Database Schema'
 
 dependencies {
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation platform(project(':corda-api'))
 
     compileOnly 'org.osgi:osgi.annotation'

--- a/data/membership-schema/build.gradle
+++ b/data/membership-schema/build.gradle
@@ -7,7 +7,7 @@ plugins {
 description 'Schema definitions for membership operations'
 
 dependencies {
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation platform(project(':corda-api'))
     implementation project(":base")
 

--- a/data/rbac-schema/build.gradle
+++ b/data/rbac-schema/build.gradle
@@ -7,7 +7,7 @@ plugins {
 description 'Schema Definition for Role Based Access Control'
 
 dependencies {
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation platform(project(':corda-api'))
     implementation project(":base")
 

--- a/data/topic-schema/build.gradle
+++ b/data/topic-schema/build.gradle
@@ -7,7 +7,7 @@ plugins {
 description 'Definition of Topics'
 
 dependencies {
-    implementation 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation platform(project(':corda-api'))
 
     testImplementation "org.assertj:assertj-core:$assertjVersion"

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,10 +7,10 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 636
+cordaApiRevision = 637
 
 # Main
-kotlinVersion = 1.7.21
+kotlinVersion = 1.8.10
 kotlin.stdlib.default.dependency = false
 
 # These are the same annotations that Kotlin uses.

--- a/ledger/ledger-common/build.gradle
+++ b/ledger/ledger-common/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     compileOnly 'org.osgi:osgi.annotation'
 
     api platform(project(':corda-api'))
-    api 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    api 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     api project(":application")
 
     testImplementation project(':crypto')

--- a/ledger/notary-plugin/build.gradle
+++ b/ledger/notary-plugin/build.gradle
@@ -9,7 +9,7 @@ description 'Corda Notary Plugin API and Core'
 dependencies {
     api platform(project(':corda-api'))
 
-    api 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    api 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     api 'javax.persistence:javax.persistence-api'
     api 'org.slf4j:slf4j-api'
 

--- a/membership/build.gradle
+++ b/membership/build.gradle
@@ -8,7 +8,7 @@ description 'Corda Membership'
 
 dependencies {
     api platform(project(':corda-api'))
-    api 'net.corda.kotlin:kotlin-stdlib-jdk8-osgi'
+    api 'org.jetbrains.kotlin:kotlin-osgi-bundle'
 
     compileOnly 'org.osgi:osgi.annotation'
 


### PR DESCRIPTION
Upgrade Kotlin 1.7.21 -> 1.8.10.

Kotlin 1.8 supports Java 8+, and so `kotlin-osgi-bundle` has absorbed the contents of `kotlin-stdlib-jdk7` and `kotlin-stdlib-jdk8`. This allows us to drop our "home-grown" Kotlin OSGi bundles, although we now need to add back the transitive depedency on `org.jetbrains:annotations` that they provided us.

The Kotlin Gradle plugin has also decided to change how the `KotlinCompile` task is configured, just for gits and shiggles.