### PR TITLE
CORE-9865 Enable access for Kafka topics needed for InteropProcessor (also for CORE-9847, CORE-9848) 

### DIFF
--- a/data/topic-schema/src/main/resources/net/corda/schema/Flow.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/Flow.yaml
@@ -33,11 +33,9 @@ topics:
     name: flow.mapper.event
     consumers:
       - flow
-      - interop
     producers:
       - flow
       - rpc
-      - interop
     config:
   FlowMapperEventStateTopic:
     name: flow.mapper.event.state

--- a/data/topic-schema/src/main/resources/net/corda/schema/Flow.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/Flow.yaml
@@ -33,9 +33,11 @@ topics:
     name: flow.mapper.event
     consumers:
       - flow
+      - interop
     producers:
       - flow
       - rpc
+      - interop
     config:
   FlowMapperEventStateTopic:
     name: flow.mapper.event.state

--- a/data/topic-schema/src/main/resources/net/corda/schema/Membership.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/Membership.yaml
@@ -10,7 +10,6 @@ topics:
     producers:
       - db
       - membership
-      - interop
     config:
       cleanup.policy: compact
       segment.ms: 600000

--- a/data/topic-schema/src/main/resources/net/corda/schema/Membership.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/Membership.yaml
@@ -10,6 +10,7 @@ topics:
     producers:
       - db
       - membership
+      - interop
     config:
       cleanup.policy: compact
       segment.ms: 600000
@@ -22,6 +23,7 @@ topics:
     consumers:
     producers:
       - membership
+      - interop
     config:
   MembershipRegistrationTopic:
     name: membership.registration
@@ -54,6 +56,7 @@ topics:
     producers:
       - membership
       - db
+      - interop
     config:
       cleanup.policy: compact
       segment.ms: 600000

--- a/data/topic-schema/src/main/resources/net/corda/schema/P2P.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/P2P.yaml
@@ -4,6 +4,7 @@ topics:
     consumers:
       - flow
       - membership
+      - interop
     producers:
       - link-manager
     config:
@@ -14,6 +15,7 @@ topics:
     producers:
       - flow
       - membership
+      - interop
     config:
   P2POutMarkersTopic:
     name: p2p.out.markers

--- a/data/topic-schema/src/main/resources/net/corda/schema/P2P.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/P2P.yaml
@@ -53,6 +53,7 @@ topics:
     producers:
       - rpc # Dynamic Network registration
       - membership # Static Network registration
+      - interop # temporary hardcoded data
     config:
       cleanup.policy: compact
       segment.ms: 600000

--- a/data/topic-schema/src/main/resources/net/corda/schema/P2P.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/P2P.yaml
@@ -7,6 +7,7 @@ topics:
       - interop
     producers:
       - link-manager
+      - interop #Temporarily for seed message
     config:
   P2POutTopic:
     name: p2p.out


### PR DESCRIPTION
Added `interop` user as consumer (c) or producer (p) to the following Kafka topics (to be able to connect):
- for CORE-9848
    - membership.members : p (temporary, for CORE-9848)
    - membership.event : p (speculative, for CORE-9848)
- for  CORE-9847:
   - p2p.hosted.identities : p  (temporary)
- for CORE-9865:
    - p2p.in : p (temporary for a seed message), c
    - p2p.out : p 

Sibling PR in corda-runtime-os: https://github.com/corda/corda-runtime-os/pull/3178