### PR TITLE
CORE-10049 - Added secrets bootstrap config

### DIFF
--- a/data/config-schema/src/main/java/net/corda/schema/configuration/ConfigKeys.java
+++ b/data/config-schema/src/main/java/net/corda/schema/configuration/ConfigKeys.java
@@ -42,7 +42,7 @@ public final class ConfigKeys {
     //
     // For instance:
     //   - EncryptionSecretsService in corda-runtime-os needs SECRETS_PASSPHRASE and SECRETS_SALT
-    //   - The Hashicorp Vault secrets add on needs SECRETS_SERVER_ADDRESS, SECRETS_SERVER_ADDRESS and
+    //   - The HashiCorp Vault secrets add on needs SECRETS_SERVER_ADDRESS, SECRETS_SERVER_ADDRESS and
     //     SECRETS_CREATED_SECRET_PATH
     //
     public static final String SECRETS_TYPE = "type";
@@ -53,6 +53,17 @@ public final class ConfigKeys {
     public static final String SECRETS_CREATED_SECRET_PATH = "createdSecretPath";
     public static final String WORKSPACE_DIR = "dir.workspace";
     public static final String TEMP_DIR = "dir.tmp";
+    // Optional extra Secrets Service configuration to control refresh and backoff durations in seconds
+    public static final String SECRET_REFRESH_PERIOD = "refreshPeriod";
+    public static final String SECRET_RETRY_BACKOFF = "retryBackoff";
+
+    // Secret declaration parent, used where values in the Config are to be read as secrets
+    // e.g. {"configSecret":{<secrets service specific secret config>}}
+    public static final String SECRET_KEY = "configSecret";
+    // HashiCorp Vault specific secret configuration properties, would be declared under the SECRET_KEY parent
+    public static final String SECRET_KEY_VAULT_PATH = "vaultPath";
+    public static final String SECRET_KEY_VAULT_KEY = "vaultKey";
+
 
     // Sandbox
     public static final String SANDBOX_CACHE_SIZE = "cache.size";


### PR DESCRIPTION
More bootstrap Config is required to integrate with HashiCorp Vault. These are for CORE-10049 and also CORE-9674.

Optional extra params which can be passed at bootstrapping:
- SECRET_REFRESH_PERIOD: A refresh period for secrets from Vault
- SECRET_RETRY_BACKOFF: A backoff period for automatic retries when Vault is not reachable

Keys and properties which define what a secret in the Config looks like. These were previously hard coded at multiple points of use, or defined outside of the api, which was incorrect as they are public facing.
- SECRET_KEY: The parent name of a secret in the Config
- SECRET_KEY_VAULT_PATH: The name of the property under SECRET_KEY which defines the path of the secret to locate it in the remote source
- SECRET_KEY_VAULT_KEY: The name of the property under SECRET_KEY which defines the key of the secret in the remote source at the specified SECRET_KEY_VAULT_PATH

This is a non-breaking change, only new values are declared.