### PR TITLE
CORE-12188 createTransactionBuilder function

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 741
+cordaApiRevision = 742
 
 # Main
 kotlinVersion = 1.8.10

--- a/ledger/ledger-consensual/src/main/java/net/corda/v5/ledger/consensual/ConsensualLedgerService.java
+++ b/ledger/ledger-consensual/src/main/java/net/corda/v5/ledger/consensual/ConsensualLedgerService.java
@@ -26,7 +26,7 @@ public interface ConsensualLedgerService {
      */
     @NotNull
     @Suspendable
-    ConsensualTransactionBuilder getTransactionBuilder();
+    ConsensualTransactionBuilder createTransactionBuilder();
 
     /**
      * Finds a {@link ConsensualSignedTransaction} in the vault by its transaction ID.

--- a/ledger/ledger-utxo/src/main/java/net/corda/v5/ledger/utxo/UtxoLedgerService.java
+++ b/ledger/ledger-utxo/src/main/java/net/corda/v5/ledger/utxo/UtxoLedgerService.java
@@ -28,7 +28,7 @@ public interface UtxoLedgerService {
      */
     @NotNull
     @Suspendable
-    UtxoTransactionBuilder getTransactionBuilder();
+    UtxoTransactionBuilder createTransactionBuilder();
 
     /**
      * Resolves the specified {@link StateRef} instances into {@link StateAndRef} instances of the specified {@link ContractState} type.


### PR DESCRIPTION
Rename getTransactionBuilder to createTransactionBuilder so it won't map to a property in kotlin - it does not behave like a property.

