### PR TITLE
CORE-11786 Remove `SecureHash.getBytes`

### DIFF
--- a/crypto/src/main/java/net/corda/v5/crypto/SecureHash.java
+++ b/crypto/src/main/java/net/corda/v5/crypto/SecureHash.java
@@ -18,13 +18,6 @@ public interface SecureHash {
     String getAlgorithm();
 
     /**
-     * The result bytes of the hashing operation with the specified digest algorithm. The specified digest algorithm
-     * can be acquired through {@link SecureHash#getAlgorithm()}
-     */
-    @NotNull
-    byte[] getBytes();
-
-    /**
      * Returns hexadecimal representation of the hash value.
      */
     @NotNull

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 726
+cordaApiRevision = 727
 
 # Main
 kotlinVersion = 1.8.10


### PR DESCRIPTION
`SecureHash` API should be enough to users to just provide the hex string form of the hash.

- removes public API `SecureHash.getBytes`

runtime-os PR: [#3412](https://github.com/corda/corda-runtime-os/pull/3412)