### PR TITLE
CORE-9630 Finality takes a transaction builder

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 647
+cordaApiRevision = 649
 
 # Main
 kotlinVersion = 1.8.10

--- a/ledger/ledger-consensual/src/main/kotlin/net/corda/v5/ledger/consensual/ConsensualLedgerService.kt
+++ b/ledger/ledger-consensual/src/main/kotlin/net/corda/v5/ledger/consensual/ConsensualLedgerService.kt
@@ -43,16 +43,16 @@ interface ConsensualLedgerService {
     fun findLedgerTransaction(id: SecureHash): ConsensualLedgerTransaction?
 
     /**
-     * Collects signatures, records and broadcasts to involved peers a [ConsensualSignedTransaction].
+     * Signs, collects signatures, records and broadcasts to involved peers a [ConsensualSignedTransaction].
      *
-     * @param signedTransaction The [ConsensualSignedTransaction] to finalise and recorded locally and with peer [sessions].
+     * @param transactionBuilder The [ConsensualTransactionBuilder] to sign, finalise and record locally and with the peer [sessions].
      * @param sessions The [FlowSession]s of the peers involved in the transaction.
      *
      * @return The fully signed [ConsensualSignedTransaction] that was recorded.
      */
     @Suspendable
     fun finalize(
-        signedTransaction: ConsensualSignedTransaction,
+        transactionBuilder: ConsensualTransactionBuilder,
         sessions: List<FlowSession>
     ): ConsensualSignedTransaction
 

--- a/ledger/ledger-consensual/src/main/kotlin/net/corda/v5/ledger/consensual/transaction/ConsensualTransactionBuilder.kt
+++ b/ledger/ledger-consensual/src/main/kotlin/net/corda/v5/ledger/consensual/transaction/ConsensualTransactionBuilder.kt
@@ -2,8 +2,6 @@ package net.corda.v5.ledger.consensual.transaction
 
 import net.corda.v5.base.annotations.DoNotImplement
 import net.corda.v5.ledger.consensual.ConsensualState
-import net.corda.v5.base.annotations.Suspendable
-import net.corda.v5.ledger.common.transaction.TransactionNoAvailableKeysException
 
 /**
  * Defines a builder for [ConsensualSignedTransaction]s.

--- a/ledger/ledger-consensual/src/main/kotlin/net/corda/v5/ledger/consensual/transaction/ConsensualTransactionBuilder.kt
+++ b/ledger/ledger-consensual/src/main/kotlin/net/corda/v5/ledger/consensual/transaction/ConsensualTransactionBuilder.kt
@@ -26,20 +26,4 @@ interface ConsensualTransactionBuilder {
      * @return Returns a new [ConsensualTransactionBuilder] with the specified output states.
      */
     fun withStates(vararg states: ConsensualState) : ConsensualTransactionBuilder
-
-    /**
-     * Verifies the content of the [ConsensualTransactionBuilder] and
-     * signs the transaction with any required signatories that belong to the current node.
-     *
-     * Calling this function once consumes the [ConsensualTransactionBuilder], so it cannot be used again.
-     * Therefore, if you want to build two transactions you need two builders.
-     *
-     * @return Returns a [ConsensualSignedTransaction] with signatures for any required signatories that belong to the current node.
-     *
-     * @throws IllegalStateException when called a second time on the same object to prevent
-     *      unintentional duplicate transactions.
-     * @throws TransactionNoAvailableKeysException if none of the required keys are available to sign the transaction.
-     */
-    @Suspendable
-    fun toSignedTransaction(): ConsensualSignedTransaction
 }

