### PR TITLE
CORE-11960 Capture the originator of a notarization request

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/uniqueness/UniquenessCheckRequestAvro.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/uniqueness/UniquenessCheckRequestAvro.avsc
@@ -18,6 +18,11 @@
       "type": "string"
     },
     {
+      "name": "originatorX500Name",
+      "type": "string",
+      "doc": "The x500 name of the of the party who initiated a notarization (and by extension, uniqueness check) request"
+    },
+    {
       "name": "inputStates",
       "type": {
         "type": "array",

--- a/data/db-schema/src/main/resources/net/corda/db/schema/vnode-uniqueness/migration/vnode-uniqueness-creation-v1.0.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/vnode-uniqueness/migration/vnode-uniqueness-creation-v1.0.xml
@@ -56,6 +56,9 @@
             <column name="tx_id" type="VARBINARY(64)">
                 <constraints nullable="false"/>s
             </column>
+            <column name="originator_x500_name" type="VARCHAR(1024)">
+                <constraints nullable="false"/>
+            </column>
             <column name="expiry_datetime" type="TIMESTAMP">
                 <constraints nullable="false"/>
             </column>

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 748
+cordaApiRevision = 749
 
 # Main
 kotlinVersion = 1.8.10

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 750
+cordaApiRevision = 751
 
 # Main
 kotlinVersion = 1.8.10

--- a/ledger/ledger-utxo/src/main/java/net/corda/v5/ledger/utxo/uniqueness/client/LedgerUniquenessCheckerClientService.java
+++ b/ledger/ledger-utxo/src/main/java/net/corda/v5/ledger/utxo/uniqueness/client/LedgerUniquenessCheckerClientService.java
@@ -21,6 +21,7 @@ public interface LedgerUniquenessCheckerClientService {
      * Requests a uniqueness check.
      *
      * @param transactionId The ID of the transaction to be processed.
+     * @param originatorX500Name The X500 name of the party that requested (initiated) notarization.
      * @param inputStates A list of the input state refs that belongs to the given transaction.
      * @param referenceStates A list of the reference state refs that belongs to the given transaction.
      * @param numOutputStates The number of output states in the given transaction.
@@ -32,6 +33,7 @@ public interface LedgerUniquenessCheckerClientService {
     @SuppressWarnings("LongParameterList")
     UniquenessCheckResult requestUniquenessCheck(
             @NotNull String transactionId,
+            @NotNull String originatorX500Name,
             @NotNull List<String> inputStates,
             @NotNull List<String> referenceStates,
             int numOutputStates,


### PR DESCRIPTION
### Summary

This PR makes the necessary DB schema and API changes to allow the originator of a notarization request to be captured within the uniqueness DB for audit purposes.

Note that this is technically a "breaking" change due to the addition of an extra parameter to `LedgerUniquenessCheckerClientService.requestUniquenessCheck`. However, in practice this is currently only used by our non-validating notary server plugin, which has been updated as part of the corresponding `corda-runtime-os` PR.

### Testing

Tested as part of the corresponding `corda-runtime-os` PR, see https://github.com/corda/corda-runtime-os/pull/3607.