### PR TITLE
CORE-12083 - Updated the avro schema `VirtualNodeInfo` and the database schema `config-creation-v1.0.xml`

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/virtualnode/VirtualNodeInfo.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/virtualnode/VirtualNodeInfo.avsc
@@ -68,6 +68,12 @@
       "type": [ "null", "string" ]
     },
     {
+      "name": "externalMessagingRouteConfig",
+      "type": [ "null", "string" ],
+      "default": null,
+      "doc": "Route configuration used for external messaging. Null value means that no configuration was provided."
+    },
+    {
       "name": "version",
       "type": "int"
     },

--- a/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/config-creation-v1.0.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/config-creation-v1.0.xml
@@ -311,6 +311,9 @@
             <column name="operation_in_progress" type="VARCHAR(255)">
                 <constraints nullable="true"/>
             </column>
+            <column name="external_messaging_route_config" type="TEXT">
+                <constraints nullable="true"/>
+            </column>
             <!-- audit -->
             <column name="entity_version" type="INT">
                 <constraints nullable="false"/>


### PR DESCRIPTION
Added the `externalMessagingRouteConfig` field to the avro schema `VirtualNodeInfo`.
Added the column `externalMessagingRouteConfi` column to the `virtual_node`.
The `externalMessagingRouteConfig` will contain the route configuration for external messaging. The field is a nullable string which will contain a JSON structure. The field can be `null` meaning no configuration has been provided.

`corda-runtime-os` PR: https://github.com/corda/corda-runtime-os/pull/3501