### PR TITLE
CORE-11845: add columns to crypto_wrapping_key for key rotation

### DIFF
--- a/data/config-schema/src/main/java/net/corda/schema/configuration/ConfigKeys.java
+++ b/data/config-schema/src/main/java/net/corda/schema/configuration/ConfigKeys.java
@@ -9,7 +9,7 @@ public final class ConfigKeys {
     // publishing changes to one of the config sections defined by a key, and readers will use the keys to
     // determine which config section a given update is for.
     public static final String BOOT_CONFIG = "corda.boot";
-    public static final String CRYPTO_CONFIG = "corda.cryptoLibrary";
+    public static final String CRYPTO_CONFIG = "corda.crypto";
     public static final String DB_CONFIG = "corda.db";
     public static final String FLOW_CONFIG = "corda.flow";
     public static final String MESSAGING_CONFIG = "corda.messaging";

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/crypto/1.0/corda.crypto.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/crypto/1.0/corda.crypto.json
@@ -1,10 +1,37 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://corda.r3.com/net/corda/schema/configuration/cryptoLibrary/1.0/corda.cryptoLibrary.json",
+  "$id": "https://corda.r3.com/net/corda/schema/configuration/crypto/1.0/corda.crypto.json",
   "title": "Corda Crypto Library Configuration Schema",
   "description": "Configuration schema for the crypto library subsection.",
   "type": "object",
   "properties": {
+    "wrappingKeys": {
+      "description" : "Key derivation parameters for wrapping keys supplied in config",
+      "type": "array",
+      "properties": {
+        "alias" : {
+          "description": "The alias for the wrapping key.",
+          "type" : "string"
+        },
+        "algorithm": {
+          "description": "Key derivation function and wrapping key algorithm selection",
+          "type": "string",
+          "default": "PBKDF2WithHmacSHA256"
+        },
+        "salt": {
+          "description": "Salt for the key derivation function",
+          "type": "string"
+        },
+        "passphrase": {
+          "description": "Passphrase for the key derivation function",
+          "type": "string"
+        }
+      }
+    },
+    "defaultWrappingKey": {
+      "description": "The default wrapping key, which must be in the wrappingKeys array.",
+      "type": "string"
+    },
     "cryptoConnectionFactory": {
       "description": "Settings for database connections factory's cache of EntityManagerFactory(s)",
       "type": "object",
@@ -279,6 +306,42 @@
                         },
                         "additionalProperties": false
                       },
+                      "wrappingKeys": {
+                        "description" : "Key derivation parameters for wrapping keys supplied in config",
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "alias": {
+                              "description": "The alias for the wrapping key.",
+                              "type": "string"
+                            },
+                            "algorithm": {
+                              "description": "Key derivation function and wrapping key algorithm selection",
+                              "type": "string",
+                              "default": "PBKDF2WithHmacSHA256"
+                            },
+                            "salt": {
+                              "description": "Salt for the key derivation function",
+                              "type": "string"
+                            },
+                            "passphrase": {
+                              "description": "Passphrase for the key derivation function",
+                              "type": "string"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "required": [
+                            "alias",
+                            "salt",
+                            "passphrase"
+                          ]
+                        }
+                      },
+                      "defaultWrappingKey": {
+                        "description": "The default wrapping key, which must be in the wrappingKeys array.",
+                        "type": "string"
+                      },
                       "wrappingKeyMap": {
                         "description": "Settings for the wrapping keys map",
                         "type": "object",
@@ -291,14 +354,6 @@
                               "TRANSIENT"
                             ],
                             "default": "CACHING"
-                          },
-                          "salt": {
-                            "description": "Salt for the root master wrapping key",
-                            "type": "string"
-                          },
-                          "passphrase": {
-                            "description": "Passphrase for the root master wrapping key",
-                            "type": "string"
                           },
                           "cache": {
                             "description": "Settings for the cache if the type is CACHING",
@@ -319,11 +374,7 @@
                             "additionalProperties": false
                           }
                         },
