### PR TITLE
CORE-11477 Revisit crypto configuration

### DIFF
--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/crypto/1.0/corda.crypto.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/crypto/1.0/corda.crypto.json
@@ -181,40 +181,6 @@
             "defaultWrappingKey": {
               "description": "The default wrapping key, which must be in the wrappingKeys array.",
               "type": "string"
-            },
-            "wrapping": {
-              "description": "Number of keys which can be handled by the HSM, -1 means unlimited capacity",
-              "type": "object",
-              "default": {},
-              "properties": {
-                "name": {
-                  "description": "Wrapping type, DEFAULT - the wrapping key are stored in database, HSM - there is additional single master key defined in the HSM",
-                  "enum": [
-                    "DEFAULT",
-                    "HSM"
-                  ],
-                  "default": "DEFAULT"
-                },
-                "hsm": {
-                  "description": "Number of keys which can be handled by the HSM, -1 means unlimited capacity",
-                  "type": "object",
-                  "default": {},
-                  "properties": {
-                    "name": {
-                      "description": "HSM provider name",
-                      "type": "string"
-                    },
-                    "cfg": {
-                      "description": "HSM specific configuration",
-                      "type": "object",
-                      "default": {},
-                      "additionalProperties": true
-                    }
-                  },
-                  "additionalProperties": false
-                }
-              },
-              "additionalProperties": false
             }
           },
           "additionalProperties": false

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/crypto/1.0/corda.crypto.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/crypto/1.0/corda.crypto.json
@@ -5,28 +5,32 @@
   "description": "Configuration schema for the crypto library subsection.",
   "type": "object",
   "properties": {
-    "signingService": {
-      "description": "Settings for SigningService",
+    "caching": {
+      "description": "Caching settings",
       "type": "object",
       "default": {},
       "properties": {
-        "cache": {
-          "description": "Settings for key metadata cache",
+        "expireAfterAccessMins": {
+          "description": "Expiration time in minutes for cached key metadata",
           "type": "object",
           "default": {},
           "properties": {
-            "expireAfterAccessMins": {
-              "description": "Expiration time in minutes for cached key metadata",
+            "default": {
               "type": "integer",
               "default": 10000
-            },
-            "maximumSize": {
-              "description": "Maximum number of cached key metadata",
+            }
+          }
+        },
+        "maximumSize": {
+          "description": "Maximum number of cached key metadata",
+          "type": "object",
+          "default": {},
+          "properties": {
+            "default": {
               "type": "integer",
               "default": 60
             }
-          },
-          "additionalProperties": false
+          }
         }
       },
       "additionalProperties": false
@@ -142,40 +146,6 @@
           "description": "SOFT HSM specific configuration",
           "type": "object",
           "properties": {
-            "keyMap": {
-              "description": "Settings for the private keys map",
-              "type": "object",
-              "default": {},
-              "properties": {
-                "name": {
-                  "description": "Map type, CACHING - the key are cached, TRANSIENT - there is no caching",
-                  "enum": [
-                    "CACHING",
-                    "TRANSIENT"
-                  ],
-                  "default": "CACHING"
-                },
-                "cache": {
-                  "description": "Settings for the cache if the type is CACHING",
-                  "type": "object",
-                  "default": {},
-                  "properties": {
-                    "expireAfterAccessMins": {
-                      "description": "Expiration time for cached keys",
-                      "type": "integer",
-                      "default": 60
-                    },
-                    "maximumSize": {
-                      "description": "Maximum number of keys in the cache",
-                      "type": "integer",
-                      "default": 1000
-                    }
-                  },
-                  "additionalProperties": false
-                }
-              },
-              "additionalProperties": false
-            },
             "wrappingKeys": {
               "description" : "Key derivation parameters for wrapping keys supplied in config",
               "type": "array",
@@ -211,40 +181,6 @@
             "defaultWrappingKey": {
               "description": "The default wrapping key, which must be in the wrappingKeys array.",
               "type": "string"
-            },
-            "wrappingKeyMap": {
-              "description": "Settings for the wrapping keys map",
-              "type": "object",
-              "default": {},
-              "properties": {
-                "name": {
-                  "description": "Map type, CACHING - the key are cached, TRANSIENT - there is no caching",
-                  "enum": [
-                    "CACHING",
-                    "TRANSIENT"
-                  ],
-                  "default": "CACHING"
-                },
-                "cache": {
-                  "description": "Settings for the cache if the type is CACHING",
-                  "type": "object",
-                  "default": {},
-                  "properties": {
-                    "expireAfterAccessMins": {
-                      "description": "Expiration time for cached keys",
-                      "type": "integer",
-                      "default": 60
-                    },
-                    "maximumSize": {
-                      "description": "Maximum number of keys in the cache",
-                      "type": "integer",
-                      "default": 1000
-                    }
-                  },
-                  "additionalProperties": false
-                }
-              },
-              "additionalProperties": false
             },
             "wrapping": {
               "description": "Number of keys which can be handled by the HSM, -1 means unlimited capacity",

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/crypto/1.0/corda.crypto.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/crypto/1.0/corda.crypto.json
@@ -134,10 +134,6 @@
           },
           "additionalProperties": false
         },
-        "name": {
-          "description": "HSM provider name",
-          "type": "string"
-        },
         "categories": {
           "description": "Categories which the HSM can be used for",
           "type": "array",
@@ -336,7 +332,6 @@
         }
       },
       "required": [
-        "name",
         "masterKeyPolicy",
         "capacity",
         "supportedSchemes",

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/crypto/1.0/corda.crypto.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/crypto/1.0/corda.crypto.json
@@ -58,19 +58,6 @@
       },
       "additionalProperties": false
     },
-    "hsmService": {
-      "description": "Settings for HSMService",
-      "type": "object",
-      "default": {},
-      "properties": {
-        "downstreamMaxAttempts": {
-          "description": "Number of attempts to call downstream services to ensure consistency when assigning an HSM",
-          "type": "integer",
-          "default": 3
-        }
-      },
-      "additionalProperties": false
-    },
     "busProcessors": {
       "description": "Settings for crypto messages processors",
       "type": "object",

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/crypto/1.0/corda.crypto.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/crypto/1.0/corda.crypto.json
@@ -187,10 +187,6 @@
               "description": "HSM settings and capabilities",
               "type": "object",
               "properties": {
-                "name": {
-                  "description": "HSM provider name",
-                  "type": "string"
-                },
                 "categories": {
                   "description": "Categories which the HSM can be used for",
                   "type": "array",

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/crypto/1.0/corda.crypto.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/crypto/1.0/corda.crypto.json
@@ -111,255 +111,239 @@
       },
       "additionalProperties": false
     },
-    "hsmMap": {
-      "description": "Settings for all available HSMs",
+    "softHsm": {
+      "description": "Settings and capabilities for the SOFT HSM",
       "type": "object",
       "default": {},
-      "patternProperties": {
-        ".": {
-          "description": "Configuration schema for an HSM.",
+      "properties": {
+        "retry": {
+          "description": "Retry settings for the HSM",
+          "type": "object",
+          "default": {},
+          "properties": {
+            "maxAttempts": {
+              "description": "Maximum number of attempts",
+              "type": "integer",
+              "default": 3
+            },
+            "attemptTimeoutMills": {
+              "description": "Wait period in milliseconds between attempts, should be reasonably large as some operations may be long, e.g. RSA key generation by the SOFT HSM may take a few seconds",
+              "type": "integer",
+              "default": 20000
+            }
+          },
+          "additionalProperties": false
+        },
+        "name": {
+          "description": "HSM provider name",
+          "type": "string"
+        },
+        "categories": {
+          "description": "Categories which the HSM can be used for",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "properties": {
+              "category": {
+                "description": "Category name, could be the wildcard * meaning all which has to be the last item if used",
+                "type": "string"
+              },
+              "policy": {
+                "description": "Defines how private keys are generated for that category, ALIASED - stored in the HSM, WRAPPED - wrapped by the HSM, BOTH - decision is taken by the HSM at runtime",
+                "enum": [
+                  "ALIASED",
+                  "WRAPPED",
+                  "BOTH"
+                ]
+              }
+            },
+            "required": [
+              "category",
+              "policy"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "masterKeyPolicy": {
+          "description": "Wrapping key policy, NONE - no wrapping key is required, SHARED - wrapping key shared by all tenants, UNIQUE - wrapping key unique for each tenant",
+          "enum": [
+            "NONE",
+            "SHARED",
+            "UNIQUE"
+          ]
+        },
+        "masterKeyAlias": {
+          "description": "If the masterKeyPolicy is SHARED then this specifies the alias of the shared key and as such is required",
+          "type": "string"
+        },
+        "capacity": {
+          "description": "Number of keys which can be handled by the HSM, -1 means unlimited capacity",
+          "type": "integer"
+        },
+        "supportedSchemes": {
+          "description": "Key schemes that are supported by the HSM",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        },
+        "cfg": {
+          "description": "SOFT HSM specific configuration",
           "type": "object",
           "properties": {
-            "workerTopicSuffix": {
-              "description": "Topic's suffix where the messages should be sent for the HSM",
-              "type": "string",
-              "default": ""
-            },
-            "retry": {
-              "description": "Retry settings for the HSM",
+            "keyMap": {
+              "description": "Settings for the private keys map",
               "type": "object",
               "default": {},
               "properties": {
-                "maxAttempts": {
-                  "description": "Maximum number of attempts",
-                  "type": "integer",
-                  "default": 3
-                },
-                "attemptTimeoutMills": {
-                  "description": "Wait period in milliseconds between attempts, should be reasonably large as some operations may be long, e.g. RSA key generation by the SOFT HSM may take a few seconds",
-                  "type": "integer",
-                  "default": 20000
-                }
-              },
-              "additionalProperties": false
-            },
-            "hsm": {
-              "description": "HSM settings and capabilities",
-              "type": "object",
-              "properties": {
                 "name": {
-                  "description": "HSM provider name",
-                  "type": "string"
-                },
-                "categories": {
-                  "description": "Categories which the HSM can be used for",
-                  "type": "array",
-                  "minItems": 1,
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "category": {
-                        "description": "Category name, could be the wildcard * meaning all which has to be the last item if used",
-                        "type": "string"
-                      },
-                      "policy": {
-                        "description": "Defines how private keys are generated for that category, ALIASED - stored in the HSM, WRAPPED - wrapped by the HSM, BOTH - decision is taken by the HSM at runtime",
-                        "enum": [
-                          "ALIASED",
-                          "WRAPPED",
-                          "BOTH"
-                        ]
-                      }
-                    },
-                    "required": [
-                      "category",
-                      "policy"
-                    ],
-                    "additionalProperties": false
-                  }
-                },
-                "masterKeyPolicy": {
-                  "description": "Wrapping key policy, NONE - no wrapping key is required, SHARED - wrapping key shared by all tenants, UNIQUE - wrapping key unique for each tenant",
+                  "description": "Map type, CACHING - the key are cached, TRANSIENT - there is no caching",
                   "enum": [
-                    "NONE",
-                    "SHARED",
-                    "UNIQUE"
-                  ]
+                    "CACHING",
+                    "TRANSIENT"
+                  ],
+                  "default": "CACHING"
                 },
-                "masterKeyAlias": {
-                  "description": "If the masterKeyPolicy is SHARED then this specifies the alias of the shared key and as such is required",
-                  "type": "string"
-                },
-                "capacity": {
-                  "description": "Number of keys which can be handled by the HSM, -1 means unlimited capacity",
-                  "type": "integer"
-                },
-                "supportedSchemes": {
-                  "description": "Key schemes that are supported by the HSM",
-                  "type": "array",
-                  "minItems": 1,
-                  "items": {
-                    "type": "string"
-                  }
-                },
-                "cfg": {
-                  "description": "SOFT HSM specific configuration",
+                "cache": {
+                  "description": "Settings for the cache if the type is CACHING",
                   "type": "object",
+                  "default": {},
                   "properties": {
-                    "keyMap": {
-                      "description": "Settings for the private keys map",
-                      "type": "object",
-                      "default": {},
-                      "properties": {
-                        "name": {
-                          "description": "Map type, CACHING - the key are cached, TRANSIENT - there is no caching",
-                          "enum": [
-                            "CACHING",
-                            "TRANSIENT"
-                          ],
-                          "default": "CACHING"
-                        },
-                        "cache": {
-                          "description": "Settings for the cache if the type is CACHING",
-                          "type": "object",
-                          "default": {},
-                          "properties": {
-                            "expireAfterAccessMins": {
-                              "description": "Expiration time for cached keys",
-                              "type": "integer",
-                              "default": 60
-                            },
-                            "maximumSize": {
-                              "description": "Maximum number of keys in the cache",
-                              "type": "integer",
-                              "default": 1000
-                            }
-                          },
-                          "additionalProperties": false
-                        }
-                      },
-                      "additionalProperties": false
+                    "expireAfterAccessMins": {
+                      "description": "Expiration time for cached keys",
+                      "type": "integer",
+                      "default": 60
                     },
-                    "wrappingKeys": {
-                      "description" : "Key derivation parameters for wrapping keys supplied in config",
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "alias": {
-                            "description": "The alias for the wrapping key.",
-                            "type": "string"
-                          },
-                          "algorithm": {
-                            "description": "Key derivation function and wrapping key algorithm selection",
-                            "type": "string",
-                            "default": "PBKDF2WithHmacSHA256"
-                          },
-                          "salt": {
-                            "description": "Salt for the key derivation function",
-                            "type": "string"
-                          },
-                          "passphrase": {
-                            "description": "Passphrase for the key derivation function",
-                            "type": "string"
-                          }
-                        },
-                        "additionalProperties": false,
-                        "required": [
-                          "alias",
-                          "salt",
-                          "passphrase"
-                        ]
-                      }
-                    },
-                    "defaultWrappingKey": {
-                      "description": "The default wrapping key, which must be in the wrappingKeys array.",
-                      "type": "string"
-                    },
-                    "wrappingKeyMap": {
-                      "description": "Settings for the wrapping keys map",
-                      "type": "object",
-                      "default": {},
-                      "properties": {
-                        "name": {
-                          "description": "Map type, CACHING - the key are cached, TRANSIENT - there is no caching",
-                          "enum": [
-                            "CACHING",
-                            "TRANSIENT"
-                          ],
-                          "default": "CACHING"
-                        },
-                        "cache": {
-                          "description": "Settings for the cache if the type is CACHING",
-                          "type": "object",
-                          "default": {},
-                          "properties": {
-                            "expireAfterAccessMins": {
-                              "description": "Expiration time for cached keys",
-                              "type": "integer",
-                              "default": 60
-                            },
-                            "maximumSize": {
-                              "description": "Maximum number of keys in the cache",
-                              "type": "integer",
-                              "default": 1000
-                            }
-                          },
-                          "additionalProperties": false
-                        }
-                      },
-                      "additionalProperties": false
-                    },
-                    "wrapping": {
-                      "description": "Number of keys which can be handled by the HSM, -1 means unlimited capacity",
-                      "type": "object",
-                      "default": {},
-                      "properties": {
-                        "name": {
-                          "description": "Wrapping type, DEFAULT - the wrapping key are stored in database, HSM - there is additional single master key defined in the HSM",
-                          "enum": [
-                            "DEFAULT",
-                            "HSM"
-                          ],
-                          "default": "DEFAULT"
-                        },
-                        "hsm": {
-                          "description": "Number of keys which can be handled by the HSM, -1 means unlimited capacity",
-                          "type": "object",
-                          "default": {},
-                          "properties": {
-                            "name": {
-                              "description": "HSM provider name",
-                              "type": "string"
-                            },
-                            "cfg": {
-                              "description": "HSM specific configuration",
-                              "type": "object",
-                              "default": {},
-                              "additionalProperties": true
-                            }
-                          },
-                          "additionalProperties": false
-                        }
-                      },
-                      "additionalProperties": false
+                    "maximumSize": {
+                      "description": "Maximum number of keys in the cache",
+                      "type": "integer",
+                      "default": 1000
                     }
                   },
                   "additionalProperties": false
                 }
               },
-              "required": [
-                "name",
-                "masterKeyPolicy",
-                "capacity",
-                "supportedSchemes",
-                "categories",
-                "cfg"
-              ]
+              "additionalProperties": false
+            },
+            "wrappingKeys": {
+              "description" : "Key derivation parameters for wrapping keys supplied in config",
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "alias": {
+                    "description": "The alias for the wrapping key.",
+                    "type": "string"
+                  },
+                  "algorithm": {
+                    "description": "Key derivation function and wrapping key algorithm selection",
+                    "type": "string",
+                    "default": "PBKDF2WithHmacSHA256"
+                  },
+                  "salt": {
+                    "description": "Salt for the key derivation function",
+                    "type": "string"
+                  },
+                  "passphrase": {
+                    "description": "Passphrase for the key derivation function",
+                    "type": "string"
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "alias",
+                  "salt",
+                  "passphrase"
+                ]
+              }
+            },
+            "defaultWrappingKey": {
+              "description": "The default wrapping key, which must be in the wrappingKeys array.",
+              "type": "string"
+            },
+            "wrappingKeyMap": {
+              "description": "Settings for the wrapping keys map",
+              "type": "object",
+              "default": {},
+              "properties": {
+                "name": {
+                  "description": "Map type, CACHING - the key are cached, TRANSIENT - there is no caching",
+                  "enum": [
+                    "CACHING",
+                    "TRANSIENT"
+                  ],
+                  "default": "CACHING"
+                },
+                "cache": {
+                  "description": "Settings for the cache if the type is CACHING",
+                  "type": "object",
+                  "default": {},
+                  "properties": {
+                    "expireAfterAccessMins": {
+                      "description": "Expiration time for cached keys",
+                      "type": "integer",
+                      "default": 60
+                    },
+                    "maximumSize": {
+                      "description": "Maximum number of keys in the cache",
+                      "type": "integer",
+                      "default": 1000
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
+            },
+            "wrapping": {
+              "description": "Number of keys which can be handled by the HSM, -1 means unlimited capacity",
+              "type": "object",
+              "default": {},
+              "properties": {
+                "name": {
+                  "description": "Wrapping type, DEFAULT - the wrapping key are stored in database, HSM - there is additional single master key defined in the HSM",
+                  "enum": [
+                    "DEFAULT",
+                    "HSM"
+                  ],
+                  "default": "DEFAULT"
+                },
+                "hsm": {
+                  "description": "Number of keys which can be handled by the HSM, -1 means unlimited capacity",
+                  "type": "object",
+                  "default": {},
+                  "properties": {
+                    "name": {
+                      "description": "HSM provider name",
+                      "type": "string"
+                    },
+                    "cfg": {
+                      "description": "HSM specific configuration",
+                      "type": "object",
+                      "default": {},
+                      "additionalProperties": true
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+              "additionalProperties": false
             }
           },
-          "additionalProperties": false        }
-      }
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "name",
+        "masterKeyPolicy",
+        "capacity",
+        "supportedSchemes",
+        "categories",
+        "cfg"
+      ],
+      "additionalProperties": false
     }
   },
   "additionalProperties": false

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/crypto/1.0/corda.crypto.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/crypto/1.0/corda.crypto.json
@@ -201,169 +201,151 @@
                   "items": {
                     "type": "string"
                   }
-                }
-              },
-              "if": {
-                "properties": {
-                  "name": { "const": "SOFT" }
-                }
-              },
-              "then": {
-                "properties": {
-                  "cfg": {
-                    "description": "SOFT HSM specific configuration",
-                    "type": "object",
-                    "properties": {
-                      "keyMap": {
-                        "description": "Settings for the private keys map",
-                        "type": "object",
-                        "default": {},
-                        "properties": {
-                          "name": {
-                            "description": "Map type, CACHING - the key are cached, TRANSIENT - there is no caching",
-                            "enum": [
-                              "CACHING",
-                              "TRANSIENT"
-                            ],
-                            "default": "CACHING"
-                          },
-                          "cache": {
-                            "description": "Settings for the cache if the type is CACHING",
-                            "type": "object",
-                            "default": {},
-                            "properties": {
-                              "expireAfterAccessMins": {
-                                "description": "Expiration time for cached keys",
-                                "type": "integer",
-                                "default": 60
-                              },
-                              "maximumSize": {
-                                "description": "Maximum number of keys in the cache",
-                                "type": "integer",
-                                "default": 1000
-                              }
-                            },
-                            "additionalProperties": false
-                          }
+                },
+                "cfg": {
+                  "description": "SOFT HSM specific configuration",
+                  "type": "object",
+                  "properties": {
+                    "keyMap": {
+                      "description": "Settings for the private keys map",
+                      "type": "object",
+                      "default": {},
+                      "properties": {
+                        "name": {
+                          "description": "Map type, CACHING - the key are cached, TRANSIENT - there is no caching",
+                          "enum": [
+                            "CACHING",
+                            "TRANSIENT"
+                          ],
+                          "default": "CACHING"
                         },
-                        "additionalProperties": false
-                      },
-                      "wrappingKeys": {
-                        "description" : "Key derivation parameters for wrapping keys supplied in config",
-                        "type": "array",
-                        "items": {
+                        "cache": {
+                          "description": "Settings for the cache if the type is CACHING",
                           "type": "object",
+                          "default": {},
                           "properties": {
-                            "alias": {
-                              "description": "The alias for the wrapping key.",
-                              "type": "string"
+                            "expireAfterAccessMins": {
+                              "description": "Expiration time for cached keys",
+                              "type": "integer",
+                              "default": 60
                             },
-                            "algorithm": {
-                              "description": "Key derivation function and wrapping key algorithm selection",
-                              "type": "string",
-                              "default": "PBKDF2WithHmacSHA256"
-                            },
-                            "salt": {
-                              "description": "Salt for the key derivation function",
-                              "type": "string"
-                            },
-                            "passphrase": {
-                              "description": "Passphrase for the key derivation function",
-                              "type": "string"
+                            "maximumSize": {
+                              "description": "Maximum number of keys in the cache",
+                              "type": "integer",
+                              "default": 1000
                             }
                           },
-                          "additionalProperties": false,
-                          "required": [
-                            "alias",
-                            "salt",
-                            "passphrase"
-                          ]
+                          "additionalProperties": false
                         }
                       },
-                      "defaultWrappingKey": {
-                        "description": "The default wrapping key, which must be in the wrappingKeys array.",
-                        "type": "string"
-                      },
-                      "wrappingKeyMap": {
-                        "description": "Settings for the wrapping keys map",
+                      "additionalProperties": false
+                    },
+                    "wrappingKeys": {
+                      "description" : "Key derivation parameters for wrapping keys supplied in config",
+                      "type": "array",
+                      "items": {
                         "type": "object",
-                        "default": {},
                         "properties": {
-                          "name": {
-                            "description": "Map type, CACHING - the key are cached, TRANSIENT - there is no caching",
-                            "enum": [
-                              "CACHING",
-                              "TRANSIENT"
-                            ],
-                            "default": "CACHING"
+                          "alias": {
+                            "description": "The alias for the wrapping key.",
+                            "type": "string"
                           },
-                          "cache": {
-                            "description": "Settings for the cache if the type is CACHING",
-                            "type": "object",
-                            "default": {},
-                            "properties": {
-                              "expireAfterAccessMins": {
-                                "description": "Expiration time for cached keys",
-                                "type": "integer",
-                                "default": 60
-                              },
-                              "maximumSize": {
-                                "description": "Maximum number of keys in the cache",
-                                "type": "integer",
-                                "default": 1000
-                              }
-                            },
-                            "additionalProperties": false
+                          "algorithm": {
+                            "description": "Key derivation function and wrapping key algorithm selection",
+                            "type": "string",
+                            "default": "PBKDF2WithHmacSHA256"
+                          },
+                          "salt": {
+                            "description": "Salt for the key derivation function",
+                            "type": "string"
+                          },
+                          "passphrase": {
+                            "description": "Passphrase for the key derivation function",
+                            "type": "string"
                           }
                         },
-                        "additionalProperties": false
-                      },
-                      "wrapping": {
-                        "description": "Number of keys which can be handled by the HSM, -1 means unlimited capacity",
-                        "type": "object",
-                        "default": {},
-                        "properties": {
-                          "name": {
-                            "description": "Wrapping type, DEFAULT - the wrapping key are stored in database, HSM - there is additional single master key defined in the HSM",
-                            "enum": [
-                              "DEFAULT",
-                              "HSM"
-                            ],
-                            "default": "DEFAULT"
-                          },
-                          "hsm": {
-                            "description": "Number of keys which can be handled by the HSM, -1 means unlimited capacity",
-                            "type": "object",
-                            "default": {},
-                            "properties": {
-                              "name": {
-                                "description": "HSM provider name",
-                                "type": "string"
-                              },
-                              "cfg": {
-                                "description": "HSM specific configuration",
-                                "type": "object",
-                                "default": {},
-                                "additionalProperties": true
-                              }
-                            },
-                            "additionalProperties": false
-                          }
-                        },
-                        "additionalProperties": false
+                        "additionalProperties": false,
+                        "required": [
+                          "alias",
+                          "salt",
+                          "passphrase"
+                        ]
                       }
                     },
-                    "additionalProperties": false
-                  }
-                }
-              },
-              "else": {
-                "properties": {
-                  "cfg": {
-                    "$comment": "Settings for any other HSM are open",
-                    "type": "object",
-                    "additionalProperties": true
-                  }
+                    "defaultWrappingKey": {
+                      "description": "The default wrapping key, which must be in the wrappingKeys array.",
+                      "type": "string"
+                    },
+                    "wrappingKeyMap": {
+                      "description": "Settings for the wrapping keys map",
+                      "type": "object",
+                      "default": {},
+                      "properties": {
+                        "name": {
+                          "description": "Map type, CACHING - the key are cached, TRANSIENT - there is no caching",
+                          "enum": [
+                            "CACHING",
+                            "TRANSIENT"
+                          ],
+                          "default": "CACHING"
+                        },
+                        "cache": {
+                          "description": "Settings for the cache if the type is CACHING",
+                          "type": "object",
+                          "default": {},
+                          "properties": {
+                            "expireAfterAccessMins": {
+                              "description": "Expiration time for cached keys",
+                              "type": "integer",
+                              "default": 60
+                            },
+                            "maximumSize": {
+                              "description": "Maximum number of keys in the cache",
+                              "type": "integer",
+                              "default": 1000
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "additionalProperties": false
+                    },
+                    "wrapping": {
+                      "description": "Number of keys which can be handled by the HSM, -1 means unlimited capacity",
+                      "type": "object",
+                      "default": {},
+                      "properties": {
+                        "name": {
+                          "description": "Wrapping type, DEFAULT - the wrapping key are stored in database, HSM - there is additional single master key defined in the HSM",
+                          "enum": [
+                            "DEFAULT",
+                            "HSM"
+                          ],
+                          "default": "DEFAULT"
+                        },
+                        "hsm": {
+                          "description": "Number of keys which can be handled by the HSM, -1 means unlimited capacity",
+                          "type": "object",
+                          "default": {},
+                          "properties": {
+                            "name": {
+                              "description": "HSM provider name",
+                              "type": "string"
+                            },
+                            "cfg": {
+                              "description": "HSM specific configuration",
+                              "type": "object",
+                              "default": {},
+                              "additionalProperties": true
+                            }
+                          },
+                          "additionalProperties": false
+                        }
+                      },
+                      "additionalProperties": false
+                    }
+                  },
+                  "additionalProperties": false
                 }
               },
               "required": [

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/crypto/1.0/corda.crypto.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/crypto/1.0/corda.crypto.json
@@ -111,8 +111,8 @@
       },
       "additionalProperties": false
     },
-    "softHsm": {
-      "description": "Settings and capabilities for the SOFT HSM",
+    "hsm": {
+      "description": "Settings and capabilities for the HSM",
       "type": "object",
       "default": {},
       "properties": {

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/crypto/1.0/corda.crypto.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/crypto/1.0/corda.crypto.json
@@ -32,24 +32,6 @@
       "description": "The default wrapping key, which must be in the wrappingKeys array.",
       "type": "string"
     },
-    "cryptoConnectionFactory": {
-      "description": "Settings for database connections factory's cache of EntityManagerFactory(s)",
-      "type": "object",
-      "default": {},
-      "properties": {
-        "expireAfterAccessMins": {
-          "description": "Expiration time in minutes for cached EntityManagerFactory",
-          "type": "integer",
-          "default": 5
-        },
-        "maximumSize": {
-          "description": "Maximum number of cached EntityManagerFactory",
-          "type": "integer",
-          "default": 3
-        }
-      },
-      "additionalProperties": false
-    },
     "signingService": {
       "description": "Settings for SigningService",
       "type": "object",

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/crypto/1.0/corda.crypto.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/crypto/1.0/corda.crypto.json
@@ -5,33 +5,6 @@
   "description": "Configuration schema for the crypto library subsection.",
   "type": "object",
   "properties": {
-    "wrappingKeys": {
-      "description" : "Key derivation parameters for wrapping keys supplied in config",
-      "type": "array",
-      "properties": {
-        "alias" : {
-          "description": "The alias for the wrapping key.",
-          "type" : "string"
-        },
-        "algorithm": {
-          "description": "Key derivation function and wrapping key algorithm selection",
-          "type": "string",
-          "default": "PBKDF2WithHmacSHA256"
-        },
-        "salt": {
-          "description": "Salt for the key derivation function",
-          "type": "string"
-        },
-        "passphrase": {
-          "description": "Passphrase for the key derivation function",
-          "type": "string"
-        }
-      }
-    },
-    "defaultWrappingKey": {
-      "description": "The default wrapping key, which must be in the wrappingKeys array.",
-      "type": "string"
-    },
     "signingService": {
       "description": "Settings for SigningService",
       "type": "object",

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/crypto/1.0/corda.crypto.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/crypto/1.0/corda.crypto.json
@@ -31,85 +31,38 @@
       },
       "additionalProperties": false
     },
-    "busProcessors": {
-      "description": "Settings for crypto messages processors",
+    "retrying": {
+      "description": "Retry settings",
       "type": "object",
       "default": {},
       "properties": {
-        "ops": {
-          "description": "Settings for crypto ops messages processor",
+        "maxAttempts": {
+          "description": "Maximum attempts to process a message",
           "type": "object",
-          "default": {},
           "properties": {
-            "maxAttempts": {
-              "description": "Maximum attempts to process a message",
+            "default": {
               "type": "integer",
               "default": 3
-            },
-            "waitBetweenMills": {
-              "description": "Time between attempts in milliseconds, if the number of values is less than attempts then the last item is repeated",
-              "type": "array",
-              "minItems": 1,
-              "default": [
-                200
-              ],
-              "items": {
-                "type": "integer"
-              }
             }
-          },
-          "additionalProperties": false
+          }
         },
-        "flow": {
-          "description": "Settings for crypto flow ops messages processor",
+        "waitBetweenMills": {
+          "description": "Time between attempts in milliseconds, if the number of values is less than attempts then the last item is repeated",
           "type": "object",
-          "default": {},
           "properties": {
-            "maxAttempts": {
-              "description": "Maximum attempts to process a message",
-              "type": "integer",
-              "default": 3
-            },
-            "waitBetweenMills": {
-              "description": "Time between attempts in milliseconds, if the number of values is less than attempts then the last item is repeated",
+            "default": {
               "type": "array",
+              "items": {
+                "type": "integer"
+              },
               "minItems": 1,
               "default": [
                 200
-              ],
-              "items": {
-                "type": "integer"
-              }
+              ]
             }
-          },
-          "additionalProperties": false
-        },
-        "registration": {
-          "description": "Settings for HSM registration messages processor",
-          "type": "object",
-          "default": {},
-          "properties": {
-            "maxAttempts": {
-              "description": "Maximum attempts to process a message",
-              "type": "integer",
-              "default": 3
-            },
-            "waitBetweenMills": {
-              "description": "Time between attempts in milliseconds, if the number of values is less than attempts then the last item is repeated",
-              "type": "array",
-              "minItems": 1,
-              "default": [
-                200
-              ],
-              "items": {
-                "type": "integer"
-              }
-            }
-          },
-          "additionalProperties": false
+          }
         }
-      },
-      "additionalProperties": false
+      }
     },
     "hsm": {
       "description": "Settings and capabilities for the HSM",

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/crypto/1.0/corda.crypto.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/crypto/1.0/corda.crypto.json
@@ -174,6 +174,10 @@
               "description": "HSM settings and capabilities",
               "type": "object",
               "properties": {
+                "name": {
+                  "description": "HSM provider name",
+                  "type": "string"
+                },
                 "categories": {
                   "description": "Categories which the HSM can be used for",
                   "type": "array",

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 744
+cordaApiRevision = 745
 
 # Main
 kotlinVersion = 1.8.10


### PR DESCRIPTION
- removes unused `cryptoConnectionFactory` configuration
- removes unused `hsmService` configuration
- removes duplicate `wrappingKeys` configuration
- replaces `hsmMap` configuration which was used to hold multiple HSM configurations with `hsm` (as we only support soft hsm)
- generalizes caching configurations
- generalizes retrying configurations


runtime-os PR: [#3578](https://github.com/corda/corda-runtime-os/pull/3578)