### PR TITLE
CORE-11034: Add default row for Sandbox config and update the schema 

### DIFF
--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/sandbox/1.0/corda.sandbox.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/sandbox/1.0/corda.sandbox.json
@@ -5,16 +5,63 @@
   "description": "Configuration schema for the sandbox subsection.",
   "type": "object",
   "properties": {
-    "cache": {
-      "description": "Settings for sandbox caching",
+    "flow": {
+      "description": "Settings for flow sandbox",
       "type": "object",
       "default": {},
       "properties": {
-        "size": {
-          "description": "The maximum number cached sandboxes.",
-          "type": "integer",
-          "minimum": 0,
-          "default": 2
+        "cache": {
+          "description": "Settings for flow sandbox caching",
+          "type": "object",
+          "default": {},
+          "properties": {
+            "size": {
+              "description": "The maximum number cached flow sandboxes.",
+              "type": "integer",
+              "minimum": 0,
+              "default": 10
+            }
+          }
+        }
+      }
+    },
+    "persistence": {
+      "description": "Settings for db sandbox",
+      "type": "object",
+      "default": {},
+      "properties": {
+        "cache": {
+          "description": "Settings for db sandbox caching",
+          "type": "object",
+          "default": {},
+          "properties": {
+            "size": {
+              "description": "The maximum number cached db sandboxes.",
+              "type": "integer",
+              "minimum": 0,
+              "default": 10
+            }
+          }
+        }
+      }
+    },
+    "verification": {
+      "description": "Settings for verification sandbox",
+      "type": "object",
+      "default": {},
+      "properties": {
+        "cache": {
+          "description": "Settings for verification sandbox caching",
+          "type": "object",
+          "default": {},
+          "properties": {
+            "size": {
+              "description": "The maximum number cached verification sandboxes.",
+              "type": "integer",
+              "minimum": 0,
+              "default": 10
+            }
+          }
         }
       }
     }

--- a/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/config-creation-v1.0.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/config-creation-v1.0.xml
@@ -113,6 +113,17 @@
             <column name="update_actor" value="admin"/>
         </insert>
 
+        <insert tableName="config">
+            <column name="section" value="corda.sandbox"/>
+            <column name="config" value=""/>
+            <column name="schema_version_major" value="1"/>
+            <column name="schema_version_minor" value="0"/>
+            <column name="version" value="0"/>
+            <column name="is_deleted" value="false"/>
+            <column name="update_ts" valueDate="${now}"/>
+            <column name="update_actor" value="admin"/>
+        </insert>
+
         <createTable tableName="config_audit">
             <column name="change_number" type="SERIAL">
                 <constraints nullable="false"/>


### PR DESCRIPTION
Default row in the config table was missing and the schema has been changed to support a cache for each sandbox type