### PR TITLE
CORE-10407: Build with Java 17 JDK, although still generate Java 11 classes.

### DIFF
--- a/base/build.gradle
+++ b/base/build.gradle
@@ -18,3 +18,6 @@ dependencies {
     testImplementation "org.assertj:assertj-core:$assertjVersion"
 }
 
+tasks.withType(Test).configureEach {
+    jvmArgs '--add-opens', 'java.base/java.nio=ALL-UNNAMED'
+}

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,6 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 import static org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
 import static org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_1_8
-import static org.gradle.api.JavaVersion.VERSION_11
 import static org.gradle.jvm.toolchain.JavaLanguageVersion.of
 
 buildscript {
@@ -42,7 +41,6 @@ snyk {
     autoUpdate = true
 }
 
-def rootProjectDir = rootDir
 def revision = {
     if (System.getenv("CORDA_REVISION")) {
         return System.getenv("CORDA_REVISION")
@@ -70,11 +68,12 @@ void configureKotlinForOSGi(Configuration configuration) {
 }
 
 def releaseType = System.getenv('RELEASE_TYPE') ?: "SNAPSHOT"
-def javaVersion = VERSION_11
+def jdkJavaVersion = 17
+def targetJavaVersion = 11
 
 logger.quiet("********************** CORDA BUILD **********************")
-if (!JavaVersion.current().isCompatibleWith(javaVersion)) {
-    throw new GradleException("The java version used ${JavaVersion.current()} is not compatible with the expected version ${javaVersion}.")
+if (!JavaVersion.current().isCompatibleWith(JavaVersion.toVersion(jdkJavaVersion))) {
+    throw new GradleException("The java version used ${JavaVersion.current()} is not compatible with the expected version ${jdkJavaVersion}.")
 }
 logger.quiet("SDK version: {}", JavaVersion.current())
 logger.quiet("JAVA HOME {}", System.getProperty("java.home"))
@@ -113,7 +112,7 @@ subprojects {
     pluginManager.withPlugin('java') {
         java {
             toolchain {
-                languageVersion = of(javaVersion.majorVersion.toInteger())
+                languageVersion = of(jdkJavaVersion)
             }
             withSourcesJar()
         }
@@ -246,6 +245,7 @@ subprojects {
         def compilerArgs = options.compilerArgs
         compilerArgs << '-parameters'
 
+        options.release = targetJavaVersion
         options.encoding = 'UTF-8'
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -45,16 +45,16 @@ grgitPluginVersion = 4.0.2
 taskTreePluginVersion = 2.1.0
 javaxPersistenceApiVersion = 2.2
 hibernateVersion = 5.6.10.Final
-jacksonVersion = 2.14.0
+jacksonVersion = 2.14.1
 
 # Testing
 assertjVersion = 3.23.+
-junitVersion = 5.9.0
+junitVersion = 5.9.2
 mockitoVersion = 4.6.+
 mockitoKotlinVersion = 4.0.0
 
 # OSGi
-bndVersion = 6.3.1
+bndVersion = 6.4.0
 osgiVersion = 8.0.0
 osgiScrAnnotationVersion = 1.5.0
 


### PR DESCRIPTION
This change means that Gradle will run, build and test the `corda-api` artifacts using a Java 17 JDK, although it will still generate Java 11 classes.

Every developer will then need to install a Java 17 JDK!