### PR TITLE
CORE-11213: bump api version to 700 to avoid collision with Beta2 branch  

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 663
+cordaApiRevision = 700
 
 # Main
 kotlinVersion = 1.8.10


### PR DESCRIPTION
with the cutting of the beta2 release branch bumping to 700 to avoid clashing with beta which will continue on 663 

Runtime PR:  https://github.com/corda/corda-runtime-os/pull/3301

