### PR TITLE
CORE-10422 Interop responder 

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/flow/FlowInitiatorType.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/flow/FlowInitiatorType.avsc
@@ -5,6 +5,7 @@
   "doc": "Represents the type flow initiator.",
   "symbols": [
      "RPC",
-     "P2P"
+     "P2P",
+     "INTEROP"
   ]
 }


### PR DESCRIPTION
New value for `flow initiator`, so any downstream processors can check if this was an Interop started flow.
Merging this tiny code change before the full functionality of the ticket is finises in `corda-runtime-os` greatly simplifies juggling with branches and builds.