### PR TITLE
CORE-12912 `ResultSet.next` API changes

### DIFF
--- a/application/src/main/java/net/corda/v5/application/persistence/PagedQuery.java
+++ b/application/src/main/java/net/corda/v5/application/persistence/PagedQuery.java
@@ -63,7 +63,8 @@ public interface PagedQuery<R> {
          * Extracts the results of a {@link ResultSet} from a previously executed query.
          * <p>
          * This method does not execute a query itself, call {@link PagedQuery#execute()} to execute a query and
-         * generate a {@link ResultSet}.
+         * generate a {@link ResultSet} or {@link ResultSet#next()} with an existing {@link ResultSet} to re-execute the
+         * query with the offset increased to the next page's offset.
          *
          * @return The results contained in the result set.
          */
@@ -71,10 +72,11 @@ public interface PagedQuery<R> {
         List<R> getResults();
 
         /**
-         * Returns {@code true} if the {@link ResultSet} has more results to retrieve.
+         * Returns {@code true} if the {@link ResultSet} can retrieve more results by re-executing the query with the
+         * offset increased to the next's page's offset.
          * <p>
          * Modifying the {@link PagedQuery} linked to the {@link ResultSet} does not affect {@link ResultSet}'s
-         * behaviour when calling {@link ResultSet#next()}.
+         * behaviour when calling this method.
          *
          * @return {@code true} if the {@link ResultSet} has more results to retrieve.
          *
@@ -83,13 +85,14 @@ public interface PagedQuery<R> {
         boolean hasNext();
 
         /**
-         * Executes the query linked to the {@link ResultSet} to retrieve the next page of results.
+         * Executes the query linked to the {@link ResultSet} to retrieve the next page of results by re-executing the
+         * query.
          * <p>
          * The offset of the executed query increments each time {@link ResultSet#next()} is called, increasing by the
          * value of the query's limit.
          * <p>
          * Modifying the {@link PagedQuery} linked to the {@link ResultSet} does not affect {@link ResultSet}'s
-         * behaviour when calling {@link ResultSet#next()}.
+         * behaviour when calling this method.
          *
          * @return The next page of results.
          * @throws NoSuchElementException If the {@link ResultSet} has no more results to retrieve.

--- a/application/src/main/java/net/corda/v5/application/persistence/PagedQuery.java
+++ b/application/src/main/java/net/corda/v5/application/persistence/PagedQuery.java
@@ -4,6 +4,7 @@ import net.corda.v5.base.annotations.Suspendable;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
+import java.util.NoSuchElementException;
 
 /**
  * Used to build a Query that supports limit and offset.
@@ -68,5 +69,33 @@ public interface PagedQuery<R> {
          */
         @NotNull
         List<R> getResults();
+
+        /**
+         * Returns {@code true} if the {@link ResultSet} has more results to retrieve.
+         * <p>
+         * Modifying the {@link PagedQuery} linked to the {@link ResultSet} does not affect {@link ResultSet}'s
+         * behaviour when calling {@link ResultSet#next()}.
+         *
+         * @return {@code true} if the {@link ResultSet} has more results to retrieve.
+         *
+         * @return
+         */
+        boolean hasNext();
+
+        /**
+         * Executes the query linked to the {@link ResultSet} to retrieve the next page of results.
+         * <p>
+         * The offset of the executed query increments each time {@link ResultSet#next()} is called, increasing by the
+         * value of the query's limit.
+         * <p>
+         * Modifying the {@link PagedQuery} linked to the {@link ResultSet} does not affect {@link ResultSet}'s
+         * behaviour when calling {@link ResultSet#next()}.
+         *
+         * @return The next page of results.
+         * @throws NoSuchElementException If the {@link ResultSet} has no more results to retrieve.
+         */
+        @Suspendable
+        @NotNull
+        List<R> next();
     }
 }

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/persistence/EntityResponse.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/persistence/EntityResponse.avsc
@@ -8,9 +8,14 @@
       "name": "results",
       "doc": "Result of request, as a list of AMQP-formatted user defined objects, which may be empty or have 1 element for certain persistence operations",
       "type": {
-        "type" : "array",
+        "type": "array",
         "items": "bytes"
       }
+    },
+    {
+      "name": "metadata",
+      "doc": "Metadata returned from the execution of the persistence operation",
+      "type": "net.corda.data.KeyValuePairList"
     }
   ]
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 759
+cordaApiRevision = 760
 
 # Main
 kotlinVersion = 1.8.21


### PR DESCRIPTION
Usage of the API would look like

```kotlin
val resultSet = query.execute()
results += resultSet.results
while (resultSet.hasNext()) {
  results += resultSet.next()
}
return results
```