### PR TITLE
CORE-11521 Remove `DigitalSignature.WithKey.context`

### DIFF
--- a/application/src/test/java/net/corda/v5/application/crypto/SigningServiceJavaApiTest.java
+++ b/application/src/test/java/net/corda/v5/application/crypto/SigningServiceJavaApiTest.java
@@ -22,8 +22,7 @@ class SigningServiceJavaApiTest {
     void signWithByteArrayAndSignatureSpecTest() {
         final DigitalSignature.WithKey signatureWithKey = new DigitalSignature.WithKey(
             publicKey,
-            "test".getBytes(),
-            new HashMap<>()
+            "test".getBytes()
         );
         Mockito.when(signingService.sign(any(), any(), any(SignatureSpec.class))).thenReturn(signatureWithKey);
 

--- a/crypto/src/main/java/net/corda/v5/crypto/DigitalSignature.java
+++ b/crypto/src/main/java/net/corda/v5/crypto/DigitalSignature.java
@@ -5,7 +5,6 @@ import net.corda.v5.base.types.OpaqueBytes;
 import org.jetbrains.annotations.NotNull;
 
 import java.security.PublicKey;
-import java.util.Map;
 
 /**
  * A wrapper around a digital signature.
@@ -21,11 +20,6 @@ public class DigitalSignature extends OpaqueBytes {
      */
     public static class WithKey extends DigitalSignature {
 
-        @NotNull
-        public final Map<String, String> getContext() {
-            return this.context;
-        }
-
         /**
          * Construct WithKey
          *
@@ -33,12 +27,10 @@ public class DigitalSignature extends OpaqueBytes {
          *                of the {@link CompositeKey} is passed to the sign operation it may contain keys which are not actually owned by
          *                the member).
          * @param bytes   The signature.
-         * @param context The context which was passed to the signing operation, note that this context is not signed over.
          */
-        public WithKey(@NotNull PublicKey by, @NotNull byte[] bytes, @NotNull Map<String, String> context) {
+        public WithKey(@NotNull PublicKey by, @NotNull byte[] bytes) {
             super(bytes);
             this.by = by;
-            this.context = context;
         }
 
         /**
@@ -47,8 +39,6 @@ public class DigitalSignature extends OpaqueBytes {
          * the member).
          */
         private final PublicKey by;
-
-        private final Map<String, String> context;
 
         @NotNull
         public final PublicKey getBy() {

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/CryptoSignatureWithKey.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/CryptoSignatureWithKey.avsc
@@ -13,11 +13,6 @@
       "name": "bytes",
       "type": "bytes",
       "doc": "Byte array of the signature, exactly as returned by crypto signing operations"
-    },
-    {
-      "name": "context",
-      "type": "net.corda.data.KeyValuePairList",
-      "doc": "The optional key/value operation specific context."
     }
   ]
 }

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/SignedMemberInfo.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/SignedMemberInfo.avsc
@@ -20,9 +20,19 @@
       "type": "net.corda.data.crypto.wire.CryptoSignatureWithKey"
     },
     {
+      "name": "memberSignatureSpec",
+      "doc": "Signature spec of member signature.",
+      "type": "net.corda.data.crypto.wire.CryptoSignatureSpec"
+    },
+    {
       "name": "mgmSignature",
       "doc": "Signature of the MGM over both the mgmContext and memberContext using MerkleTree.",
       "type": "net.corda.data.crypto.wire.CryptoSignatureWithKey"
+    },
+    {
+      "name": "mgmSignatureSpec",
+      "doc": "Signature spec of MGM signature.",
+      "type": "net.corda.data.crypto.wire.CryptoSignatureSpec"
     }
   ]
 }

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/SignedMemberInfo.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/SignedMemberInfo.avsc
@@ -21,8 +21,8 @@
     },
     {
       "name": "memberSignatureSpec",
-      "doc": "Signature spec of member signature.",
-      "type": "net.corda.data.crypto.wire.CryptoSignatureSpec"
+      "type": "net.corda.data.crypto.wire.CryptoSignatureSpec",
+      "doc": "Signature spec of member signature."
     },
     {
       "name": "mgmSignature",
@@ -31,8 +31,8 @@
     },
     {
       "name": "mgmSignatureSpec",
-      "doc": "Signature spec of MGM signature.",
-      "type": "net.corda.data.crypto.wire.CryptoSignatureSpec"
+      "type": "net.corda.data.crypto.wire.CryptoSignatureSpec",
+      "doc": "Signature spec of MGM signature."
     }
   ]
 }

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/response/query/MemberSignature.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/response/query/MemberSignature.avsc
@@ -13,6 +13,11 @@
       "name": "signature",
       "doc": "The member signature.",
       "type": "net.corda.data.crypto.wire.CryptoSignatureWithKey"
