### PR TITLE
CORE-11140 - Remove minimum platform version from group parameters

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 723
+cordaApiRevision = 724
 
 # Main
 kotlinVersion = 1.8.10

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 724
+cordaApiRevision = 725
 
 # Main
 kotlinVersion = 1.8.10

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 721
+cordaApiRevision = 722
 
 # Main
 kotlinVersion = 1.8.10

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 722
+cordaApiRevision = 723
 
 # Main
 kotlinVersion = 1.8.10

--- a/membership/src/main/java/net/corda/v5/membership/GroupParameters.java
+++ b/membership/src/main/java/net/corda/v5/membership/GroupParameters.java
@@ -20,14 +20,12 @@ import java.util.Collection;
  * <ul>
  * <li>Java:<pre>{@code
  * GroupParameters groupParameters = fullTransaction.getMembershipParameters();
- * int minimumPlatformVersion = groupParameters.getMinimumPlatformVersion();
  * Instant modifiedTime = groupParameters.getModifiedTime();
  * int epoch = groupParameters.getEpoch();
  * Collection<NotaryInfo> notaries = groupParameters.getNotaries();
  * }</pre></li>
  * <li>Kotlin:<pre>{@code
  * val groupParameters = fullTransaction.membershipParameters
- * val minimumPlatformVersion = groupParameters?.minimumPlatformVersion
  * val modifiedTime = groupParameters?.modifiedTime
  * val epoch = groupParameters?.epoch
  * val notaries = groupParameters?.notaries
@@ -36,11 +34,6 @@ import java.util.Collection;
  */
 @CordaSerializable
 public interface GroupParameters extends LayeredPropertyMap {
-
-    /**
-     * @return The minimum platform version required to be running on in order to transact within a group.
-     */
-    int getMinimumPlatformVersion();
 
     /**
      * @return The {@link Instant} representing the last time the group parameters were modified.

--- a/membership/src/test/java/net/corda/v5/membership/GroupParametersJavaApiTest.java
+++ b/membership/src/test/java/net/corda/v5/membership/GroupParametersJavaApiTest.java
@@ -41,15 +41,6 @@ public class GroupParametersJavaApiTest {
     }
 
     @Test
-    public void minimumPlatformVersion() {
-        when(groupParameters.getMinimumPlatformVersion()).thenReturn(5);
-        final int platformVersion = groupParameters.getMinimumPlatformVersion();
-
-        assertThat(platformVersion).isNotNull();
-        assertThat(platformVersion).isEqualTo(5);
-    }
-
-    @Test
     public void modifiedTime() {
         final Instant instant = Instant.now();
         when(groupParameters.getModifiedTime()).thenReturn(instant);


### PR DESCRIPTION
Removing minimum platform version from the `GroupParameters`. There is no use for it in Corda 5 at the moment.