### PR TITLE
CORE-6971: Allow CordaSerializable on custom serializer target types

### DIFF
--- a/base/src/main/java/net/corda/v5/base/types/OpaqueBytesSubSequence.java
+++ b/base/src/main/java/net/corda/v5/base/types/OpaqueBytesSubSequence.java
@@ -1,10 +1,12 @@
 package net.corda.v5.base.types;
 
+import net.corda.v5.base.annotations.CordaSerializable;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * Class is public for serialization purposes.
  */
+@CordaSerializable
 public final class OpaqueBytesSubSequence extends ByteSequence {
     private final byte[] bytes;
 

--- a/ledger/ledger-consensual/src/main/java/net/corda/v5/ledger/consensual/transaction/ConsensualSignedTransaction.java
+++ b/ledger/ledger-consensual/src/main/java/net/corda/v5/ledger/consensual/transaction/ConsensualSignedTransaction.java
@@ -1,6 +1,7 @@
 package net.corda.v5.ledger.consensual.transaction;
 
 import net.corda.v5.application.crypto.DigitalSignatureAndMetadata;
+import net.corda.v5.base.annotations.CordaSerializable;
 import net.corda.v5.base.annotations.DoNotImplement;
 import net.corda.v5.crypto.SecureHash;
 import net.corda.v5.ledger.common.transaction.TransactionWithMetadata;
@@ -32,6 +33,7 @@ import java.util.List;
  * <p>
  * Adding or removing a signature does not change the transaction ID.
  */
+@CordaSerializable
 @DoNotImplement
 public interface ConsensualSignedTransaction extends TransactionWithMetadata {
 

--- a/ledger/ledger-utxo/src/main/java/net/corda/v5/ledger/utxo/transaction/UtxoSignedTransaction.java
+++ b/ledger/ledger-utxo/src/main/java/net/corda/v5/ledger/utxo/transaction/UtxoSignedTransaction.java
@@ -1,6 +1,7 @@
 package net.corda.v5.ledger.utxo.transaction;
 
 import net.corda.v5.application.crypto.DigitalSignatureAndMetadata;
+import net.corda.v5.base.annotations.CordaSerializable;
 import net.corda.v5.base.annotations.DoNotImplement;
 import net.corda.v5.base.annotations.Suspendable;
 import net.corda.v5.ledger.common.Party;
@@ -36,6 +37,7 @@ import java.util.List;
  * A transaction ID should be the hash of the wrapped wire representation's Merkle tree root, therefore adding or
  * removing a signature does not change it.
  */
+@CordaSerializable
 @DoNotImplement
 public interface UtxoSignedTransaction extends TransactionWithMetadata {
 

--- a/ledger/ledger-utxo/src/main/java/net/corda/v5/ledger/utxo/transaction/filtered/UtxoFilteredTransaction.java
+++ b/ledger/ledger-utxo/src/main/java/net/corda/v5/ledger/utxo/transaction/filtered/UtxoFilteredTransaction.java
@@ -1,5 +1,6 @@
 package net.corda.v5.ledger.utxo.transaction.filtered;
 
+import net.corda.v5.base.annotations.CordaSerializable;
 import net.corda.v5.base.annotations.DoNotImplement;
 import net.corda.v5.base.exceptions.CordaRuntimeException;
 import net.corda.v5.crypto.SecureHash;
@@ -33,6 +34,7 @@ import java.security.PublicKey;
  * - {@link #getNotary()} and {@link #getTimeWindow()} are always unique - they are either revealed,
  * or the filtered transaction will return null when accessing them.
  */
+@CordaSerializable
 @DoNotImplement
 public interface UtxoFilteredTransaction {
 


### PR DESCRIPTION
- Add `@CordaSerializable` to `OpaqueBytesSubSequence`, `UtxoSignedTransaction`, `UtxoFilteredTransaction` and  `ConsensualSignedTransaction`.