### PR TITLE
CORE-9586 Allow Custom Fields in Registration schema

### DIFF
--- a/data/membership-schema/src/main/resources/net/corda/schema/membership/member/dynamic/registration/1.0/corda.member.dynamic.registration.json
+++ b/data/membership-schema/src/main/resources/net/corda/schema/membership/member/dynamic/registration/1.0/corda.member.dynamic.registration.json
@@ -38,7 +38,7 @@
       "type": "string"
     },
     "(?=^(?!corda\\.).+)(?=^(?=.{1,128}$)[a-zA-Z0-9]*[^$%^&*;:,<>?()\"']*$)": {
-      "description": "Optional. A user can specify additional properties, they must not start with corda or be more than 128 characters.",
+      "description": "Optional. A user can specify additional properties, they must not start with corda. or be more than 128 characters.",
       "type": "string",
       "maxLength": 128
     }
@@ -77,6 +77,5 @@
   "required": [
     "corda.session.key.id"
   ],
-  "additionalProperties": false,
-  "maxProperties": 128
+  "additionalProperties": false
 }

--- a/data/membership-schema/src/main/resources/net/corda/schema/membership/member/dynamic/registration/1.0/corda.member.dynamic.registration.json
+++ b/data/membership-schema/src/main/resources/net/corda/schema/membership/member/dynamic/registration/1.0/corda.member.dynamic.registration.json
@@ -37,7 +37,7 @@
       "description": "Optional. The ledger public key signature spec. Can be multiple specified by index.",
       "type": "string"
     },
-    "^ext\\.[a-zA-Z0-9\\.]+$": {
+    "^ext\\.[a-zA-Z0-9.]+$": {
       "description": "Optional. A user can specify additional properties, they must be prefixed with `ext.`.",
       "type": "string",
       "maxLength": 256

--- a/data/membership-schema/src/main/resources/net/corda/schema/membership/member/dynamic/registration/1.0/corda.member.dynamic.registration.json
+++ b/data/membership-schema/src/main/resources/net/corda/schema/membership/member/dynamic/registration/1.0/corda.member.dynamic.registration.json
@@ -37,10 +37,10 @@
       "description": "Optional. The ledger public key signature spec. Can be multiple specified by index.",
       "type": "string"
     },
-    "(?=^(?!corda\\.).+)(?=^(?=.{1,128}$)[a-zA-Z0-9]*[^$%^&*;:,<>?()\"']*$)": {
-      "description": "Optional. A user can specify additional properties, they must not start with corda. or be more than 128 characters.",
+    "^ext\\.[a-zA-Z0-9\\.]+$": {
+      "description": "Optional. A user can specify additional properties, they must be prefixed with `ext.`",
       "type": "string",
-      "maxLength": 128
+      "maxLength": 256
     }
   },
   "properties": {

--- a/data/membership-schema/src/main/resources/net/corda/schema/membership/member/dynamic/registration/1.0/corda.member.dynamic.registration.json
+++ b/data/membership-schema/src/main/resources/net/corda/schema/membership/member/dynamic/registration/1.0/corda.member.dynamic.registration.json
@@ -36,6 +36,11 @@
     "^corda.ledger.keys.[0-9]+.signature.spec$": {
       "description": "Optional. The ledger public key signature spec. Can be multiple specified by index.",
       "type": "string"
+    },
+    "(?=^(?!corda\\.).+)(?=^(?=.{1,128}$)[a-zA-Z0-9]*[^$%^&*;:,<>?()\"']*$)": {
+      "description": "Optional. A user can specify additional properties, they must not start with corda or be more than 128 characters.",
+      "type": "string",
+      "maxLength": 128
     }
   },
   "properties": {
@@ -72,5 +77,6 @@
   "required": [
     "corda.session.key.id"
   ],
-  "additionalProperties": false
+  "additionalProperties": false,
+  "maxProperties": 128
 }

--- a/data/membership-schema/src/main/resources/net/corda/schema/membership/member/dynamic/registration/1.0/corda.member.dynamic.registration.json
+++ b/data/membership-schema/src/main/resources/net/corda/schema/membership/member/dynamic/registration/1.0/corda.member.dynamic.registration.json
@@ -38,7 +38,7 @@
       "type": "string"
     },
     "^ext\\.[a-zA-Z0-9\\.]+$": {
-      "description": "Optional. A user can specify additional properties, they must be prefixed with `ext.`",
+      "description": "Optional. A user can specify additional properties, they must be prefixed with `ext.`.",
       "type": "string",
       "maxLength": 256
     }


### PR DESCRIPTION
Allow extra string fields in the registration context. These will be used to allow registering member to add custom fields to their member info. Enforce that the custom fields start with a "ext." prefix, all other fields are reserved for future platform usage. Custom fields can have 256 characters in the value.
