### PR TITLE
CORE-10198: Fix compileAll task for Kotlin 1.8.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -284,7 +284,7 @@ subprojects {
         description = "Compiles all the Kotlin and Java classes, including all of the test classes."
         group = "verification"
 
-        task.dependsOn tasks.withType(AbstractCompile)
+        task.dependsOn tasks.withType(AbstractCompile), tasks.withType(KotlinCompile)
     }
 
     tasks.register('allDependencyInsight', DependencyInsightReportTask)


### PR DESCRIPTION
As of Kotlin 1.8, the `KotlinCompile` task no longer extends `AbstractCompile`.