### PR TITLE
CORE-12804: Add error kind

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/response/query/PersistenceFailedResponse.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/response/query/PersistenceFailedResponse.avsc
@@ -8,6 +8,14 @@
       "name": "errorMessage",
       "type": "string",
       "doc": "Error message provided in the case of failure."
+    }, {
+      "name": "errorKind",
+      "type": {
+        "type": "enum",
+        "name": "ErrorKind",
+        "symbols": ["GENERAL", "INVALID_ENTITY_UPDATE"]
+      },
+      "doc": "The kind of error that caused the failure"
     }
   ]
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 755
+cordaApiRevision = 758
 
 # Main
 kotlinVersion = 1.8.21

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 757
+cordaApiRevision = 758
 
 # Main
 kotlinVersion = 1.8.21


### PR DESCRIPTION
This will add an error kind to the membership persistence failure response. It will allow us to propagate the type of error from the DB worker to the persistent client.

Currently, it has only one kind (that is needed for CORE-12804); we should add more kinds in the future (for example, for CORE-11847)

The runtime pull request is in https://github.com/corda/corda-runtime-os/pull/3746