### PR TITLE
CORE-11132: update downstream job use correct info

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ cordaPipeline(
     runIntegrationTests: false,
     nexusAppId: 'net.corda-api-5.0',
     dependentJobsNames: ['/Corda5/corda-runtime-os-version-compatibility/release%2Fos%2F5.0'],
-    dependentJobsNonBlocking: ['/Corda5/corda-api-compatibility/release%2Fos%2F5.0'],
+    dependentJobsNonBlocking: ['/Corda5/corda-api-compatibility/],
     // always use -beta-9999999999999 for local publication as this is used for the version compatibility checks,
     //  This is a PR gate, so we want to check the "post merge" state before publication for real.
     localPublishVersionSuffixOverride: '-beta-9999999999999',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ cordaPipeline(
     runIntegrationTests: false,
     nexusAppId: 'net.corda-api-5.0',
     dependentJobsNames: ['/Corda5/corda-runtime-os-version-compatibility/release%2Fos%2F5.0'],
-    dependentJobsNonBlocking: ['/Corda5/corda-api-compatibility/],
+    dependentJobsNonBlocking: ['/Corda5/corda-api-compatibility/'],
     // always use -beta-9999999999999 for local publication as this is used for the version compatibility checks,
     //  This is a PR gate, so we want to check the "post merge" state before publication for real.
     localPublishVersionSuffixOverride: '-beta-9999999999999',


### PR DESCRIPTION
dependentJobsNonBlocking needs to not have a branch name as this is dynamically added by Jenkin code 