--- a/ledger/ledger-consensual/src/test/java/net/corda/v5/ledger/consensual/ConsensualLedgerServiceJavaApiTest.java
+++ b/ledger/ledger-consensual/src/test/java/net/corda/v5/ledger/consensual/ConsensualLedgerServiceJavaApiTest.java
@@ -68,16 +68,16 @@ public class ConsensualLedgerServiceJavaApiTest {
 
     @Test
     public void finalizeTest() {
-        ConsensualSignedTransaction consensualSignedTransactionIn = mock(ConsensualSignedTransaction.class);
+        ConsensualTransactionBuilder consensualTransactionBuilder = mock(ConsensualTransactionBuilder.class);
         ConsensualSignedTransaction consensualSignedTransactionOut = mock(ConsensualSignedTransaction.class);
         List<FlowSession> flowSessions = Arrays.asList(mock(FlowSession.class), mock(FlowSession.class));
-        when(consensualLedgerService.finalize(consensualSignedTransactionIn, flowSessions)).thenReturn(consensualSignedTransactionOut);
+        when(consensualLedgerService.finalize(consensualTransactionBuilder, flowSessions)).thenReturn(consensualSignedTransactionOut);
 
-        ConsensualSignedTransaction result = consensualLedgerService.finalize(consensualSignedTransactionIn, flowSessions);
+        ConsensualSignedTransaction result = consensualLedgerService.finalize(consensualTransactionBuilder, flowSessions);
 
         Assertions.assertThat(result).isNotNull();
         Assertions.assertThat(result).isEqualTo(consensualSignedTransactionOut);
-        verify(consensualLedgerService, times(1)).finalize(consensualSignedTransactionIn, flowSessions);
+        verify(consensualLedgerService, times(1)).finalize(consensualTransactionBuilder, flowSessions);
     }
 
     @Test

--- a/ledger/ledger-consensual/src/test/java/net/corda/v5/ledger/consensual/transaction/ConsensualTransactionBuilderJavaApiTest.java
+++ b/ledger/ledger-consensual/src/test/java/net/corda/v5/ledger/consensual/transaction/ConsensualTransactionBuilderJavaApiTest.java
@@ -67,17 +67,4 @@ public class ConsensualTransactionBuilderJavaApiTest {
         verify(consensualTransactionBuilder, times(1))
                 .withStates(consensualState1, consensualState2);
     }
-
-
-    @Test
-    public void toSignedTransaction() {
-        final ConsensualSignedTransaction mockSignedTransaction = mock(ConsensualSignedTransaction.class);
-        when(consensualTransactionBuilder.toSignedTransaction()).thenReturn(mockSignedTransaction);
-
-        final ConsensualSignedTransaction result = consensualTransactionBuilder.toSignedTransaction();
-
-        Assertions.assertThat(result).isNotNull();
-        Assertions.assertThat(result).isEqualTo(mockSignedTransaction);
-        verify(consensualTransactionBuilder, times(1)).toSignedTransaction();
-    }
 }

