### PR TITLE
CORE-11065 Custom ledger queries liquibase changes

### DIFF
--- a/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v1.0.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v1.0.xml
@@ -156,32 +156,6 @@
                                  referencedColumnNames="transaction_id,group_idx,leaf_idx"
                                  referencedTableName="utxo_transaction_component"/>
 
-        <createTable tableName="utxo_relevant_transaction_state">
-            <column name="transaction_id" type="VARCHAR(160)">
-                <constraints nullable="false"/>
-            </column>
-            <column name="group_idx" type="INT">
-                <constraints nullable="false"/>
-            </column>
-            <column name="leaf_idx" type="INT">
-                <constraints nullable="false"/>
-            </column>
-            <column name="consumed" type="BOOLEAN">
-                <constraints nullable="false"/>
-            </column>
-            <column name="created" type="TIMESTAMP">
-                <constraints nullable="false"/>
-            </column>
-        </createTable>
-        <addPrimaryKey columnNames="transaction_id, group_idx, leaf_idx"
-                       constraintName="utxo_relevant_transaction_state_pkey"
-                       tableName="utxo_relevant_transaction_state"/>
-        <addForeignKeyConstraint baseColumnNames="transaction_id,group_idx,leaf_idx"
-                                 baseTableName="utxo_relevant_transaction_state"
-                                 constraintName="fk_utxo_relevant_transaction_state"
-                                 referencedColumnNames="transaction_id,group_idx,leaf_idx"
-                                 referencedTableName="utxo_transaction_component"/>
-
         <createTable tableName="utxo_cpk">
             <column name="file_checksum" type="VARCHAR(255)">
                 <constraints nullable="false" primaryKey="true"/>
@@ -217,4 +191,6 @@
                        constraintName="utxo_transaction_cpk_pkey"
                        tableName="utxo_transaction_cpk"/>
     </changeSet>
+
+    <include file="net/corda/db/schema/vnode-vault/migration/ledger-utxo-relevant-transaction-state-creation-v1.0.xml"/>
 </databaseChangeLog>

--- a/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-relevant-transaction-state-creation-v1.0.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-relevant-transaction-state-creation-v1.0.xml
@@ -1,0 +1,40 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+
+    <changeSet author="R3.Corda" id="ledger-utxo-relevant-transaction-state-creation-postgres-v1.0" dbms="postgresql">
+
+        <createTable tableName="utxo_relevant_transaction_state">
+            <column name="transaction_id" type="VARCHAR(160)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="group_idx" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="leaf_idx" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="consumed" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="custom" type="JSONB">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created" type="TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="consumed_timestamp" type="TIMESTAMP">
+                <constraints nullable="true"/>
+            </column>
+        </createTable>
+        <addPrimaryKey columnNames="transaction_id, group_idx, leaf_idx"
+                       constraintName="utxo_relevant_transaction_state_pkey"
+                       tableName="utxo_relevant_transaction_state"/>
+        <addForeignKeyConstraint baseColumnNames="transaction_id,group_idx,leaf_idx"
+                                 baseTableName="utxo_relevant_transaction_state"
+                                 constraintName="fk_utxo_relevant_transaction_state"
+                                 referencedColumnNames="transaction_id,group_idx,leaf_idx"
+                                 referencedTableName="utxo_transaction_component"/>
+    </changeSet>
+</databaseChangeLog>

--- a/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-relevant-transaction-state-creation-v1.0.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-relevant-transaction-state-creation-v1.0.xml
@@ -18,7 +18,7 @@
             <column name="consumed" type="BOOLEAN">
                 <constraints nullable="false"/>
             </column>
-            <column name="custom" type="JSONB">
+            <column name="custom_representation" type="JSONB">
                 <constraints nullable="false"/>
             </column>
             <column name="created" type="TIMESTAMP">

--- a/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-relevant-transaction-state-creation-v1.0.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-relevant-transaction-state-creation-v1.0.xml
@@ -15,16 +15,13 @@
             <column name="leaf_idx" type="INT">
                 <constraints nullable="false"/>
             </column>
-            <column name="consumed" type="BOOLEAN">
-                <constraints nullable="false"/>
-            </column>
             <column name="custom_representation" type="JSONB">
                 <constraints nullable="false"/>
             </column>
             <column name="created" type="TIMESTAMP">
                 <constraints nullable="false"/>
             </column>
-            <column name="consumed_timestamp" type="TIMESTAMP">
+            <column name="consumed" type="TIMESTAMP">
                 <constraints nullable="true"/>
             </column>
         </createTable>

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 716
+cordaApiRevision = 717
 
 # Main
 kotlinVersion = 1.8.10


### PR DESCRIPTION
Add `custom_representation` and repurpose the `consumed` column
in the `utxo_relevant_transaction_state` table.

The `custom_representation` column is of type `JSONB` and is
therefore Postgres  specific.

`ledger-utxo-relevant-transaction-state-creation-v1.0.xml` has been 
separated to create the table. For now it has been restricted to 
creating the table only for Postgres databases, meaning that the table
will not be made for anything else. In the future, we can add the table
with the correct columns when we support more databases.