### PR TITLE
CORE-9073 Add missing producer configuration for the registration event topic

### DIFF
--- a/data/topic-schema/src/main/resources/net/corda/schema/Membership.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/Membership.yaml
@@ -29,6 +29,7 @@ topics:
       - membership
     producers:
       - membership
+      - rpc
     config:
   MembershipRegistrationStateTopic:
     name: membership.registration.state


### PR DESCRIPTION
Follows on from https://github.com/corda/corda-api/pull/849

Found during e2e testing that the REST worker could not publish to the registration event topic because it did not have the correct permissions.