+    },
+    {
+      "name": "signatureSpec",
+      "doc": "Signature spec of member signature.",
+      "type": "net.corda.data.crypto.wire.CryptoSignatureSpec"
     }
   ]
 }

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/response/query/MemberSignature.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/response/query/MemberSignature.avsc
@@ -16,8 +16,8 @@
     },
     {
       "name": "signatureSpec",
-      "doc": "Signature spec of member signature.",
-      "type": "net.corda.data.crypto.wire.CryptoSignatureSpec"
+      "type": "net.corda.data.crypto.wire.CryptoSignatureSpec",
+      "doc": "Signature spec of member signature."
     }
   ]
 }

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/p2p/MembershipRegistrationRequest.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/p2p/MembershipRegistrationRequest.avsc
@@ -24,8 +24,8 @@
     },
     {
       "name": "memberSignatureSpec",
-      "doc": "Signature spec of member signature.",
-      "type": "net.corda.data.crypto.wire.CryptoSignatureSpec"
+      "type": "net.corda.data.crypto.wire.CryptoSignatureSpec",
+      "doc": "Signature spec of member signature."
     },
     {
       "name": "isPending",

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/p2p/MembershipRegistrationRequest.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/p2p/MembershipRegistrationRequest.avsc
@@ -23,6 +23,11 @@
       "type": "net.corda.data.crypto.wire.CryptoSignatureWithKey"
     },
     {
+      "name": "memberSignatureSpec",
+      "doc": "Signature spec of member signature.",
+      "type": "net.corda.data.crypto.wire.CryptoSignatureSpec"
+    },
+    {
       "name": "isPending",
       "doc": "Indicates if the signature is for pending registration request information.",
       "type": "boolean"

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/p2p/WireGroupParameters.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/p2p/WireGroupParameters.avsc
@@ -13,6 +13,11 @@
       "name": "mgmSignature",
       "doc": "Signature of the MGM using MerkleTree.",
       "type": "net.corda.data.crypto.wire.CryptoSignatureWithKey"
+    },
+    {
+      "name": "mgmSignatureSpec",
+      "doc": "Signature spec of MGM signature.",
+      "type": "net.corda.data.crypto.wire.CryptoSignatureSpec"
     }
   ]
 }

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/p2p/WireGroupParameters.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/p2p/WireGroupParameters.avsc
@@ -16,8 +16,8 @@
     },
     {
       "name": "mgmSignatureSpec",
-      "doc": "Signature spec of MGM signature.",
-      "type": "net.corda.data.crypto.wire.CryptoSignatureSpec"
+      "type": "net.corda.data.crypto.wire.CryptoSignatureSpec",
+      "doc": "Signature spec of MGM signature."
     }
   ]
 }

--- a/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/vnode-vault-creation-v1.0.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/vnode-vault-creation-v1.0.xml
@@ -139,7 +139,7 @@
             <column name="public_key" type="VARBINARY(1024)">
                 <constraints nullable="false"/>
             </column>
-            <column name="context" type="VARBINARY(2048)">
+            <column name="signature_spec" type="NVARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
             <column name="content" type="VARBINARY(4096)">

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 715
+cordaApiRevision = 716
 
 # Main
 kotlinVersion = 1.8.10


### PR DESCRIPTION
`DigitalSignature.WithKey.context` gets returned as part of the signature. Callers of sign operation have no control over it so it's of no use to them (and also as such `DigitalSignature.WithKey.context` is not signed either).

- removes `DigitalSignature.WithKey.context`

runtime-os PR: [#3347](https://github.com/corda/corda-runtime-os/pull/3347)