### PR TITLE
CORE-12860 Create keys for uniqueness tables as part of table creation

### DIFF
--- a/data/db-schema/src/main/resources/net/corda/db/schema/vnode-uniqueness/migration/vnode-uniqueness-creation-v1.0.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/vnode-uniqueness/migration/vnode-uniqueness-creation-v1.0.xml
@@ -30,18 +30,12 @@
                 <constraints nullable="true"/>
             </column>
         </createTable>
-    </changeSet>
-
-    <changeSet author="R3.Corda" id="uniqueness-creation-v1.0-2" runInTransaction="false">
-        <preConditions onFail="MARK_RAN">
-            <not>
-                <primaryKeyExists primaryKeyName="uniqueness_state_details_pkey" tableName="uniqueness_state_details"/>
-            </not>
-        </preConditions>
         <addPrimaryKey columnNames="issue_tx_id_algo, issue_tx_id, issue_tx_output_idx"
                        constraintName="uniqueness_state_details_pkey"
                        tableName="uniqueness_state_details"/>
     </changeSet>
+
+    <!-- uniqueness-creation-v1.0-2 intentionally skipped - previously used for key creation -->
 
     <changeSet author="R3.Corda" id="uniqueness-creation-v1.0-3" runInTransaction="false">
         <preConditions onFail="MARK_RAN">
@@ -69,18 +63,12 @@
                 <constraints nullable="false"/>
             </column>
         </createTable>
-    </changeSet>
-
-    <changeSet author="R3.Corda" id="uniqueness-creation-v1.0-4" runInTransaction="false">
-        <preConditions onFail="MARK_RAN">
-            <not>
-                <primaryKeyExists primaryKeyName="uniqueness_tx_details_pkey" tableName="uniqueness_tx_details"/>
-            </not>
-        </preConditions>
         <addPrimaryKey columnNames="tx_id_algo, tx_id"
                        constraintName="uniqueness_tx_details_pkey"
                        tableName="uniqueness_tx_details"/>
     </changeSet>
+
+    <!-- uniqueness-creation-v1.0-4 intentionally skipped - previously used for key creation -->
 
     <changeSet author="R3.Corda" id="uniqueness-creation-v1.0-5" runInTransaction="false">
         <preConditions onFail="MARK_RAN">
@@ -99,16 +87,10 @@
                 <constraints nullable="false"/>
             </column>
         </createTable>
-    </changeSet>
-
-    <changeSet author="R3.Corda" id="uniqueness-creation-v1.0-6" runInTransaction="false">
-        <preConditions onFail="MARK_RAN">
-            <not>
-                <primaryKeyExists primaryKeyName="uniqueness_rejected_txs_pkey" tableName="uniqueness_rejected_txs"/>
-            </not>
-        </preConditions>
         <addPrimaryKey columnNames="tx_id_algo, tx_id"
                        constraintName="uniqueness_rejected_txs_pkey"
                        tableName="uniqueness_rejected_txs"/>
     </changeSet>
+
+    <!-- uniqueness-creation-v1.0-6 intentionally skipped - previously used for key creation -->
 </databaseChangeLog>


### PR DESCRIPTION
### Summary

Previously, the Liquibase changelog for the uniqueness DB first created a table (and its columns), before adding a key in a subsequent changeset. This works fine for Postgres, however, with Cockroach DB (not yet officially supported), this results in Cockroach DB creating a default primary key using just the row id of a record. When the changeset to then add the key is run, it detects the key already exists, and skips the changeset. Even if this was not done, it would fail to add the key due to it already existing.

This change creates the primary key as part of the same changeset as the table creation, which results in the correct behavior for Cockroach DB. Whilst not officially supported yet, making this change now avoids potential migration / backwards compatibility headaches down the line, since it will be difficult to make changes (as opposed to additions) to the liquibase changelogs post-GA.

NOTE: This change does not require an API version bump, as there are no implications on the `corda-runtime-os` repo and the end result (on Postgres) is the same.

### Testing

Created a Cockroach DB cluster, and ran the `backingStoreBenchmark` command against this DB. Verified that uniqueness DB tables were created with the correct keys.

Also ran the uniqueness checker DB integration tests against HSQLDB and Postgres, and standard smoke tests against Postgres, and confirmed no regressions. Also verified the keys remain correct on a Postgres by manual inspection.