### PR TITLE
CORE-12190 - Increase gateway default timeout for requests

### DIFF
--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/p2p.gateway/1.0/corda.p2p.gateway.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/p2p.gateway/1.0/corda.p2p.gateway.json
@@ -106,14 +106,14 @@
         "responseTimeout": {
           "description": "The time, in milliseconds, after which the delivery of a message is considered failed.",
           "type": "integer",
-          "default": 1000,
+          "default": 3000,
           "minimum": 100,
           "maximum": 10000
         },
         "retryDelay": {
           "description": "The time, in milliseconds, after which a message that previously failed is retried.",
           "type": "integer",
-          "default": 1000,
+          "default": 2000,
           "minimum": 100,
           "maximum": 10000
         },


### PR DESCRIPTION
The current default timeout for HTTP requests from the p2p gateway was 1 second, which is a bit tight for some scenarios. For example, our test infrastructure is not very well resourced and there were a lot of timeout exceptions in the logs. Raising the defaults slightly to make this a bit more tolerant to delays.

Conscious we also have e2e replay configuration at the link manager, but I intentionally didn't go down the path of adjusting this as that might require some fine tuning to be done properly and the intention of this change is to mainly reduce noise in our logs for easier troubleshooting. 

### Testing
Tested by comparing runs of e2e tests without and with this change. See [first build](https://ci02.dev.r3.com/blue/organizations/jenkins/Corda5%2Fcorda-runtime-os/detail/PR-3529/1/pipeline) in https://github.com/corda/corda-runtime-os/pull/3529
Before the change, I could find between 10 and 30 `TimeoutException`s in the gateway worker logs.
After the change, there was zero `TimeoutException`s in the gateway worker logs.