### PR TITLE
CORE-12255 Crypto API refinements

### DIFF
--- a/base/src/main/java/net/corda/v5/base/util/ByteArrays.java
+++ b/base/src/main/java/net/corda/v5/base/util/ByteArrays.java
@@ -1,4 +1,4 @@
-package net.corda.v5.base.types;
+package net.corda.v5.base.util;
 
 import org.jetbrains.annotations.NotNull;
 

--- a/base/src/main/java/net/corda/v5/base/util/EncodingUtils.java
+++ b/base/src/main/java/net/corda/v5/base/util/EncodingUtils.java
@@ -1,6 +1,5 @@
 package net.corda.v5.base.util;
 
-import net.corda.v5.base.types.ByteArrays;
 import org.jetbrains.annotations.NotNull;
 
 import java.nio.charset.Charset;

--- a/crypto/src/main/java/net/corda/v5/crypto/CompositeKey.java
+++ b/crypto/src/main/java/net/corda/v5/crypto/CompositeKey.java
@@ -46,7 +46,7 @@ public interface CompositeKey extends PublicKey {
      * key tree in question, and the total combined weight of all children is calculated for every intermediary node.
      * If all thresholds are satisfied, the composite key requirement is considered to be met.
      */
-    boolean isFulfilledBy(@NotNull Iterable<PublicKey> keysToCheck);
+    boolean isFulfilledBy(@NotNull Set<PublicKey> keysToCheck);
 
     /**
      * Set of all leaf keys of that {@link CompositeKey}.

--- a/crypto/src/main/java/net/corda/v5/crypto/KeyUtils.java
+++ b/crypto/src/main/java/net/corda/v5/crypto/KeyUtils.java
@@ -42,7 +42,7 @@ public final class KeyUtils {
      * @param otherKeys An {@link Iterable} sequence of {@link PublicKey}.
      * @return True if <code>key</code> is in otherKeys.
      */
-    public static boolean isKeyInSet(@NotNull PublicKey key, @NotNull Iterable<PublicKey> otherKeys) {
+    public static boolean isKeyInKeys(@NotNull PublicKey key, @NotNull Iterable<PublicKey> otherKeys) {
         if (key instanceof CompositeKey) {
             CompositeKey compositeKey = (CompositeKey) key;
             Set<PublicKey> leafKeys = compositeKey.getLeafKeys();
@@ -78,7 +78,7 @@ public final class KeyUtils {
      * @param firstKey  The key with the requirements.
      * @param otherKeys The key to check whether requirements are fulfilled.
      */
-    public static boolean isKeyFulfilledBy(@NotNull PublicKey firstKey, @NotNull Iterable<PublicKey> otherKeys) {
+    public static boolean isKeyFulfilledByKeys(@NotNull PublicKey firstKey, @NotNull Iterable<PublicKey> otherKeys) {
         if (firstKey instanceof CompositeKey) {
             CompositeKey firstKeyComposite = (CompositeKey) firstKey;
             return firstKeyComposite.isFulfilledBy(otherKeys);
@@ -100,8 +100,8 @@ public final class KeyUtils {
      * @param firstKey The key with the requirements.
      * @param otherKey The key to check whether requirements are fulfilled.
      */
-    public static boolean isKeyFulfilledBy(@NotNull PublicKey firstKey, @NotNull PublicKey otherKey) {
-        return isKeyFulfilledBy(firstKey,
+    public static boolean isKeyFulfilledByKeys(@NotNull PublicKey firstKey, @NotNull PublicKey otherKey) {
+        return isKeyFulfilledByKeys(firstKey,
                 Collections.singleton(otherKey));
     }
 }

--- a/crypto/src/main/java/net/corda/v5/crypto/KeyUtils.java
+++ b/crypto/src/main/java/net/corda/v5/crypto/KeyUtils.java
@@ -42,7 +42,7 @@ public final class KeyUtils {
      * @param otherKeys An {@link Iterable} sequence of {@link PublicKey}.
      * @return True if <code>key</code> is in otherKeys.
      */
-    public static boolean isKeyInKeys(@NotNull PublicKey key, @NotNull Set<PublicKey> otherKeys) {
+    public static boolean isKeyInSet(@NotNull PublicKey key, @NotNull Set<PublicKey> otherKeys) {
         if (key instanceof CompositeKey) {
             CompositeKey compositeKey = (CompositeKey) key;
             Set<PublicKey> leafKeys = compositeKey.getLeafKeys();
@@ -77,7 +77,7 @@ public final class KeyUtils {
      * @param key  The key with the requirements.
      * @param otherKeys The key to check whether requirements are fulfilled.
      */
-    public static boolean isKeyFulfilledByKeys(@NotNull PublicKey key, @NotNull Set<PublicKey> otherKeys) {
+    public static boolean isKeyFulfilledBy(@NotNull PublicKey key, @NotNull Set<PublicKey> otherKeys) {
         if (key instanceof CompositeKey) {
             CompositeKey firstKeyComposite = (CompositeKey) key;
             return firstKeyComposite.isFulfilledBy(otherKeys);
@@ -96,8 +96,8 @@ public final class KeyUtils {
      * @param key The key with the requirements.
      * @param otherKey The key to check whether requirements are fulfilled.
      */
-    public static boolean isKeyFulfilledByKeys(@NotNull PublicKey key, @NotNull PublicKey otherKey) {
-        return isKeyFulfilledByKeys(key,
+    public static boolean isKeyFulfilledBy(@NotNull PublicKey key, @NotNull PublicKey otherKey) {
+        return isKeyFulfilledBy(key,
                 Collections.singleton(otherKey));
     }
 }

--- a/crypto/src/main/java/net/corda/v5/crypto/KeyUtils.java
+++ b/crypto/src/main/java/net/corda/v5/crypto/KeyUtils.java
@@ -46,14 +46,11 @@ public final class KeyUtils {
         if (key instanceof CompositeKey) {
             CompositeKey compositeKey = (CompositeKey) key;
             Set<PublicKey> leafKeys = compositeKey.getLeafKeys();
-            // TODO Here we could be checking which is set has less items and iterate through that
-            for (PublicKey otherKey : otherKeys) {
-                if (leafKeys.contains(otherKey)) return true;
-            }
+            leafKeys.retainAll(otherKeys);
+            return !leafKeys.isEmpty();
         } else {
             return otherKeys.contains(key);
         }
-        return false;
     }
 
     /**

--- a/crypto/src/main/java/net/corda/v5/crypto/KeyUtils.java
+++ b/crypto/src/main/java/net/corda/v5/crypto/KeyUtils.java
@@ -42,17 +42,16 @@ public final class KeyUtils {
      * @param otherKeys An {@link Iterable} sequence of {@link PublicKey}.
      * @return True if <code>key</code> is in otherKeys.
      */
-    public static boolean isKeyInKeys(@NotNull PublicKey key, @NotNull Iterable<PublicKey> otherKeys) {
+    public static boolean isKeyInKeys(@NotNull PublicKey key, @NotNull Set<PublicKey> otherKeys) {
         if (key instanceof CompositeKey) {
             CompositeKey compositeKey = (CompositeKey) key;
             Set<PublicKey> leafKeys = compositeKey.getLeafKeys();
+            // TODO Here we could be checking which is set has less items and iterate through that
             for (PublicKey otherKey : otherKeys) {
                 if (leafKeys.contains(otherKey)) return true;
             }
         } else {
-            for (PublicKey otherKey : otherKeys) {
-                if (otherKey.equals(key)) return true;
-            }
+            return otherKeys.contains(key);
         }
         return false;
     }
@@ -75,18 +74,15 @@ public final class KeyUtils {
      * check fulfilment against a set of keys, without having to handle simple and composite keys separately (that is, this is
      * polymorphic).
      * 
-     * @param firstKey  The key with the requirements.
+     * @param key  The key with the requirements.
      * @param otherKeys The key to check whether requirements are fulfilled.
      */
-    public static boolean isKeyFulfilledByKeys(@NotNull PublicKey firstKey, @NotNull Iterable<PublicKey> otherKeys) {
-        if (firstKey instanceof CompositeKey) {
-            CompositeKey firstKeyComposite = (CompositeKey) firstKey;
+    public static boolean isKeyFulfilledByKeys(@NotNull PublicKey key, @NotNull Set<PublicKey> otherKeys) {
+        if (key instanceof CompositeKey) {
+            CompositeKey firstKeyComposite = (CompositeKey) key;
             return firstKeyComposite.isFulfilledBy(otherKeys);
         }
-        for (PublicKey otherKey : otherKeys) {
-            if (otherKey.equals(firstKey)) return true;
-        }
-        return false;
+        return otherKeys.contains(key);
     }
 
     /**
@@ -97,11 +93,11 @@ public final class KeyUtils {
      * Since we do not define composite keys as acceptable on the second argument of this function, this relation
      * is not reflexive, not symmetric and not transitive. 
      *
-     * @param firstKey The key with the requirements.
+     * @param key The key with the requirements.
      * @param otherKey The key to check whether requirements are fulfilled.
      */
-    public static boolean isKeyFulfilledByKeys(@NotNull PublicKey firstKey, @NotNull PublicKey otherKey) {
-        return isKeyFulfilledByKeys(firstKey,
+    public static boolean isKeyFulfilledByKeys(@NotNull PublicKey key, @NotNull PublicKey otherKey) {
+        return isKeyFulfilledByKeys(key,
                 Collections.singleton(otherKey));
     }
 }

--- a/crypto/src/main/java/net/corda/v5/crypto/SecureHash.java
+++ b/crypto/src/main/java/net/corda/v5/crypto/SecureHash.java
@@ -21,7 +21,7 @@ public interface SecureHash {
      * Returns hexadecimal representation of the hash value.
      */
     @NotNull
-    String getHexString();
+    String toHexString();
 
     /**
      * The delimiter used in the string form of a secure hash to separate the algorithm name from the hexadecimal
@@ -38,5 +38,5 @@ public interface SecureHash {
      * Example outcome of toString(): SHA-256:98AF8725385586B41FEFF205B4E05A000823F78B5F8F5C02439CE8F67A781D90
      */
     @NotNull
-    String getAlgorithmAndHexString();
+    String toAlgorithmAndHexString();
 }

--- a/crypto/src/main/java/net/corda/v5/crypto/SecureHash.java
+++ b/crypto/src/main/java/net/corda/v5/crypto/SecureHash.java
@@ -21,7 +21,7 @@ public interface SecureHash {
      * Returns hexadecimal representation of the hash value.
      */
     @NotNull
-    String toHexString();
+    String getHexString();
 
     /**
      * The delimiter used in the string form of a secure hash to separate the algorithm name from the hexadecimal
@@ -38,5 +38,5 @@ public interface SecureHash {
      * Example outcome of toString(): SHA-256:98AF8725385586B41FEFF205B4E05A000823F78B5F8F5C02439CE8F67A781D90
      */
     @NotNull
-    String toString();
+    String getAlgorithmAndHexString();
 }

--- a/crypto/src/main/java/net/corda/v5/crypto/SecureHash.java
+++ b/crypto/src/main/java/net/corda/v5/crypto/SecureHash.java
@@ -38,5 +38,5 @@ public interface SecureHash {
      * Example outcome of toString(): SHA-256:98AF8725385586B41FEFF205B4E05A000823F78B5F8F5C02439CE8F67A781D90
      */
     @NotNull
-    String toAlgorithmAndHexString();
+    String toString();
 }

--- a/crypto/src/test/kotlin/net/corda/v5/crypto/KeyUtilsTests.kt
+++ b/crypto/src/test/kotlin/net/corda/v5/crypto/KeyUtilsTests.kt
@@ -39,25 +39,25 @@ class KeyUtilsTests {
     @ParameterizedTest
     @MethodSource("publicKeys")
     fun `isKeyFulfilledBy overload with collection should return true if the keys are matching at least one given public key`(key: PublicKey) {
-        assertTrue(KeyUtils.isKeyFulfilledBy(key, listOf(generateKeyPair(ECDSA_SECP256R1_SPEC).public, key)))
+        assertTrue(KeyUtils.isKeyFulfilledBy(key, setOf(generateKeyPair(ECDSA_SECP256R1_SPEC).public, key)))
     }
 
 
     @ParameterizedTest
     @MethodSource("publicKeys")
     fun `isKeyFulfilledBy overload with collection should return false if the keys are not matching at least one given public key`(key: PublicKey) {
-        assertFalse(KeyUtils.isKeyFulfilledBy(key, listOf(generateKeyPair(ECDSA_SECP256R1_SPEC).public)))
+        assertFalse(KeyUtils.isKeyFulfilledBy(key, setOf(generateKeyPair(ECDSA_SECP256R1_SPEC).public)))
     }
     
     @ParameterizedTest
     @MethodSource("publicKeys") 
     fun `isKeyInSet claims a key is in a member of single-element set containing that key`(key: PublicKey) {
-        assertTrue(KeyUtils.isKeyInSet(key, listOf(key)))
+        assertTrue(KeyUtils.isKeyInSet(key, setOf(key)))
     }
 
     @ParameterizedTest
     @MethodSource("publicKeys")
     fun `isKeyInSet claims a key is not a member of single-element set containing another key`(key: PublicKey) {
-        assertFalse(KeyUtils.isKeyInSet(key, listOf(other)))
+        assertFalse(KeyUtils.isKeyInSet(key, setOf(other)))
     }
 }

--- a/crypto/src/test/kotlin/net/corda/v5/crypto/KeyUtilsTests.kt
+++ b/crypto/src/test/kotlin/net/corda/v5/crypto/KeyUtilsTests.kt
@@ -25,39 +25,39 @@ class KeyUtilsTests {
     @ParameterizedTest
     @MethodSource("publicKeys")
     fun `isKeyFulfilledBy overload with single key should return true if the keys are matching for a given public key`(key: PublicKey) {
-        assertTrue(KeyUtils.isKeyFulfilledByKeys(key, key))
+        assertTrue(KeyUtils.isKeyFulfilledBy(key, key))
     }
 
 
     @ParameterizedTest
     @MethodSource("publicKeys")
     fun `isKeyFulfilledBy overload with single key should return false if the keys are not matching for a given public key`(key: PublicKey) {
-        assertFalse(KeyUtils.isKeyFulfilledByKeys(key, generateKeyPair(ECDSA_SECP256K1_SPEC).public))
+        assertFalse(KeyUtils.isKeyFulfilledBy(key, generateKeyPair(ECDSA_SECP256K1_SPEC).public))
     }
 
 
     @ParameterizedTest
     @MethodSource("publicKeys")
     fun `isKeyFulfilledBy overload with collection should return true if the keys are matching at least one given public key`(key: PublicKey) {
-        assertTrue(KeyUtils.isKeyFulfilledByKeys(key, listOf(generateKeyPair(ECDSA_SECP256R1_SPEC).public, key)))
+        assertTrue(KeyUtils.isKeyFulfilledBy(key, listOf(generateKeyPair(ECDSA_SECP256R1_SPEC).public, key)))
     }
 
 
     @ParameterizedTest
     @MethodSource("publicKeys")
     fun `isKeyFulfilledBy overload with collection should return false if the keys are not matching at least one given public key`(key: PublicKey) {
-        assertFalse(KeyUtils.isKeyFulfilledByKeys(key, listOf(generateKeyPair(ECDSA_SECP256R1_SPEC).public)))
+        assertFalse(KeyUtils.isKeyFulfilledBy(key, listOf(generateKeyPair(ECDSA_SECP256R1_SPEC).public)))
     }
     
     @ParameterizedTest
     @MethodSource("publicKeys") 
     fun `isKeyInSet claims a key is in a member of single-element set containing that key`(key: PublicKey) {
-        assertTrue(KeyUtils.isKeyInKeys(key, listOf(key)))
+        assertTrue(KeyUtils.isKeyInSet(key, listOf(key)))
     }
 
     @ParameterizedTest
     @MethodSource("publicKeys")
     fun `isKeyInSet claims a key is not a member of single-element set containing another key`(key: PublicKey) {
-        assertFalse(KeyUtils.isKeyInKeys(key, listOf(other)))
+        assertFalse(KeyUtils.isKeyInSet(key, listOf(other)))
     }
 }

--- a/crypto/src/test/kotlin/net/corda/v5/crypto/KeyUtilsTests.kt
+++ b/crypto/src/test/kotlin/net/corda/v5/crypto/KeyUtilsTests.kt
@@ -25,39 +25,39 @@ class KeyUtilsTests {
     @ParameterizedTest
     @MethodSource("publicKeys")
     fun `isKeyFulfilledBy overload with single key should return true if the keys are matching for a given public key`(key: PublicKey) {
-        assertTrue(KeyUtils.isKeyFulfilledBy(key, key))
+        assertTrue(KeyUtils.isKeyFulfilledByKeys(key, key))
     }
 
 
     @ParameterizedTest
     @MethodSource("publicKeys")
     fun `isKeyFulfilledBy overload with single key should return false if the keys are not matching for a given public key`(key: PublicKey) {
-        assertFalse(KeyUtils.isKeyFulfilledBy(key, generateKeyPair(ECDSA_SECP256K1_SPEC).public))
+        assertFalse(KeyUtils.isKeyFulfilledByKeys(key, generateKeyPair(ECDSA_SECP256K1_SPEC).public))
     }
 
 
     @ParameterizedTest
     @MethodSource("publicKeys")
     fun `isKeyFulfilledBy overload with collection should return true if the keys are matching at least one given public key`(key: PublicKey) {
-        assertTrue(KeyUtils.isKeyFulfilledBy(key, listOf(generateKeyPair(ECDSA_SECP256R1_SPEC).public, key)))
+        assertTrue(KeyUtils.isKeyFulfilledByKeys(key, listOf(generateKeyPair(ECDSA_SECP256R1_SPEC).public, key)))
     }
 
 
     @ParameterizedTest
     @MethodSource("publicKeys")
     fun `isKeyFulfilledBy overload with collection should return false if the keys are not matching at least one given public key`(key: PublicKey) {
-        assertFalse(KeyUtils.isKeyFulfilledBy(key, listOf(generateKeyPair(ECDSA_SECP256R1_SPEC).public)))
+        assertFalse(KeyUtils.isKeyFulfilledByKeys(key, listOf(generateKeyPair(ECDSA_SECP256R1_SPEC).public)))
     }
     
     @ParameterizedTest
     @MethodSource("publicKeys") 
     fun `isKeyInSet claims a key is in a member of single-element set containing that key`(key: PublicKey) {
-        assertTrue(KeyUtils.isKeyInSet(key, listOf(key)))
+        assertTrue(KeyUtils.isKeyInKeys(key, listOf(key)))
     }
 
     @ParameterizedTest
     @MethodSource("publicKeys")
     fun `isKeyInSet claims a key is not a member of single-element set containing another key`(key: PublicKey) {
-        assertFalse(KeyUtils.isKeyInSet(key, listOf(other)))
+        assertFalse(KeyUtils.isKeyInKeys(key, listOf(other)))
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 742
+cordaApiRevision = 744
 
 # Main
 kotlinVersion = 1.8.10

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 744
+cordaApiRevision = 743
 
 # Main
 kotlinVersion = 1.8.10


### PR DESCRIPTION
- moves `ByteArrays` under utils
- changes functions in `KeyUtils` and `CompositeKey.isFulfilledBy` to accept `Set<PublicKey>` instead of `Iterable<PublicKey>` to improve their complexity

runtime-os PR: [#3541](https://github.com/corda/corda-runtime-os/pull/3541)