### PR TITLE
CORE-11255: Add initial platform version to FlowState

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/flow/state/checkpoint/Checkpoint.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/flow/state/checkpoint/Checkpoint.avsc
@@ -10,6 +10,11 @@
       "doc": "Internal, globally unique key for a flow instance."
     },
     {
+      "name": "initialPlatformVersion",
+      "type": "int",
+      "doc": "The platform version at the time the flow was started."
+    },
+    {
       "name": "pipelineState",
       "type": "net.corda.data.flow.state.checkpoint.PipelineState",
       "doc": "State required by the pipeline, e.g. to support retries."

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 740
+cordaApiRevision = 741
 
 # Main
 kotlinVersion = 1.8.10


### PR DESCRIPTION
Adding this will allow flows to react appropriately when the platform is upgraded across a suspend.