### PR TITLE
ES-132 fix jacococ plugin post grale 8 bump - remove deprecated parameters

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -223,8 +223,8 @@ subprojects {
             dependsOn tasks.named('test') // tests are required to run before generating the report
 
             reports {
-                xml.enabled true
-                html.enabled true
+                xml.required = true
+                html.required = true
             }
         }
 


### PR DESCRIPTION
The `Report.enabled` property has been deprecated. This was removed in Gradle 8.0, and now causes `jacocoTestReport` gradle task to fail

Use required and explicitly assign, [see docs ](https://docs.gradle.org/7.5/dsl/org.gradle.api.reporting.Report.html#org.gradle.api.reporting.Report:enabled)