### PR TITLE
CORE-12034 Make `DigitalSignature` an interface on public API

### DIFF
--- a/crypto/src/main/java/net/corda/v5/crypto/DigitalSignature.java
+++ b/crypto/src/main/java/net/corda/v5/crypto/DigitalSignature.java
@@ -21,12 +21,9 @@ public interface DigitalSignature {
     interface WithKeyId extends DigitalSignature {
 
         /**
-         * The key id of the public key (public key hash) whose corresponding private key was used to sign the data
-         * TODO change the below to say that if composite key is passed in sign operation then key id will be of
-         *  firstly found key leaf
-         * (as if an instance
-         * of the {@link CompositeKey} is passed to the sign operation it may contain keys which are not actually owned by
-         * the member).
+         * The key id of the public key (public key hash) whose private key pair was used to sign the data. If the
+         * original key passed in to the sign operation is a {@link CompositeKey} then the key id, is the id of the
+         * composite key leaf used to produce the signature.
          */
         @NotNull
         SecureHash getBy();

--- a/crypto/src/main/java/net/corda/v5/crypto/DigitalSignature.java
+++ b/crypto/src/main/java/net/corda/v5/crypto/DigitalSignature.java
@@ -21,8 +21,8 @@ public interface DigitalSignature {
     interface WithKeyId extends DigitalSignature {
 
         /**
-         * The key id of the public key (public key hash) whose private key pair was used to sign the data. If the
-         * original key passed in to the sign operation is a {@link CompositeKey} then the key id, is the id of the
+         * Returns the key ID of the public key (public key hash) whose private key pair was used to sign the data. If the
+         * original key passed in to the sign operation is a {@link CompositeKey} then the key ID, is the ID of the
          * composite key leaf used to produce the signature.
          */
         @NotNull

--- a/crypto/src/main/java/net/corda/v5/crypto/DigitalSignature.java
+++ b/crypto/src/main/java/net/corda/v5/crypto/DigitalSignature.java
@@ -20,7 +20,6 @@ public interface DigitalSignature {
     @DoNotImplement
     interface WithKeyId extends DigitalSignature {
 
-        // TODO consider renaming to getKeyId() ?
         /**
          * The key id of the public key (public key hash) whose corresponding private key was used to sign the data
          * TODO change the below to say that if composite key is passed in sign operation then key id will be of

--- a/crypto/src/main/java/net/corda/v5/crypto/DigitalSignature.java
+++ b/crypto/src/main/java/net/corda/v5/crypto/DigitalSignature.java
@@ -21,7 +21,7 @@ public interface DigitalSignature {
     interface WithKeyId extends DigitalSignature {
 
         /**
-         * Returns the key ID of the public key (public key hash) whose private key pair was used to sign the data. If the
+         * Gets the key ID of the public key (public key hash) whose private key pair was used to sign the data. If the
          * original key passed in to the sign operation is a {@link CompositeKey} then the key ID, is the ID of the
          * composite key leaf used to produce the signature.
          */

--- a/crypto/src/main/java/net/corda/v5/crypto/DigitalSignature.java
+++ b/crypto/src/main/java/net/corda/v5/crypto/DigitalSignature.java
@@ -1,46 +1,35 @@
 package net.corda.v5.crypto;
 
 import net.corda.v5.base.annotations.CordaSerializable;
-import net.corda.v5.base.types.OpaqueBytes;
+import net.corda.v5.base.annotations.DoNotImplement;
 import org.jetbrains.annotations.NotNull;
 
 /**
  * A wrapper around a digital signature.
  */
+@DoNotImplement
 @CordaSerializable
-public class DigitalSignature extends OpaqueBytes {
-    public DigitalSignature(@NotNull byte[] bytes) {
-        super(bytes);
-    }
+public interface DigitalSignature {
+
+    @NotNull
+    byte[] getBytes();
 
     /**
      * A digital signature that identifies who is the owner of the signing key used to create this signature.
      */
-    public static class WithKeyId extends DigitalSignature {
+    @DoNotImplement
+    interface WithKeyId extends DigitalSignature {
 
+        // TODO consider renaming to getKeyId() ?
         /**
-         * Creates a new {@code WithKeyId} using the specified key ID and the signature ({@code bytes}).
-         *
-         * @param by      The ID of the public key (public key hash) whose corresponding private key used to sign the data
-         *                (as if an instance of the {@link CompositeKey} is passed to the sign operation it may contain
-         *                keys which are not actually owned by the member).
-         * @param bytes   The signature.
-         */
-        public WithKeyId(@NotNull SecureHash by, @NotNull byte[] bytes) {
-            super(bytes);
-            this.by = by;
-        }
-
-        /**
-         * Public key which corresponding private key was used to sign the data (as if an instance
+         * The key id of the public key (public key hash) whose corresponding private key was used to sign the data
+         * TODO change the below to say that if composite key is passed in sign operation then key id will be of
+         *  firstly found key leaf
+         * (as if an instance
          * of the {@link CompositeKey} is passed to the sign operation it may contain keys which are not actually owned by
          * the member).
          */
-        private final SecureHash by;
-
         @NotNull
-        public final SecureHash getBy() {
-            return this.by;
-        }
+        SecureHash getBy();
     }
 }

--- a/crypto/src/main/java/net/corda/v5/crypto/DigitalSignature.java
+++ b/crypto/src/main/java/net/corda/v5/crypto/DigitalSignature.java
@@ -23,7 +23,7 @@ public interface DigitalSignature {
         /**
          * Gets the key ID of the public key (public key hash) whose private key pair was used to sign the data. If the
          * original key passed in to the sign operation is a {@link CompositeKey} then the key ID, is the ID of the
-         * composite key leaf used to produce the signature.
+         * composite key leaf used to sign.
          */
         @NotNull
         SecureHash getBy();

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 736
+cordaApiRevision = 737
 
 # Main
 kotlinVersion = 1.8.10


### PR DESCRIPTION
- makes `DigitalSignature` an interface and decouples it from `OpaqueBytes` and `ByteSequence` on API
- adds `DigitalSignature.getBytes` (previously inherited from `OpaqueBytes`)
- makes `DigitalSignature.WithKeyId` an interface on API

runtime-os PR: [#3491](https://github.com/corda/corda-runtime-os/pull/3491)