### PR TITLE
CORE-9350 Rename truststore to trustroot in the mgm registration context

### DIFF
--- a/data/membership-schema/src/main/resources/net/corda/schema/membership/mgm/registration/1.0/corda.mgm.registration.json
+++ b/data/membership-schema/src/main/resources/net/corda/schema/membership/mgm/registration/1.0/corda.mgm.registration.json
@@ -13,11 +13,11 @@
       "description": "The P2P connection URL protocol version. Can be multiple specified by index.",
       "type": "string"
     },
-    "^corda.group.truststore.session.[0-9]+$": {
+    "^corda.group.trustroot.session.[0-9]+$": {
       "description": "Session trust root certificates in PEM format for validating session certificates in the group. Can be multiple specified by index.",
       "type": "string"
     },
-    "^corda.group.truststore.tls.[0-9]+$": {
+    "^corda.group.trustroot.tls.[0-9]+$": {
       "description": "TLS trust root certificates in PEM format for validating TLS certificates in the group. Can be multiple specified by index.",
       "type": "string"
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 723
+cordaApiRevision = 724
 
 # Main
 kotlinVersion = 1.8.10


### PR DESCRIPTION
Change field names in the MGM registration schema.