### PR TITLE
CORE-12634 Add permissions so REST worker can publish group parameters

### DIFF
--- a/data/topic-schema/src/main/resources/net/corda/schema/Membership.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/Membership.yaml
@@ -10,6 +10,7 @@ topics:
     producers:
       - db
       - membership
+      - rest
     config:
       cleanup.policy: compact
       segment.ms: 600000


### PR DESCRIPTION
After CORE-10576: the REST worker can now publish the group parameters if the member being suspended is a notary. We need to add permissions so the REST worker can write to the group parameters topic.