### PR TITLE
CORE-3819: Configure default Gradle behaviour explicitly.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,6 +2,9 @@
 # because some versions here need to be matched by app authors in
 # their own projects. So don't get fancy with syntax!
 
+org.gradle.java.installations.auto-download=false
+org.gradle.jvmargs=-Dfile.encoding=UTF-8
+
 # Versioning
 cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change


### PR DESCRIPTION
Later versions of Gradle require org.gradle.java.installations.auto-download to be set explicitly.