-                        "additionalProperties": false,
-                        "required": [
-                          "salt",
-                          "passphrase"
-                        ]
+                        "additionalProperties": false
                       },
                       "wrapping": {
                         "description": "Number of keys which can be handled by the HSM, -1 means unlimited capacity",

--- a/data/db-schema/src/main/java/net/corda/db/schema/DbSchema.java
+++ b/data/db-schema/src/main/java/net/corda/db/schema/DbSchema.java
@@ -51,6 +51,7 @@ public final class DbSchema {
     public static final String CRYPTO = "CRYPTO";
     public static final String CRYPTO_WRAPPING_KEY_TABLE = "crypto_wrapping_key";
     public static final String CRYPTO_SIGNING_KEY_TABLE = "crypto_signing_key";
+    public static final String CRYPTO_SIGNING_KEY_MATERIAL_TABLE = "crypto_signing_key_material";
     public static final String CRYPTO_HSM_CONFIG_TABLE = "crypto_hsm_config";
     public static final String CRYPTO_HSM_CATEGORY_MAP_TABLE = "crypto_hsm_category_map";
     public static final String CRYPTO_HSM_ASSOCIATION_TABLE = "crypto_hsm_association";

--- a/data/db-schema/src/main/resources/net/corda/db/schema/crypto/migration/crypto-creation-v1.0.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/crypto/migration/crypto-creation-v1.0.xml
@@ -2,12 +2,27 @@
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <!--
+     For now, the schema must be identical between here and the 
+     virtual node schema (in ../../vnode-crypto/migration/crypto-creation-v1.0.xml)
+     since the crypto processor uses the same code irrespective of where the table resides.
+     
+     We could just include the same changeset files in both cases, but that might confuse readers
+     and liquibase, so instead we have to keep the content in sync.  
+     -->
     <changeSet author="R3.Corda" id="crypto-creation-v1.0">
         <createTable tableName="crypto_wrapping_key">
+            <column name="id" type="UUID">
+                <constraints nullable="false"/>>
+            </column>
             <column name="alias" type="VARCHAR(64)">
                 <constraints nullable="false"/>
             </column>
-            <column name="created" type="TIMESTAMP">
+            <!-- generation of the wrapping key; higher generation numbers to be used to replaced expiring wrapping keys -->
+            <column name="generation" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
                 <constraints nullable="false"/>
             </column>
             <column name="encoding_version" type="INT">
@@ -19,11 +34,29 @@
             <column name="key_material" type="VARBINARY(1048576)">
                 <constraints nullable="false"/>
             </column>
+            <column name="rotation_date" type="TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <!-- If true, the parent key is a wrapping key in this table, and 
+               parent_key_reference is the id of that wrapping key. If false, the parent_key
+               is a corda config path. -->  
+            <column name="is_parent_key_managed" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <!-- the identity of the key used for key_material; may reference a root wrapping key outside the database, 
+                 so there is no foreign key constraint -->
+            <column name="parent_key_reference" type="VARCHAR(256)">
+                <constraints nullable="false"/>
+            </column>
         </createTable>
-        <addPrimaryKey  columnNames="alias"
+        <addPrimaryKey  columnNames="id"
                         tableName="crypto_wrapping_key"
                         constraintName="crypto_wrapping_key_pk"/>
-
+        <addUniqueConstraint columnNames="alias, generation"
+                             tableName="crypto_wrapping_key"
+                             constraintName="alias_and_generation_are_unique"/>
+        <!-- TODO FK constraint back to crypto_wrapping_key on parent_key_reference when is_parentkey_managed=true, if possible
+             (or remodel so we can) -->
         <createTable tableName="crypto_hsm_association">
             <column name="id" type="VARCHAR(36)">
                 <constraints nullable="false"/>
@@ -88,16 +121,21 @@
         and liquibase, so instead we have to keep the content in sync.  
         -->
         <createTable tableName="crypto_signing_key">
+            <column name="id" type="UUID">
+                <constraints nullable="false"/>
+            </column>
             <column name="tenant_id" type="VARCHAR(12)">
                 <constraints nullable="false"/>
             </column>
+            <!-- short hash (first 12 hex chars of SHA256) of the public key --> 
             <column name="key_id" type="CHAR(12)">
                 <constraints nullable="false"/>
             </column>
+            <!-- full SHA256hash of the public key -->
             <column name="full_key_id" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="timestamp" type="TIMESTAMP">
+            <column name="created" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
                 <constraints nullable="false"/>
             </column>
             <column name="category" type="VARCHAR(64)">
@@ -109,13 +147,7 @@
             <column name="public_key" type="VARBINARY(1048576)">
                 <constraints nullable="false"/>
             </column>
-            <column name="key_material" type="VARBINARY(1048576)">
-                <constraints nullable="true"/>
-            </column>
             <column name="encoding_version" type="INT">
-                <constraints nullable="true"/>
-            </column>
-            <column name="master_key_alias" type="VARCHAR(64)">
                 <constraints nullable="true"/>
             </column>
             <column name="alias" type="VARCHAR(64)">
@@ -135,6 +167,9 @@
             </column>
         </createTable>
         <addPrimaryKey constraintName="crypto_signing_key_pk"
+                       tableName="crypto_signing_key"
+                       columnNames="id"/>
+        <addUniqueConstraint constraintName="crypto_signing_key_unique"
                        tableName="crypto_signing_key"
                        columnNames="tenant_id, key_id"/>
         <createIndex indexName="crypto_signing_key_full_key_idx"
@@ -156,5 +191,25 @@
             <column name="tenant_id"/>
             <column name="alias"/>
         </createIndex>
+        <createTable tableName="crypto_signing_key_material">
+            <column name="wrapping_key_id" type="UUID">
+                <constraints nullable="false"/>
+            </column>
+            <column name="signing_key_id" type="UUID">
+                <constraints nullable="false"/>
+            </column>
+            <column name="signing_key_material" type="VARBINARY(1048576)">
+                <constraints nullable="false"/>
+            </column>
+            <!-- when the key material was generated -->
+            <column name="created" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+        <addPrimaryKey constraintName="crypto_signing_key_material_pk"
+                       tableName="crypto_signing_key_material"
+                       columnNames="signing_key_id, wrapping_key_id"/>
+        <!-- TODO FK constraint to crypto_wrapping_key on (wrapping_key_alias, wrapping_key_generation) -->
+        <!-- TODO FK constraint to crypto_signing_key on (signing_key_alias, signing_key_generation) -->
     </changeSet>
 </databaseChangeLog>

--- a/data/db-schema/src/main/resources/net/corda/db/schema/vnode-crypto/migration/vnode-crypto-creation-v1.0.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/vnode-crypto/migration/vnode-crypto-creation-v1.0.xml
@@ -2,26 +2,140 @@
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+    <!--
+    For now, the crypto_signing_key table schema must be identical between here and the 
+    cluster schema (in ../../crypto/migration/crypto-creation-v1.0.xml)
+    since the crypto processor uses the same code irrespective of where the table resides.
+    
+    We could just include the same changeset files in both cases, but that might confuse readers
+    and liquibase, so instead we have to keep the content in sync.  
+    -->
     <changeSet author="R3.Corda" id="vnode-crypto-creation-v1.0">
+        <createTable tableName="crypto_wrapping_key">
+            <column name="id" type="UUID">
+                <constraints nullable="false"/>>
+            </column>
+            <column name="alias" type="VARCHAR(64)">
+                <constraints nullable="false"/>
+            </column>
+            <!-- generation of the wrapping key; higher generation numbers to be used to replaced expiring wrapping keys -->
+            <column name="generation" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="encoding_version" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="algorithm_name" type="VARCHAR(64)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="key_material" type="VARBINARY(1048576)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="rotation_date" type="TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <!-- If true, the parent key is a wrapping key in this table, and 
+               parent_key_reference is the id of that wrapping key. If false, the parent_key
+               is a corda config path. -->
+            <column name="is_parent_key_managed" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <!-- the identity of the key used for key_material; may reference a root wrapping key outside the database, 
+                 so there is no foreign key constraint -->
+            <column name="parent_key_reference" type="VARCHAR(256)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+        <addPrimaryKey  columnNames="id"
+                        tableName="crypto_wrapping_key"
+                        constraintName="crypto_wrapping_key_pk"/>
+        <addUniqueConstraint columnNames="alias, generation"
+                             tableName="crypto_wrapping_key"
+                             constraintName="alias_and_generation_are_unique"/>
+        <!-- TODO FK constraint back to crypto_wrapping_key on parent_key_reference when is_parentkey_managed=true, if possible
+             (or remodel so we can) -->
+        <createTable tableName="crypto_hsm_association">
+            <column name="id" type="VARCHAR(36)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="tenant_id" type="VARCHAR(12)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="hsm_id" type="VARCHAR(36)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="timestamp" type="TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="master_key_alias" type="VARCHAR(30)">
+                <constraints nullable="true"/>
+            </column>
+        </createTable>
+        <addPrimaryKey  columnNames="id"
+                        tableName="crypto_hsm_association"
+                        constraintName="crypto_hsm_association_pk"/>
+        <addUniqueConstraint columnNames="tenant_id, hsm_id"
+                             tableName="crypto_hsm_association"
+                             constraintName="crypto_hsm_association_uc"/>
+
+        <createTable tableName="crypto_hsm_category_association">
+            <column name="id" type="VARCHAR(36)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="tenant_id" type="VARCHAR(12)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="category" type="VARCHAR(20)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="hsm_association_id" type="VARCHAR(36)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="timestamp" type="TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+            <column name="deprecated_at" type="BIGINT">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+        <addPrimaryKey  columnNames="id"
+                        tableName="crypto_hsm_category_association"
+                        constraintName="crypto_hsm_category_association_pk"/>
+        <addUniqueConstraint columnNames="tenant_id, category, deprecated_at"
+                             tableName="crypto_hsm_category_association"
+                             constraintName="crypto_hsm_category_association_uc"/>
+        <addForeignKeyConstraint  baseColumnNames="hsm_association_id"
+                                  baseTableName="crypto_hsm_category_association"
+                                  referencedColumnNames="id"
+                                  referencedTableName="crypto_hsm_association"
+                                  constraintName="crypto_hsm_category_association_fk1"/>
         <!--
         For now, the crypto_signing_key table schema must be identical between here and the 
         virtual node schema (in ../../crypto/migration/crypto-creation-v1.0.xml)
         since the crypto processor uses the same code irrespective of where the table resides.
-        
+       
         We could just include the same changeset files in both cases, but that might confuse readers
         and liquibase, so instead we have to keep the content in sync.  
         -->
         <createTable tableName="crypto_signing_key">
+            <column name="id" type="UUID">
+                <constraints nullable="false"/>
+            </column>
             <column name="tenant_id" type="VARCHAR(12)">
                 <constraints nullable="false"/>
             </column>
+            <!-- short hash (first 12 hex chars of SHA256) of the public key -->
             <column name="key_id" type="CHAR(12)">
                 <constraints nullable="false"/>
             </column>
+            <!-- full SHA256hash of the public key -->
             <column name="full_key_id" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="timestamp" type="TIMESTAMP">
+            <column name="created" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
                 <constraints nullable="false"/>
             </column>
             <column name="category" type="VARCHAR(64)">
@@ -33,13 +147,7 @@
             <column name="public_key" type="VARBINARY(1048576)">
                 <constraints nullable="false"/>
             </column>
-            <column name="key_material" type="VARBINARY(1048576)">
-                <constraints nullable="true"/>
-            </column>
             <column name="encoding_version" type="INT">
-                <constraints nullable="true"/>
-            </column>
-            <column name="master_key_alias" type="VARCHAR(64)">
                 <constraints nullable="true"/>
             </column>
             <column name="alias" type="VARCHAR(64)">
@@ -60,7 +168,10 @@
         </createTable>
         <addPrimaryKey constraintName="crypto_signing_key_pk"
                        tableName="crypto_signing_key"
-                       columnNames="tenant_id, key_id"/>
+                       columnNames="id"/>
+        <addUniqueConstraint constraintName="crypto_signing_key_unique"
+                             tableName="crypto_signing_key"
+                             columnNames="tenant_id, key_id"/>
         <createIndex indexName="crypto_signing_key_full_key_idx"
                      tableName="crypto_signing_key">
             <column name="tenant_id"/>
@@ -80,5 +191,25 @@
             <column name="tenant_id"/>
             <column name="alias"/>
         </createIndex>
+        <createTable tableName="crypto_signing_key_material">
+            <column name="wrapping_key_id" type="UUID">
+                <constraints nullable="false"/>
+            </column>
+            <column name="signing_key_id" type="UUID">
+                <constraints nullable="false"/>
+            </column>
+            <column name="signing_key_material" type="VARBINARY(1048576)">
+                <constraints nullable="false"/>
+            </column>
+            <!-- when the key material was generated -->
+            <column name="created" type="TIMESTAMP" defaultValueComputed="CURRENT_TIMESTAMP">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+        <addPrimaryKey constraintName="crypto_signing_key_material_pk"
+                       tableName="crypto_signing_key_material"
+                       columnNames="signing_key_id, wrapping_key_id"/>
+        <!-- TODO FK constraint to crypto_wrapping_key on (wrapping_key_alias, wrapping_key_generation) -->
+        <!-- TODO FK constraint to crypto_signing_key on (signing_key_alias, signing_key_generation) -->
     </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
We do not intend to implement key rotation at this time, but we have got far enough with the design that we can see making some schema changes now before we need to supply migrations will make implementation at a later date easier, and deploying releases that introduce those changes less disruptive.

Move out signing key material into a new table table crypto_signing_key_material,  so that it is possible to store the same private key wrapped by mutliple differnet wrapping keys. This allows us to support incremental key rotation.  To facilitate this, add a synthetic primary UUID key to the signing and wrapping key tables.

Add a rotation date column to wrapping keys. Currently, this can be populated to the far future, but if it is set to a an upcoming time would tirgger rotation. 

Include a reference to parent wrapping key from signing keys, a flag to indicate whether the wrapping key is stored in the crypto processor.

Rename timestamp in crypto tables to be created, which is more specific.

Rename cryptoLibrary in the top level of the configuration to be simply crypto instead, to improve consistency with other config node names.

