### PR TITLE
CORE-11135: PR check, must have a JIra refrence

### DIFF
--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -9,6 +9,6 @@ jobs:
     steps:
       - uses: morrisoncole/pr-lint-action@v1.6.1
         with:
-          title-regex: '^((CORDA|EG|ENT|INFRA|CORE)-\d+|NOTICK)(.*)'
+          title-regex: '^((CORDA|EG|ENT|INFRA|CORE)-\d+)(.*)'
           on-failed-regex-comment: "PR title failed to match regex -> `%regex%`"
           repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
For tracking and compliance reasons, all work should have an associated Jira going forward, no NOTICK titles.

this check will block merging unless a valid Jira is in the title