--- a/ledger/ledger-utxo/src/main/kotlin/net/corda/v5/ledger/utxo/UtxoLedgerService.kt
+++ b/ledger/ledger-utxo/src/main/kotlin/net/corda/v5/ledger/utxo/UtxoLedgerService.kt
@@ -99,7 +99,7 @@ interface UtxoLedgerService {
      */
     @Suspendable
     fun finalize(
-        signedTransaction: UtxoSignedTransaction,
+        transactionBuilder: UtxoTransactionBuilder,
         sessions: List<FlowSession>
     ): UtxoSignedTransaction
 

--- a/ledger/ledger-utxo/src/main/kotlin/net/corda/v5/ledger/utxo/UtxoLedgerService.kt
+++ b/ledger/ledger-utxo/src/main/kotlin/net/corda/v5/ledger/utxo/UtxoLedgerService.kt
@@ -90,7 +90,7 @@ interface UtxoLedgerService {
     /**
      * Verifies, signs, collects signatures, records and broadcasts a [UtxoSignedTransaction] to involved peers.
      *
-     * @param signedTransaction The [UtxoSignedTransaction] to verify, finalise and recorded locally and with peer [sessions].
+     * @param transactionBuilder The [UtxoTransactionBuilder] to verify, sign, finalise and record locally and with the peer [sessions].
      * @param sessions The [FlowSession]s of the peers involved in the transaction.
      *
      * @return The fully signed [UtxoSignedTransaction] that was recorded.

--- a/ledger/ledger-utxo/src/main/kotlin/net/corda/v5/ledger/utxo/transaction/UtxoTransactionBuilder.kt
+++ b/ledger/ledger-utxo/src/main/kotlin/net/corda/v5/ledger/utxo/transaction/UtxoTransactionBuilder.kt
@@ -1,10 +1,8 @@
 package net.corda.v5.ledger.utxo.transaction
 
 import net.corda.v5.base.annotations.DoNotImplement
-import net.corda.v5.base.annotations.Suspendable
 import net.corda.v5.crypto.SecureHash
 import net.corda.v5.ledger.common.Party
-import net.corda.v5.ledger.common.transaction.TransactionNoAvailableKeysException
 import net.corda.v5.ledger.utxo.Attachment
 import net.corda.v5.ledger.utxo.Command
 import net.corda.v5.ledger.utxo.ContractState

--- a/ledger/ledger-utxo/src/main/kotlin/net/corda/v5/ledger/utxo/transaction/UtxoTransactionBuilder.kt
+++ b/ledger/ledger-utxo/src/main/kotlin/net/corda/v5/ledger/utxo/transaction/UtxoTransactionBuilder.kt
@@ -177,20 +177,4 @@ interface UtxoTransactionBuilder {
      * @return Returns a [UtxoTransactionBuilder] including the specified time window.
      */
     fun setTimeWindowBetween(from: Instant, until: Instant): UtxoTransactionBuilder
-
-    /**
-     * Verifies the content of the [UtxoTransactionBuilder] and
-     * signs the transaction with any required signatories that belong to the current node.
-     *
-     * Calling this function once consumes the [UtxoTransactionBuilder], so it cannot be used again.
-     * Therefore, if you want to build two transactions you need two builders.
-     *
-     * @return Returns a [UtxoSignedTransaction] with signatures for any required signatories that belong to the current node.
-     *
-     * @throws IllegalStateException when called a second time on the same object to prevent
-     *      unintentional duplicate transactions.
-     * @throws TransactionNoAvailableKeysException if none of the required keys are available to sign the transaction.
-     */
-    @Suspendable
-    fun toSignedTransaction(): UtxoSignedTransaction
 }

--- a/ledger/ledger-utxo/src/test/java/net/corda/v5/ledger/utxo/AbstractMockTestHarness.java
+++ b/ledger/ledger-utxo/src/test/java/net/corda/v5/ledger/utxo/AbstractMockTestHarness.java
@@ -201,6 +201,5 @@ public class AbstractMockTestHarness {
         Mockito.when(utxoTransactionBuilder.getEncumbranceGroups()).thenReturn(encumbranceGroups);
         Mockito.when(utxoTransactionBuilder.setTimeWindowUntil(maxInstant)).thenReturn(utxoTransactionBuilder);
         Mockito.when(utxoTransactionBuilder.setTimeWindowBetween(minInstant, maxInstant)).thenReturn(utxoTransactionBuilder);
-        Mockito.when(utxoTransactionBuilder.toSignedTransaction()).thenReturn(utxoSignedTransaction);
     }
 }

