### PR TITLE
CORE-12415 - Handle expired registration requests

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/common/RegistrationRequestDetails.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/common/RegistrationRequestDetails.avsc
@@ -31,6 +31,11 @@
       "type": "string"
     },
     {
+      "name": "holdingIdentityId",
+      "doc": "ID of the owner of this registration request.",
+      "type": "string"
+    },
+    {
       "name": "registrationProtocolVersion",
       "doc": "Registration protocol number.",
       "type": "int"

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 744-MGM
+cordaApiRevision = 745-MGM
 
 # Main
 kotlinVersion = 1.8.10


### PR DESCRIPTION
Added holding identity information to RegistrationDetails.avsc to be later used when creating the keys for the registration command topic.