### PR TITLE
CORE-9004: Snakeyaml waiver removed

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -47,13 +47,6 @@ ignore:
           artifacts.
         expires: 2023-06-19T10:40:55.991Z
         created: 2022-12-20T10:40:55.995Z
-  SNYK-JAVA-ORGYAML-3152153:
-    - '*':
-        reason: >-
-          We are not exposed because we don’t accept yaml based input in any of
-          the components affected.
-        expires: 2023-06-19T15:49:59.760Z
-        created: 2023-02-24T15:49:59.763Z
   SNYK-JAVA-COMFASTERXMLWOODSTOX-3091135:
     - '*':
         reason: >-


### PR DESCRIPTION
Snakeyaml version is upgraded which removes the vulnerability. Hence the waiver is removed from the file.