### PR TITLE
CORE-9332: Align `DigitalSignatureVerificationService.verify` overloads

### DIFF
--- a/application/src/main/java/net/corda/v5/application/crypto/DigitalSignatureVerificationService.java
+++ b/application/src/main/java/net/corda/v5/application/crypto/DigitalSignatureVerificationService.java
@@ -15,21 +15,19 @@ import java.security.PublicKey;
  */
 @DoNotImplement
 public interface DigitalSignatureVerificationService {
-    // TODO The following `verify` overload should be aligned with the other one as per: https://r3-cev.atlassian.net/browse/CORE-9332
     /**
      * Verifies a digital signature by using {@code signatureSpec}.
      * Always throws an exception if verification fails.
      *
-     * @param publicKey The signer's {@link PublicKey}.
-     * @param signatureSpec The signature spec.
+     * @param originalData  The clear data/message that was signed (usually the Merkle root).
      * @param signatureData The signatureData on a message.
-     * @param clearData The clear data/message that was signed (usually the Merkle root).
-     *
+     * @param publicKey     The signer's {@link PublicKey}.
+     * @param signatureSpec The signature spec.
      * @throws CryptoSignatureException If verification of the digital signature fails.
      * @throws IllegalArgumentException If the signature scheme is not supported or if any of the clear or signature
-     * data is empty.
+     *                                  data is empty.
      */
-    void verify(@NotNull PublicKey publicKey, @NotNull SignatureSpec signatureSpec, @NotNull byte[] signatureData, @NotNull byte[] clearData);
+    void verify(@NotNull byte[] originalData, @NotNull byte[] signatureData, @NotNull PublicKey publicKey, @NotNull SignatureSpec signatureSpec);
 
     /**
      * Verifies a digital signature against data. Throws {@link CryptoSignatureException} if verification fails.

--- a/application/src/main/java/net/corda/v5/application/crypto/DigitalSignatureVerificationService.java
+++ b/application/src/main/java/net/corda/v5/application/crypto/DigitalSignatureVerificationService.java
@@ -19,12 +19,12 @@ public interface DigitalSignatureVerificationService {
      * Verifies a digital signature by using {@code signatureSpec}.
      * Always throws an exception if verification fails.
      *
-     * @param originalData  The clear data/message that was signed (usually the Merkle root).
+     * @param originalData  The original data/message that was signed (usually the Merkle root).
      * @param signatureData The signatureData on a message.
      * @param publicKey     The signer's {@link PublicKey}.
      * @param signatureSpec The signature spec.
      * @throws CryptoSignatureException If verification of the digital signature fails.
-     * @throws IllegalArgumentException If the signature scheme is not supported or if any of the clear or signature
+     * @throws IllegalArgumentException If the signature scheme is not supported or if any of the original or signature
      *                                  data is empty.
      */
     void verify(@NotNull byte[] originalData, @NotNull byte[] signatureData, @NotNull PublicKey publicKey, @NotNull SignatureSpec signatureSpec);
@@ -38,7 +38,7 @@ public interface DigitalSignatureVerificationService {
      * @param signatureSpec The signature spec.
      *
      * @throws CryptoSignatureException If verification of the digital signature fails.
-     * @throws IllegalArgumentException If the signature scheme is not supported or if any of the clear or signature
+     * @throws IllegalArgumentException If the signature scheme is not supported or if any of the original or signature
      * data is empty.
      */
     void verify(@NotNull byte[] originalData, @NotNull DigitalSignature signature, @NotNull PublicKey publicKey, @NotNull SignatureSpec signatureSpec);

--- a/application/src/main/java/net/corda/v5/application/crypto/DigitalSignatureVerificationService.java
+++ b/application/src/main/java/net/corda/v5/application/crypto/DigitalSignatureVerificationService.java
@@ -32,14 +32,13 @@ public interface DigitalSignatureVerificationService {
     /**
      * Verifies a digital signature against data. Throws {@link CryptoSignatureException} if verification fails.
      *
-     * @param originalData The original data on which the signature was applied (usually the Merkle root).
-     * @param signature The digital signature.
-     * @param publicKey The signer's {@link PublicKey}.
+     * @param originalData  The original data on which the signature was applied (usually the Merkle root).
+     * @param signature     The digital signature.
+     * @param publicKey     The signer's {@link PublicKey}.
      * @param signatureSpec The signature spec.
-     *
      * @throws CryptoSignatureException If verification of the digital signature fails.
      * @throws IllegalArgumentException If the signature scheme is not supported or if any of the original or signature
-     * data is empty.
+     *                                  data is empty.
      */
     void verify(@NotNull byte[] originalData, @NotNull DigitalSignature signature, @NotNull PublicKey publicKey, @NotNull SignatureSpec signatureSpec);
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 709
+cordaApiRevision = 710
 
 # Main
 kotlinVersion = 1.8.10

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 710
+cordaApiRevision = 711
 
 # Main
 kotlinVersion = 1.8.10


### PR DESCRIPTION
Changes:
- change the signature order of one `verify` method to align with the second `verify` method in `DigitalSignatureVerificationService`.
- rename `clearData` -> `originalData` to align with the rest of the interface.

Runtime-os PR: [#3342](https://github.com/corda/corda-runtime-os/pull/3342)
