### PR TITLE
CORE-11477 Revisit crypto hsm configuration

### DIFF
--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/crypto/1.0/corda.crypto.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/crypto/1.0/corda.crypto.json
@@ -4,6 +4,7 @@
   "title": "Corda Crypto Library Configuration Schema",
   "description": "Configuration schema for the crypto library subsection.",
   "type": "object",
+  "default": {},
   "properties": {
     "caching": {
       "description": "Caching settings",

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/crypto/1.0/corda.crypto.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/crypto/1.0/corda.crypto.json
@@ -163,7 +163,6 @@
         "masterKeyPolicy",
         "capacity",
         "supportedSchemes",
-        "categories",
         "cfg"
       ],
       "additionalProperties": false

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/crypto/1.0/corda.crypto.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/crypto/1.0/corda.crypto.json
@@ -92,14 +92,6 @@
           },
           "additionalProperties": false
         },
-        "wrappingKeyPolicy": {
-          "description": "Wrapping key policy, NONE - no wrapping key is required, SHARED - wrapping key shared by all tenants, UNIQUE - wrapping key unique for each tenant",
-          "enum": [
-            "NONE",
-            "SHARED",
-            "UNIQUE"
-          ]
-        },
         "wrappingKeys": {
           "description" : "Key derivation parameters for wrapping keys supplied in config",
           "type": "array",
@@ -138,7 +130,6 @@
         }
       },
       "required": [
-        "wrappingKeyPolicy",
         "wrappingKeys",
         "defaultWrappingKey"
       ],

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/crypto/1.0/corda.crypto.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/crypto/1.0/corda.crypto.json
@@ -99,10 +99,6 @@
             "UNIQUE"
           ]
         },
-        "masterKeyAlias": {
-          "description": "If the masterKeyPolicy is SHARED then this specifies the alias of the shared key and as such is required",
-          "type": "string"
-        },
         "supportedSchemes": {
           "description": "Key schemes that are supported by the HSM",
           "type": "array",

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/crypto/1.0/corda.crypto.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/crypto/1.0/corda.crypto.json
@@ -99,14 +99,6 @@
             "UNIQUE"
           ]
         },
-        "supportedSchemes": {
-          "description": "Key schemes that are supported by the HSM",
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "type": "string"
-          }
-        },
         "cfg": {
           "description": "SOFT HSM specific configuration",
           "type": "object",
@@ -153,7 +145,6 @@
       },
       "required": [
         "masterKeyPolicy",
-        "supportedSchemes",
         "cfg"
       ],
       "additionalProperties": false

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/crypto/1.0/corda.crypto.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/crypto/1.0/corda.crypto.json
@@ -99,53 +99,47 @@
             "UNIQUE"
           ]
         },
-        "cfg": {
-          "description": "SOFT HSM specific configuration",
-          "type": "object",
-          "properties": {
-            "wrappingKeys": {
-              "description" : "Key derivation parameters for wrapping keys supplied in config",
-              "type": "array",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "alias": {
-                    "description": "The alias for the wrapping key.",
-                    "type": "string"
-                  },
-                  "algorithm": {
-                    "description": "Key derivation function and wrapping key algorithm selection",
-                    "type": "string",
-                    "default": "PBKDF2WithHmacSHA256"
-                  },
-                  "salt": {
-                    "description": "Salt for the key derivation function",
-                    "type": "string"
-                  },
-                  "passphrase": {
-                    "description": "Passphrase for the key derivation function",
-                    "type": "string"
-                  }
-                },
-                "additionalProperties": false,
-                "required": [
-                  "alias",
-                  "salt",
-                  "passphrase"
-                ]
+        "wrappingKeys": {
+          "description" : "Key derivation parameters for wrapping keys supplied in config",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "alias": {
+                "description": "The alias for the wrapping key.",
+                "type": "string"
+              },
+              "algorithm": {
+                "description": "Key derivation function and wrapping key algorithm selection",
+                "type": "string",
+                "default": "PBKDF2WithHmacSHA256"
+              },
+              "salt": {
+                "description": "Salt for the key derivation function",
+                "type": "string"
+              },
+              "passphrase": {
+                "description": "Passphrase for the key derivation function",
+                "type": "string"
               }
             },
-            "defaultWrappingKey": {
-              "description": "The default wrapping key, which must be in the wrappingKeys array.",
-              "type": "string"
-            }
-          },
-          "additionalProperties": false
+            "additionalProperties": false,
+            "required": [
+              "alias",
+              "salt",
+              "passphrase"
+            ]
+          }
+        },
+        "defaultWrappingKey": {
+          "description": "The default wrapping key, which must be in the wrappingKeys array.",
+          "type": "string"
         }
       },
       "required": [
         "masterKeyPolicy",
-        "cfg"
+        "wrappingKeys",
+        "defaultWrappingKey"
       ],
       "additionalProperties": false
     }

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/crypto/1.0/corda.crypto.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/crypto/1.0/corda.crypto.json
@@ -103,10 +103,6 @@
           "description": "If the masterKeyPolicy is SHARED then this specifies the alias of the shared key and as such is required",
           "type": "string"
         },
