### PR TITLE
CORE-9980 send/receive transaction builder

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 712
+cordaApiRevision = 713
 
 # Main
 kotlinVersion = 1.8.10

--- a/ledger/ledger-utxo/src/main/java/net/corda/v5/ledger/utxo/UtxoLedgerService.java
+++ b/ledger/ledger-utxo/src/main/java/net/corda/v5/ledger/utxo/UtxoLedgerService.java
@@ -125,4 +125,62 @@ public interface UtxoLedgerService {
             @NotNull FlowSession session,
             @NotNull UtxoTransactionValidator validator
     );
+
+    /**
+     * Sends a transaction builder to another session, then it waits for other side to propose transaction builder components,
+     * then applies the proposed components to a copy of the original builder and returns that new builder.
+     * <p>
+     * It supports similar workflows:
+     * Initiator:
+     * <p>
+     * val updatedTxBuilder = utxoLedgerService.sendAndReceiveTransactionBuilder(txBuilder, session)
+     * <p>
+     * The proposal one's notary and time window will get discarded and the original will be kept if both the original and
+     * the proposal have these components set. Also, all duplications will be discarded.
+     * <p>
+     * Receiver:
+     * <p>
+     * val proposedTxBuilder = utxoLedgerService.receiveTransactionBuilder(session)
+     * proposedTxBuilder.add...(...)
+     * proposedTxBuilder.add...(...)
+     * proposedTxBuilder.add...(...)
+     * utxoLedgerService.replyTransactionBuilderProposal(proposedTxBuilder, session)
+     *
+     * @param transactionBuilder The {@link UtxoTransactionBuilder} to send.
+     * @param session The receiver {@link FlowSession]}.
+     *
+     * @return A new merged builder of the original and proposed components.
+     */
+    @NotNull
+    @Suspendable
+    UtxoTransactionBuilder sendAndReceiveTransactionBuilder(
+            @NotNull UtxoTransactionBuilder transactionBuilder,
+            @NotNull FlowSession session
+    );
+
+    /**
+     * Receives a transaction builder from another session.
+     *
+     * @param session The {@link FlowSession] to receive the {@link UtxoTransactionBuilder} from.
+     */
+    @NotNull
+    @Suspendable
+    UtxoTransactionBuilder receiveTransactionBuilder(
+            @NotNull FlowSession session
+    );
+
+    /**
+     * Sends the differences of transaction builders to another session with all dependent back chains.
+     * It works only with {@link #receiveTransactionBuilder(FlowSession)} created {@link UtxoTransactionBuilder}s
+     * which track the differences internally.
+     * If it is called with anything else, it throws [InvalidParameterException].
+     * <p>
+     * @param transactionBuilder The {@link UtxoTransactionBuilder} to send.
+     * @param session The receiver {@link FlowSession}.
+     */
+    @Suspendable
+    void sendUpdatedTransactionBuilder(
+            @NotNull UtxoTransactionBuilder transactionBuilder,
+            @NotNull FlowSession session
+    );
 }

--- a/ledger/ledger-utxo/src/main/java/net/corda/v5/ledger/utxo/UtxoLedgerService.java
+++ b/ledger/ledger-utxo/src/main/java/net/corda/v5/ledger/utxo/UtxoLedgerService.java
@@ -135,7 +135,7 @@ public interface UtxoLedgerService {
      * <p>
      * val updatedTxBuilder = utxoLedgerService.sendAndReceiveTransactionBuilder(txBuilder, session)
      * <p>
-     * The proposal one's notary and time window will get discarded and the original will be kept if both the original and
+     * The notary and time window from the proposal will get discarded and the original will be kept if both the original and
      * the proposal have these components set. Also, all duplications will be discarded.
      * <p>
      * Receiver:
@@ -171,7 +171,7 @@ public interface UtxoLedgerService {
 
     /**
      * Sends the differences of transaction builders to another session with all dependent back chains.
-     * It works only with {@link #receiveTransactionBuilder(FlowSession)} created {@link UtxoTransactionBuilder}s
+     * It works only with {@link UtxoTransactionBuilder}s created from {@link #receiveTransactionBuilder(FlowSession)}
      * which track the differences internally.
      * If it is called with anything else, it throws [InvalidParameterException].
      * <p>


### PR DESCRIPTION
Send and receive transaction builder functionality.

Example usage:
Initiator:
```kotlin
val updatedTxBuilder = utxoLedgerService.sendAndReceiveTransactionBuilder(txBuilder, session)
```

Receiver:
```kotlin
val proposedTxBuilder = utxoLedgerService.receiveTransactionBuilder(session)
proposedTxBuilder.add...(...)
proposedTxBuilder.add...(...)
proposedTxBuilder.add...(...)
utxoLedgerService.sendUpdatedTransactionBuilder(proposedTxBuilder, session)
```
proposedTxBuilder tracks diffs internally with a smarter transactionbuilder implementation.

Design summary: https://github.com/corda/platform-eng-design/pull/545

Runtime-os: https://github.com/corda/corda-runtime-os/pull/3195