### PR TITLE
CORE-10407: Resolve warnings about Java modules.

### DIFF
--- a/base/build.gradle
+++ b/base/build.gradle
@@ -18,3 +18,6 @@ dependencies {
     testImplementation "org.assertj:assertj-core:$assertjVersion"
 }
 
+tasks.withType(Test).configureEach {
+    jvmArgs '--add-opens', 'java.base/java.nio=ALL-UNNAMED'
+}

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,6 @@ snyk {
     autoUpdate = true
 }
 
-def rootProjectDir = rootDir
 def revision = {
     if (System.getenv("CORDA_REVISION")) {
         return System.getenv("CORDA_REVISION")

--- a/gradle.properties
+++ b/gradle.properties
@@ -52,12 +52,12 @@ jacksonVersion = 2.14.0
 
 # Testing
 assertjVersion = 3.23.+
-junitVersion = 5.9.0
+junitVersion = 5.9.2
 mockitoVersion = 4.6.+
 mockitoKotlinVersion = 4.0.0
 
 # OSGi
-bndVersion = 6.3.1
+bndVersion = 6.4.0
 osgiVersion = 8.0.0
 osgiScrAnnotationVersion = 1.5.0
 


### PR DESCRIPTION
Resolve build warnings about illegal module access.

Also upgrade to Bnd 6.4.0 and JUnit 5.9.2.
