### PR TITLE
CORE-10330: Remove Kotlin from transitive dependencies.

### DIFF
--- a/crypto-extensions/build.gradle
+++ b/crypto-extensions/build.gradle
@@ -1,18 +1,15 @@
 plugins {
-    id 'org.jetbrains.kotlin.jvm'
-    id 'corda.common-publishing'
     id 'corda-api.common-library'
+    id 'corda.common-publishing'
+    id 'corda.java-only'
 }
 
 description 'Corda Crypto Extensions API'
 
 dependencies {
-    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
-
     compileOnly 'org.osgi:osgi.annotation'
 
     api platform(project(':corda-api'))
-
-    api project(":crypto")
+    api project(':crypto')
 }
 

--- a/crypto/build.gradle
+++ b/crypto/build.gradle
@@ -1,13 +1,12 @@
 plugins {
-    id 'org.jetbrains.kotlin.jvm'
-    id 'corda.common-publishing'
     id 'corda-api.common-library'
+    id 'corda.common-publishing'
+    id 'corda.java-only'
 }
 
 description 'Corda Crypto'
 
 dependencies {
-    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation 'org.slf4j:slf4j-api'
 
     compileOnly 'org.osgi:osgi.annotation'

--- a/data/topic-schema/build.gradle
+++ b/data/topic-schema/build.gradle
@@ -7,7 +7,6 @@ plugins {
 description 'Definition of Topics'
 
 dependencies {
-    implementation 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     implementation platform(project(':corda-api'))
 
     testImplementation "org.assertj:assertj-core:$assertjVersion"

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,10 +10,10 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 754
+cordaApiRevision = 755
 
 # Main
-kotlinVersion = 1.8.10
+kotlinVersion = 1.8.20
 kotlin.stdlib.default.dependency = false
 
 # These are the same annotations that Kotlin uses.

--- a/ledger/ledger-common/build.gradle
+++ b/ledger/ledger-common/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'corda-api.common-library'
     id 'corda.common-publishing'
-    id 'org.jetbrains.kotlin.jvm'
+    id 'corda.java-only'
 }
 
 description 'Corda Ledger Common'
@@ -10,8 +10,7 @@ dependencies {
     compileOnly 'org.osgi:osgi.annotation'
 
     api platform(project(':corda-api'))
-    api 'org.jetbrains.kotlin:kotlin-osgi-bundle'
-    api project(":application")
+    api project(':application')
 
     testImplementation project(':crypto')
     testImplementation "org.assertj:assertj-core:$assertjVersion"

--- a/ledger/ledger-consensual/build.gradle
+++ b/ledger/ledger-consensual/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'corda-api.common-library'
     id 'corda.common-publishing'
-    id 'org.jetbrains.kotlin.jvm'
+    id 'corda.java-only'
 }
 
 description 'Corda Consensual Ledger'

--- a/ledger/ledger-utxo/build.gradle
+++ b/ledger/ledger-utxo/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'corda-api.common-library'
     id 'corda.common-publishing'
-    id 'org.jetbrains.kotlin.jvm'
+    id 'corda.java-only'
 }
 
 description 'Corda UTXO Ledger'

--- a/ledger/notary-plugin/build.gradle
+++ b/ledger/notary-plugin/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'corda-api.common-library'
     id 'corda.common-publishing'
-    id 'org.jetbrains.kotlin.jvm'
+    id 'corda.java-only'
 }
 
 description 'Corda Notary Plugin API and Core'
@@ -9,7 +9,6 @@ description 'Corda Notary Plugin API and Core'
 dependencies {
     api platform(project(':corda-api'))
 
-    api 'org.jetbrains.kotlin:kotlin-osgi-bundle'
     api 'javax.persistence:javax.persistence-api'
     api 'org.slf4j:slf4j-api'
 

--- a/serialization/build.gradle
+++ b/serialization/build.gradle
@@ -8,7 +8,7 @@ description 'Corda Serialization'
 
 dependencies {
     api platform(project(':corda-api'))
-    api project(":base")
+    api project(':base')
 
     compileOnly 'org.jetbrains:annotations'
     compileOnly 'org.osgi:osgi.annotation'


### PR DESCRIPTION
We no longer need a runtime dependency on `kotlin-osgi-bundle` now that everything is written in Java.

Also upgrade our tests to use Kotlin 1.8.20, for consistency.
