### PR TITLE
CORE-9725 Adding constant to FlowContextProperties for CPK file checksums

### DIFF
--- a/application/src/main/java/net/corda/v5/application/flows/FlowContextPropertyKeys.java
+++ b/application/src/main/java/net/corda/v5/application/flows/FlowContextPropertyKeys.java
@@ -9,6 +9,7 @@ public final class FlowContextPropertyKeys {
     public static final String CPI_VERSION = "corda.cpiVersion";
     public static final String CPI_SIGNER_SUMMARY_HASH = "corda.cpiSignerSummaryHash";
     public static final String CPI_FILE_CHECKSUM = "corda.cpiFileChecksum";
+    public static final String CPK_FILE_CHECKSUM = "corda.cpkFileChecksum";
     public static final String INITIAL_PLATFORM_VERSION = "corda.initialPlatformVersion";
     public static final String INITIAL_SOFTWARE_VERSION = "corda.initialSoftwareVersion";
 }


### PR DESCRIPTION
Associated `corda-runtime-os` PR: https://github.com/corda/corda-runtime-os/pull/3543

As part of [CORE-9725](https://r3-cev.atlassian.net/browse/CORE-9725), external workers will now create sandboxes based on the CPKs which exist in the flow checkpoint at the point in time that the external event request is sent. To facilitate this, the CPK hashes will be added to external event context properties.

[CORE-9725]: https://r3-cev.atlassian.net/browse/CORE-9725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