### PR TITLE
CORE-5630 - Added the field `externalChannelsConfig` to the CpkMetadata.avsc

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/packaging/CpkMetadata.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/packaging/CpkMetadata.avsc
@@ -42,6 +42,11 @@
         "logicalType": "timestamp-millis"
       },
       "doc": "Time ([Instant]) in milliseconds when the record was updated or added."
+    },
+    {
+      "name": "externalChannelsConfig",
+      "type": ["null", "string"],
+      "default": null
     }
   ]
 }


### PR DESCRIPTION
Added the field `externalChannelsConfig` to the CpkMetadata Avro JSON. This field contains the configuration for external channels.

