### PR TITLE
CORE-11674 renaming APIs, avro, liquibase to isVisible

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/ledger/persistence/FindUnconsumedVisibleStates.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/ledger/persistence/FindUnconsumedVisibleStates.avsc
@@ -1,7 +1,7 @@
 {
   "type": "record",
   "name": "FindUnconsumedStatesByType",
-  "doc": "Retrieve the unconsumed relevant states of specific type. One of several types of ledger persistence request {@link LedgerPersistenceRequest}",
+  "doc": "Retrieve the unconsumed visible states of specific type. One of several types of ledger persistence request {@link LedgerPersistenceRequest}",
   "namespace": "net.corda.data.ledger.persistence",
   "fields": [
     {

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/ledger/persistence/PersistTransaction.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/ledger/persistence/PersistTransaction.avsc
@@ -15,12 +15,12 @@
       "doc": "the transaction status"
     },
     {
-      "name": "relevantStatesIndexes",
+      "name": "visibleStatesIndexes",
       "type": {
         "type" : "array",
         "items" : "int"
       },
-      "doc": "indexes of the relevant states"
+      "doc": "indexes of the visible states"
     }
   ]
 }

--- a/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v1.0.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v1.0.xml
@@ -192,5 +192,5 @@
                        tableName="utxo_transaction_cpk"/>
     </changeSet>
 
-    <include file="net/corda/db/schema/vnode-vault/migration/ledger-utxo-relevant-transaction-state-creation-v1.0.xml"/>
+    <include file="net/corda/db/schema/vnode-vault/migration/ledger-utxo-visible-transaction-state-creation-v1.0.xml"/>
 </databaseChangeLog>

--- a/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-visible-transaction-state-creation-v1.0.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-visible-transaction-state-creation-v1.0.xml
@@ -3,9 +3,9 @@
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
 
-    <changeSet author="R3.Corda" id="ledger-utxo-relevant-transaction-state-creation-postgres-v1.0" dbms="postgresql">
+    <changeSet author="R3.Corda" id="ledger-utxo-visible-transaction-state-creation-postgres-v1.0" dbms="postgresql">
 
-        <createTable tableName="utxo_relevant_transaction_state">
+        <createTable tableName="utxo_visible_transaction_state">
             <column name="transaction_id" type="VARCHAR(160)">
                 <constraints nullable="false"/>
             </column>
@@ -26,11 +26,11 @@
             </column>
         </createTable>
         <addPrimaryKey columnNames="transaction_id, group_idx, leaf_idx"
-                       constraintName="utxo_relevant_transaction_state_pkey"
-                       tableName="utxo_relevant_transaction_state"/>
+                       constraintName="utxo_visible_transaction_state_pkey"
+                       tableName="utxo_visible_transaction_state"/>
         <addForeignKeyConstraint baseColumnNames="transaction_id,group_idx,leaf_idx"
-                                 baseTableName="utxo_relevant_transaction_state"
-                                 constraintName="fk_utxo_relevant_transaction_state"
+                                 baseTableName="utxo_visible_transaction_state"
+                                 constraintName="fk_utxo_visible_transaction_state"
                                  referencedColumnNames="transaction_id,group_idx,leaf_idx"
                                  referencedTableName="utxo_transaction_component"/>
     </changeSet>

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 718
+cordaApiRevision = 719
 
 # Main
 kotlinVersion = 1.8.10


### PR DESCRIPTION
The functions to determine whether a participant can see states has been renamed from isRelevant to isVisible. This PR is consistently renaming relevantState etc. to visibleState (in API, Avro and DB tables).