-        "capacity": {
-          "description": "Number of keys which can be handled by the HSM, -1 means unlimited capacity",
-          "type": "integer"
-        },
         "supportedSchemes": {
           "description": "Key schemes that are supported by the HSM",
           "type": "array",
@@ -161,7 +157,6 @@
       },
       "required": [
         "masterKeyPolicy",
-        "capacity",
         "supportedSchemes",
         "cfg"
       ],

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/crypto/1.0/corda.crypto.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/crypto/1.0/corda.crypto.json
@@ -91,33 +91,6 @@
           },
           "additionalProperties": false
         },
-        "categories": {
-          "description": "Categories which the HSM can be used for",
-          "type": "array",
-          "minItems": 1,
-          "items": {
-            "type": "object",
-            "properties": {
-              "category": {
-                "description": "Category name, could be the wildcard * meaning all which has to be the last item if used",
-                "type": "string"
-              },
-              "policy": {
-                "description": "Defines how private keys are generated for that category, ALIASED - stored in the HSM, WRAPPED - wrapped by the HSM, BOTH - decision is taken by the HSM at runtime",
-                "enum": [
-                  "ALIASED",
-                  "WRAPPED",
-                  "BOTH"
-                ]
-              }
-            },
-            "required": [
-              "category",
-              "policy"
-            ],
-            "additionalProperties": false
-          }
-        },
         "masterKeyPolicy": {
           "description": "Wrapping key policy, NONE - no wrapping key is required, SHARED - wrapping key shared by all tenants, UNIQUE - wrapping key unique for each tenant",
           "enum": [

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/crypto/1.0/corda.crypto.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/crypto/1.0/corda.crypto.json
@@ -92,7 +92,7 @@
           },
           "additionalProperties": false
         },
-        "masterKeyPolicy": {
+        "wrappingKeyPolicy": {
           "description": "Wrapping key policy, NONE - no wrapping key is required, SHARED - wrapping key shared by all tenants, UNIQUE - wrapping key unique for each tenant",
           "enum": [
             "NONE",
@@ -138,7 +138,7 @@
         }
       },
       "required": [
-        "masterKeyPolicy",
+        "wrappingKeyPolicy",
         "wrappingKeys",
         "defaultWrappingKey"
       ],

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/crypto/1.0/corda.crypto.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/crypto/1.0/corda.crypto.json
@@ -74,7 +74,7 @@
       "type": "object",
       "default": {},
       "properties": {
-        "retry": {
+        "retrying": {
           "description": "Retry settings for the HSM",
           "type": "object",
           "default": {},

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 748
+cordaApiRevision = 749
 
 # Main
 kotlinVersion = 1.8.10


### PR DESCRIPTION
- removes the following unused hsm configuration:
  - `hsm.categories`
  - `hsm.capacity`
  - `hsm.masterKeyAlias`
  - `hsm.supportedSchemes`
  - `hsm.masterKeyPolicy`
- flattens `hsm.config` properties into `hsm`

This PR addresses comments from [#1044](https://github.com/corda/corda-api/pull/1044) 

runtime-os PR: [#3593](https://github.com/corda/corda-runtime-os/pull/3593)