--- a/ledger/ledger-utxo/src/test/java/net/corda/v5/ledger/utxo/UtxoLedgerServiceJavaApiTests.java
+++ b/ledger/ledger-utxo/src/test/java/net/corda/v5/ledger/utxo/UtxoLedgerServiceJavaApiTests.java
@@ -65,29 +65,29 @@ public final class UtxoLedgerServiceJavaApiTests extends AbstractMockTestHarness
 
     @Test
     public void finalizeTest() {
-        UtxoSignedTransaction UtxoSignedTransactionIn = mock(UtxoSignedTransaction.class);
-        UtxoSignedTransaction UtxoSignedTransactionOut = mock(UtxoSignedTransaction.class);
+        UtxoTransactionBuilder utxoTransactionBuilder = mock(UtxoTransactionBuilder.class);
+        UtxoSignedTransaction utxoSignedTransactionOut = mock(UtxoSignedTransaction.class);
         List<FlowSession> flowSessions = Arrays.asList(mock(FlowSession.class), mock(FlowSession.class));
-        when(utxoLedgerService.finalize(UtxoSignedTransactionIn, flowSessions)).thenReturn(UtxoSignedTransactionOut);
+        when(utxoLedgerService.finalize(utxoTransactionBuilder, flowSessions)).thenReturn(utxoSignedTransactionOut);
 
-        UtxoSignedTransaction result = utxoLedgerService.finalize(UtxoSignedTransactionIn, flowSessions);
+        UtxoSignedTransaction result = utxoLedgerService.finalize(utxoTransactionBuilder, flowSessions);
 
         org.assertj.core.api.Assertions.assertThat(result).isNotNull();
-        org.assertj.core.api.Assertions.assertThat(result).isEqualTo(UtxoSignedTransactionOut);
-        verify(utxoLedgerService, times(1)).finalize(UtxoSignedTransactionIn, flowSessions);
+        org.assertj.core.api.Assertions.assertThat(result).isEqualTo(utxoSignedTransactionOut);
+        verify(utxoLedgerService, times(1)).finalize(utxoTransactionBuilder, flowSessions);
     }
 
     @Test
     public void receiveFinality() {
-        UtxoSignedTransaction UtxoSignedTransaction = mock(UtxoSignedTransaction.class);
+        UtxoSignedTransaction utxoSignedTransaction = mock(UtxoSignedTransaction.class);
         FlowSession flowSession = mock(FlowSession.class);
         UtxoTransactionValidator utxoTransactionValidator = mock(UtxoTransactionValidator.class);
-        when(utxoLedgerService.receiveFinality(flowSession, utxoTransactionValidator)).thenReturn(UtxoSignedTransaction);
+        when(utxoLedgerService.receiveFinality(flowSession, utxoTransactionValidator)).thenReturn(utxoSignedTransaction);
 
         UtxoSignedTransaction result = utxoLedgerService.receiveFinality(flowSession, utxoTransactionValidator);
 
         org.assertj.core.api.Assertions.assertThat(result).isNotNull();
-        org.assertj.core.api.Assertions.assertThat(result).isEqualTo(UtxoSignedTransaction);
+        org.assertj.core.api.Assertions.assertThat(result).isEqualTo(utxoSignedTransaction);
         verify(utxoLedgerService, times(1)).receiveFinality(flowSession, utxoTransactionValidator);
     }
 }

--- a/ledger/ledger-utxo/src/test/java/net/corda/v5/ledger/utxo/UtxoTransactionBuilderJavaApiTests.java
+++ b/ledger/ledger-utxo/src/test/java/net/corda/v5/ledger/utxo/UtxoTransactionBuilderJavaApiTests.java
@@ -130,10 +130,4 @@ public final class UtxoTransactionBuilderJavaApiTests extends AbstractMockTestHa
         UtxoTransactionBuilder value = utxoTransactionBuilder.setTimeWindowBetween(minInstant, maxInstant);
         Assertions.assertEquals(utxoTransactionBuilder, value);
     }
-
-    @Test
-    public void toSignedTransactionShouldReturnTheExpectedValue() {
-        UtxoSignedTransaction value = utxoTransactionBuilder.toSignedTransaction();
-        Assertions.assertEquals(utxoSignedTransaction, value);
-    }
 }


### PR DESCRIPTION
`UtxoLedgerService.finalize` and `ConsensualLedgerService.finalize` both
now take in their respective transaction builders instead of signed
transactions.

The respective finality flows now sign the builders.

`toSignedTransaction` has been made internal and removed from the API.

The "cant sign twice" code has been removed from the builders because
we control the signing of them, making the code redundant (as it was there
to help developers).