### PR TITLE
CORE-10690 - Allow additional properties in group policy schema

### DIFF
--- a/data/membership-schema/src/main/resources/net/corda/schema/membership/group/policy/1.0/corda.group.policy.json
+++ b/data/membership-schema/src/main/resources/net/corda/schema/membership/group/policy/1.0/corda.group.policy.json
@@ -78,8 +78,7 @@
             "protocolParameters": {
               "$ref": "#/$defs/protocolParameters"
             }
-          },
-          "additionalProperties": false
+          }
         },
         "else": {
           "$comment": "Properties for a group policy generated for a member by an MGM",
@@ -100,8 +99,7 @@
             "protocolParameters": {
               "$ref": "#/$defs/protocolParameters"
             }
-          },
-          "additionalProperties": false
+          }
         }
       },
       "else": {
@@ -117,8 +115,7 @@
           "protocolParameters": {
             "$ref": "#/$defs/mgmProtocolParameters"
           }
-        },
-        "additionalProperties": false
+        }
       }
     },
     {
@@ -232,8 +229,7 @@
           "description": "The client certificate subject (valid only in mutual TLS type).",
           "type": "string"
         }
-      },
-      "additionalProperties": false
+      }
     },
     "protocolParameters": {
       "description": "All parameters required to perform the registration or synchronisation protocols.",
@@ -264,8 +260,7 @@
                 "type": "object"
               }
             }
-          },
-          "additionalProperties": false
+          }
         }
       }
     },


### PR DESCRIPTION
Switching `additionalProperties` to the default (`true`), so that group policy can be evolved in the future in a way that allows for interoperability across different versions (MGM vs members for dynamic networks or plugin vs members in static networks). Retained only for the flexible string-based key-value maps.