### PR TITLE
INFRA-2046: seperate kdoc and java doc publsihing 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -334,17 +334,27 @@ wrapper {
     distributionType = Wrapper.DistributionType.BIN
 }
 
-tasks.register('generateMultiModuleDocs', Zip) {
-    description = 'Create mutli module docs Site Jar'
+tasks.register('generateMultiModuleKDocs', Zip) {
+    description = 'Create mutli module docs Kdoc Site zip'
     group = 'documentation'
 
     dependsOn dokkaHtmlMultiModule
-    archiveName "corda-api-docs-${project.version}.zip"-
+    archiveName "corda-api-kdocs-${project.version}.zip"-
     from(dokkaHtmlMultiModule.outputDirectory)
-    destinationDir(file("$buildDir/corda-api-docs"))
+    destinationDir(file("$buildDir/corda-api-kdocs"))
 }
 
-if (project.hasProperty('publishMultiModulekDocs')) {
+tasks.register('generateMultiModuleJavaDocs', Zip) {
+    description = 'Create mutli module docs JavaDoc site zip'
+    group = 'documentation'
+
+    dependsOn dokkaJavadocCollector
+    archiveName "corda-api-javadocs-${project.version}.zip"-
+    from(dokkaHtmlMultiModule.outputDirectory)
+    destinationDir(file("$buildDir/corda-api-javadocs"))
+}
+
+if (project.hasProperty('publishMultiModuleDocs')) {
     publishing {
         publications {
             dokkaDocs(MavenPublication) {

--- a/buildSrc/src/main/groovy/corda.java-only.gradle
+++ b/buildSrc/src/main/groovy/corda.java-only.gradle
@@ -1,9 +1,9 @@
-plugins {
-    id 'org.jetbrains.kotlin.jvm'
+pluginManager.withPlugin('org.jetbrains.kotlin.jvm') {
+    throw new StopExecutionException("Module '${project.path}' should only contain Java classes")
 }
 
-tasks.named('compileKotlin') {
-    doFirst {
-        throw new InvalidUserCodeException("Module '${project.path}' should only contain Java classes")
+pluginManager.withPlugin('java') {
+    java {
+        withJavadocJar()
     }
 }


### PR DESCRIPTION
Seperate javaDoc and Kdoc publishing as requested by docs team.

Builds now have two distinct targets (and artifacts published) for Kdoc / JavaDoc.

`generateMultiModuleKDocs` will generate a zip archive of all kdoc in the project

`generateMultiModuleJavaDocs` will generate a zip archive of all javaDocs in the project.

Refactored `corda.java-only.gradle` to a slightly different approach to remove the need to apply `org.jetbrains.kotlin.jvm` plugin to the java modules, as this causes the java modules to also be included in the Kdoc. 

