### PR TITLE
CORE-10346 Renaming Kafka topic from `rpc` to `rest`

### DIFF
--- a/data/topic-schema/src/main/resources/net/corda/schema/Membership.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/Membership.yaml
@@ -29,7 +29,7 @@ topics:
       - membership
     producers:
       - membership
-      - rpc
+      - rest
     config:
   MembershipRegistrationStateTopic:
     name: membership.registration.state


### PR DESCRIPTION
This is a follow-up PR to https://github.com/corda/corda-api/pull/862/files – the change we're reverting was made while the original PR was waiting for the version number to unlock on Friday, and so it was missed.

# PR Checklist:

- [ ] Have you run the unit, integration and smoke tests as described [here](https://docs.corda.net/head/testing.html)?
- [ ] If you added public APIs, did you write the JavaDocs?
- [ ] If the changes are of interest to application developers, have you added them to the [changelog](https://docs.corda.net/head/changelog.html) (`/docs/source/changelog.rst`), and potentially the [release notes](https://docs.corda.net/head/release-notes.html) (`/docs/source/release-notes.rst`)?
- [ ] If you are contributing for the first time, please read the [contributor agreement](https://docs.corda.net/head/contributing.html) now and add a comment to this pull request stating that your PR is in accordance with the [Developer's Certificate of Origin](https://docs.corda.net/head/contributing.html#merging-the-changes-back-into-corda).

Thanks for your code, it's appreciated! :)
