### PR TITLE
CORE-12143: Remove lingering and unused module configuration.

### DIFF
--- a/base/build.gradle
+++ b/base/build.gradle
@@ -17,7 +17,3 @@ dependencies {
     testApi 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     testImplementation "org.assertj:assertj-core:$assertjVersion"
 }
-
-tasks.withType(Test).configureEach {
-    jvmArgs '--add-opens', 'java.base/java.nio=ALL-UNNAMED'
-}


### PR DESCRIPTION
The tests this was configuring have been moved into `corda-runtime-os`.