### PR TITLE
CORE-10346 Updating kafka topic name from RPC -> REST

### DIFF
--- a/data/topic-schema/src/main/kotlin/net/corda/schema/Schemas.kt
+++ b/data/topic-schema/src/main/kotlin/net/corda/schema/Schemas.kt
@@ -162,16 +162,16 @@ class Schemas {
     }
 
     /**
-     * RPC Message schema
+     * Rest Message schema
      */
-    class RPC {
+    class Rest {
         companion object {
-            const val RPC_PERM_MGMT_REQ_TOPIC = "rpc.permissions.management"
-            val RPC_PERM_MGMT_RESP_TOPIC = getRPCResponseTopic(RPC_PERM_MGMT_REQ_TOPIC)
-            const val RPC_PERM_USER_TOPIC = "rpc.permissions.user"
-            const val RPC_PERM_GROUP_TOPIC = "rpc.permissions.group"
-            const val RPC_PERM_ROLE_TOPIC = "rpc.permissions.role"
-            const val RPC_PERM_ENTITY_TOPIC = "rpc.permissions.permission"
+            const val REST_PERM_MGMT_REQ_TOPIC = "rest.permissions.management"
+            val REST_PERM_MGMT_RESP_TOPIC = getRPCResponseTopic(REST_PERM_MGMT_REQ_TOPIC)
+            const val REST_PERM_USER_TOPIC = "rest.permissions.user"
+            const val REST_PERM_GROUP_TOPIC = "rest.permissions.group"
+            const val REST_PERM_ROLE_TOPIC = "rest.permissions.role"
+            const val REST_PERM_ENTITY_TOPIC = "rest.permissions.permission"
         }
     }
 

--- a/data/topic-schema/src/main/resources/net/corda/schema/Certificates.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/Certificates.yaml
@@ -4,12 +4,12 @@ topics:
     consumers:
       - db
     producers:
-      - rpc
+      - rest
     config:
   CertificatesRpcOpsRespTopic:
     name: certificates.rpc.ops.resp
     consumers:
-      - rpc
+      - rest
     producers:
       - db
     config:

--- a/data/topic-schema/src/main/resources/net/corda/schema/Config.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/Config.yaml
@@ -4,12 +4,12 @@ topics:
     consumers:
       - db
     producers:
-      - rpc
+      - rest
     config:
   ConfigManagementRequestResponseTopic:
     name: config.management.request.resp
     consumers:
-      - rpc
+      - rest
     producers:
       - db
     config:
@@ -22,7 +22,7 @@ topics:
       - membership
       - gateway
       - link-manager
-      - rpc
+      - rest
       - uniqueness
     producers:
       - db

--- a/data/topic-schema/src/main/resources/net/corda/schema/Crypto.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/Crypto.yaml
@@ -5,13 +5,13 @@ topics:
       - crypto
     producers:
       - membership
-      - rpc
+      - rest
     config:
   CryptoHSMRPCRegistrationRespTopic:
     name: crypto.hsm.rpc.registration.resp
     consumers:
       - membership
-      - rpc
+      - rest
     producers:
       - crypto
     config:
@@ -31,7 +31,7 @@ topics:
       - gateway
       - link-manager
       - membership
-      - rpc
+      - rest
     config:
   CryptoOpsRpcResponseTopic:
     name: crypto.ops.rpc.resp
@@ -40,7 +40,7 @@ topics:
       - gateway
       - link-manager
       - membership
-      - rpc
+      - rest
     producers:
       - crypto
     config:

--- a/data/topic-schema/src/main/resources/net/corda/schema/Flow.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/Flow.yaml
@@ -35,7 +35,7 @@ topics:
       - flow
     producers:
       - flow
-      - rpc
+      - rest
     config:
   FlowMapperEventStateTopic:
     name: flow.mapper.event.state
@@ -60,10 +60,10 @@ topics:
   FlowStatusTopic:
     name: flow.status
     consumers:
-      - rpc
+      - rest
     producers:
       - flow
-      - rpc
+      - rest
     config:
       cleanup.policy: compact
       segment.ms: 600000

--- a/data/topic-schema/src/main/resources/net/corda/schema/Membership.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/Membership.yaml
@@ -6,7 +6,7 @@ topics:
       - flow
       - link-manager
       - membership
-      - rpc
+      - rest
     producers:
       - db
       - membership
@@ -50,7 +50,7 @@ topics:
     consumers:
       - link-manager
       - membership
-      - rpc
+      - rest
       - flow
     producers:
       - membership
@@ -67,11 +67,11 @@ topics:
     consumers:
       - membership
     producers:
-      - rpc
+      - rest
   MembershipRpcOpsResponseTopic:
     name: membership.rpc.ops.resp
     consumers:
-      - rpc
+      - rest
     producers:
       - membership
   MembershipDBRpcOpsTopic:
@@ -81,14 +81,14 @@ topics:
     producers:
       - link-manager
       - membership
-      - rpc
+      - rest
     config:
   MembershipDBRpcOpsResponseTopic:
     name: membership.db.rpc.ops.resp
     consumers:
       - link-manager
       - membership
-      - rpc
+      - rest
     producers:
       - db
     config:
@@ -97,7 +97,7 @@ topics:
     consumers:
       - membership
     producers:
-      - rpc
+      - rest
   MembershipStaticNetworkTopic:
     name: membership.static.network
     consumers:

--- a/data/topic-schema/src/main/resources/net/corda/schema/P2P.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/P2P.yaml
@@ -49,7 +49,7 @@ topics:
       - link-manager
       - membership
     producers:
-      - rpc # Dynamic Network registration
+      - rest # Dynamic Network registration
       - membership # Static Network registration
     config:
       cleanup.policy: compact

--- a/data/topic-schema/src/main/resources/net/corda/schema/Permissions.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/Permissions.yaml
@@ -2,7 +2,7 @@ topics:
   PermissionsUserSummaryTopic:
     name: permissions.user.summary
     consumers:
-      - rpc
+      - rest
       - db
     producers:
       - db

--- a/data/topic-schema/src/main/resources/net/corda/schema/Rest.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/Rest.yaml
@@ -1,36 +1,22 @@
 topics:
-  RPCPermissionsManagementTopic:
-    name: rpc.permissions.management
+  RestPermissionsManagementTopic:
+    name: rest.permissions.management
     consumers:
       - db
     producers:
-      - rpc
+      - rest
     config:
-  RPCPermissionsManagementResponseTopic:
-    name: rpc.permissions.management.resp
+  RestPermissionsManagementResponseTopic:
+    name: rest.permissions.management.resp
     consumers:
-      - rpc
+      - rest
     producers:
       - db
     config:
-  RPCPermissionsGroupTopic:
-    name: rpc.permissions.group
+  RestPermissionsGroupTopic:
+    name: rest.permissions.group
     consumers:
-      - rpc
-      - db
-    producers:
-      - db
-    config:
-      cleanup.policy: compact
-      segment.ms: 600000
-      delete.retention.ms: 300000
-      min.compaction.lag.ms: 60000
-      max.compaction.lag.ms: 604800000
-      min.cleanable.dirty.ratio: 0.5
-  RPCPermissionsPermissionTopic:
-    name: rpc.permissions.permission
-    consumers:
-      - rpc
+      - rest
       - db
     producers:
       - db
@@ -41,10 +27,10 @@ topics:
       min.compaction.lag.ms: 60000
       max.compaction.lag.ms: 604800000
       min.cleanable.dirty.ratio: 0.5
-  RPCPermissionsUserTopic:
-    name: rpc.permissions.user
+  RestPermissionsPermissionTopic:
+    name: rest.permissions.permission
     consumers:
-      - rpc
+      - rest
       - db
     producers:
       - db
@@ -55,10 +41,24 @@ topics:
       min.compaction.lag.ms: 60000
       max.compaction.lag.ms: 604800000
       min.cleanable.dirty.ratio: 0.5
-  RPCPermissionsRoleTopic:
-    name: rpc.permissions.role
+  RestPermissionsUserTopic:
+    name: rest.permissions.user
     consumers:
-      - rpc
+      - rest
+      - db
+    producers:
+      - db
+    config:
+      cleanup.policy: compact
+      segment.ms: 600000
+      delete.retention.ms: 300000
+      min.compaction.lag.ms: 60000
+      max.compaction.lag.ms: 604800000
+      min.cleanable.dirty.ratio: 0.5
+  RestPermissionsRoleTopic:
+    name: rest.permissions.role
+    consumers:
+      - rest
       - db
     producers:
       - db

--- a/data/topic-schema/src/main/resources/net/corda/schema/VirtualNode.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/VirtualNode.yaml
@@ -6,7 +6,7 @@ topics:
       - flow
       - membership
       - link-manager
-      - rpc
+      - rest
     producers:
       - db
     config:
@@ -21,12 +21,12 @@ topics:
     consumers:
       - db
     producers:
-      - rpc
+      - rest
     config:
   CPIStatusTopic:
     name: cpi.upload.status
     consumers:
-      - rpc
+      - rest
     producers:
       - db
     config:
@@ -49,12 +49,12 @@ topics:
     consumers:
       - db
     producers:
-      - rpc
+      - rest
     config:
   VirtualNodeCreationRequestResponseTopic:
     name: virtual.node.creation.request.resp
     consumers:
-      - rpc
+      - rest
     producers:
       - db
     config:
@@ -66,7 +66,7 @@ topics:
       - flow
       - membership
       - link-manager
-      - rpc
+      - rest
     producers:
       - db
     config:
@@ -81,12 +81,12 @@ topics:
     consumers:
       - db
     producers:
-      - rpc
+      - rest
     config:
   VirtualNodeAsyncRequestTopic:
     name: virtual.node.async.request
     consumers:
       - db
     producers:
-      - rpc
+      - rest
     config:

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 649
+cordaApiRevision = 651
 
 # Main
 kotlinVersion = 1.8.10


### PR DESCRIPTION
This PR is part of the broader RPC -> REST renaming initiative described in [CORE-7040](https://r3-cev.atlassian.net/browse/CORE-7040), and satisfies [CORE-8034](https://r3-cev.atlassian.net/browse/CORE-8034) (rename `rpc-worker` -> `rest-worker`), and [CORE-10346](https://r3-cev.atlassian.net/browse/CORE-10346) (rename kafka topic from `rpc` -> `rest` worker).

This PR goes hand-in-hand with the runtime-os changes in this PR: https://github.com/corda/corda-runtime-os/pull/3110

# PR Checklist:

- [ ] Have you run the unit, integration and smoke tests as described [here](https://docs.corda.net/head/testing.html)?
- [ ] If you added public APIs, did you write the JavaDocs?
- [ ] If the changes are of interest to application developers, have you added them to the [changelog](https://docs.corda.net/head/changelog.html) (`/docs/source/changelog.rst`), and potentially the [release notes](https://docs.corda.net/head/release-notes.html) (`/docs/source/release-notes.rst`)?
- [ ] If you are contributing for the first time, please read the [contributor agreement](https://docs.corda.net/head/contributing.html) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://docs.corda.net/head/contributing.html#merging-the-changes-back-into-corda).

Thanks for your code, it's appreciated! :)


[CORE-7040]: https://r3-cev.atlassian.net/browse/CORE-7040?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CORE-8034]: https://r3-cev.atlassian.net/browse/CORE-8034?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CORE-10346]: https://r3-cev.atlassian.net/browse/CORE-10346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