### PR TITLE
CORE-3920 Sessions Should Not hang indefinitely if both parties are waiting to receive data

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/flow/event/SessionEvent.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/flow/event/SessionEvent.avsc
@@ -53,6 +53,12 @@
       "doc": "Sequence number of the last contiguous message received from a counterparty. 0 if no messages received."
     },
     {
+      "name": "partyWaitingForData",
+      "type": "boolean",
+      "default": false,
+      "doc": "True if party is waiting to receive the next message."
+    },
+    {
       "name": "outOfOrderSequenceNums",
       "type": {
         "type": "array",

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/flow/state/session/SessionState.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/flow/state/session/SessionState.avsc
@@ -53,6 +53,12 @@
       "doc": "Record the sequence number of the last event sent to the counterparty. Record all events sent but not yet acknowledged by the counterparty as well as any messages to send to the counterparty."
     },
     {
+      "name": "expectedSendSequenceNumber",
+      "type": "int",
+      "default": 0,
+      "doc": "The sequence number of the message that counterparty is waiting to receive. This value is used to detect situations where session hangs indefinitely because both parties are waiting to receive data."
+    },
+    {
       "name": "status",
       "type": {
         "type": "enum",

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 755
+cordaApiRevision = 756
 
 # Main
 kotlinVersion = 1.8.20


### PR DESCRIPTION
Added fields `SessionEvent.partyWaitingForData` and `SessionState.expectedSendSequenceNumber` that will be used to detect situations where session hangs indefinitely because both parties are waiting to receive data.