### PR TITLE
CORE-11837: Remove sessionInitiationKeys from the member info

### DIFF
--- a/membership/src/main/java/net/corda/v5/membership/MemberInfo.java
+++ b/membership/src/main/java/net/corda/v5/membership/MemberInfo.java
@@ -24,7 +24,6 @@ import java.util.List;
  * List<PublicKey> ledgerKeys = memberInfo.getLedgerKeys();
  * Long serial = memberInfo.getSerial();
  * int platformVersion = memberInfo.getPlatformVersion();
- * var sessionKeys = memberInfo.getSessionInitiationKeys();
  * Boolean isActive = memberInfo.isActive();
  * }</pre></li>
  * <li>Kotlin:<pre>{@code
@@ -34,7 +33,6 @@ import java.util.List;
  * val ledgerKeys: kotlin.collections.List<PublicKey> = memberInfo.ledgerKeys
  * val serial: Long = memberInfo.serial
  * val platformVersion: Int = memberInfo.platformVersion
- * val sessionKeys: PublicKey = memberInfo.sessionInitiationKeys
  * val isActive: Boolean = memberInfo.isActive
  * }</pre></li>
  * </ul>
@@ -58,11 +56,6 @@ public interface MemberInfo {
      * exists.
      */
     @NotNull MemberX500Name getName();
-
-    /**
-     * @return Member's session initiation keys.
-     */
-    @NotNull List<PublicKey> getSessionInitiationKeys();
 
     /**
      * @return List of current and previous (rotated) ledger keys, which member can still use to sign unspent

--- a/membership/src/test/java/net/corda/v5/membership/MemberInfoJavaApiTest.java
+++ b/membership/src/test/java/net/corda/v5/membership/MemberInfoJavaApiTest.java
@@ -69,18 +69,6 @@ public class MemberInfoJavaApiTest {
     }
 
     @Test
-    public void getSessionKey() {
-        PublicKey testPublicKey = mock(PublicKey.class);
-        when(memberInfo.getSessionInitiationKeys()).thenReturn(List.of(testPublicKey));
-
-        var results = memberInfo.getSessionInitiationKeys();
-
-        assertThat(results).contains(testPublicKey);
-
-        verify(memberInfo, times(1)).getSessionInitiationKeys();
-    }
-
-    @Test
     public void getPlatformVersion() {
         int test = 5;
         when(memberInfo.getPlatformVersion()).thenReturn(test);


### PR DESCRIPTION
Remove the sessionInitiationKeys from the member info public API. It should be used only by the membership and P2P layers. 

Runtime pull request is in https://github.com/corda/corda-runtime-os/pull/3492
E2E pull request in E2E pull request in https://github.com/corda/corda-e2e-tests/pull/52