### PR TITLE
CORE-11162: Remove source and destination from inbound unauthenticated messages

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/p2p/UnauthenticatedRegistrationRequestHeader.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/p2p/UnauthenticatedRegistrationRequestHeader.avsc
@@ -5,6 +5,11 @@
   "doc": "Registration request header containing information required for hybrid encryption/decryption.",
   "fields": [
     {
+      "name": "mgm",
+      "doc": "Holding identity of the target MGM.",
+      "type": "net.corda.data.identity.HoldingIdentity"
+    },
+    {
       "name": "salt",
       "doc": "Salt value as bytes that needs to be used for encryption/decryption.",
       "type": "bytes"

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/LinkInMessage.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/LinkInMessage.avsc
@@ -12,7 +12,7 @@
         "net.corda.data.p2p.crypto.InitiatorHandshakeMessage",
         "net.corda.data.p2p.crypto.ResponderHelloMessage",
         "net.corda.data.p2p.crypto.ResponderHandshakeMessage",
-        "net.corda.data.p2p.app.UnauthenticatedMessage"
+        "net.corda.data.p2p.app.InboundUnauthenticatedMessage"
       ]
     }
   ]

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/LinkOutMessage.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/LinkOutMessage.avsc
@@ -16,7 +16,7 @@
         "net.corda.data.p2p.crypto.InitiatorHandshakeMessage",
         "net.corda.data.p2p.crypto.ResponderHelloMessage",
         "net.corda.data.p2p.crypto.ResponderHandshakeMessage",
-        "net.corda.data.p2p.app.UnauthenticatedMessage"
+        "net.corda.data.p2p.app.InboundUnauthenticatedMessage"
       ]
     }
   ]

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/app/AppMessage.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/app/AppMessage.avsc
@@ -8,7 +8,8 @@
         "name": "message",
         "type": [
           "net.corda.data.p2p.app.AuthenticatedMessage",
-          "net.corda.data.p2p.app.UnauthenticatedMessage"
+          "net.corda.data.p2p.app.OutboundUnauthenticatedMessage",
+          "net.corda.data.p2p.app.InboundUnauthenticatedMessage"
         ]
       }
   ]

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/app/InboundUnauthenticatedMessage.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/app/InboundUnauthenticatedMessage.avsc
@@ -1,12 +1,12 @@
 {
   "type": "record",
-  "name": "UnauthenticatedMessage",
+  "name": "InboundUnauthenticatedMessage",
   "namespace": "net.corda.data.p2p.app",
   "doc": "A message that will be delivered by the p2p layer directly (without using an end-to-end session). If there is a need for authentication, this has to be performed at the application layer.",
   "fields": [
     {
       "name": "header",
-      "type": "net.corda.data.p2p.app.UnauthenticatedMessageHeader"
+      "type": "net.corda.data.p2p.app.InboundUnauthenticatedMessageHeader"
     },
     {
       "name": "payload",

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/app/InboundUnauthenticatedMessageHeader.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/app/InboundUnauthenticatedMessageHeader.avsc
@@ -1,0 +1,17 @@
+{
+  "type": "record",
+  "name": "InboundUnauthenticatedMessageHeader",
+  "namespace": "net.corda.data.p2p.app",
+  "fields": [
+    {
+      "doc": "This value identifies the upstream user of the p2p layer that this message is sent from and should be received by. It can be used to filter incoming messages from the p2p layer and process only the ones destined for a specific system.",
+      "name": "subsystem",
+      "type": "string"
+    },
+    {
+      "doc": "A unique identifier for this message. This will be used by the p2p layer to identify the message in the logs.",
+      "name": "messageId",
+      "type": "string"
+    }
+  ]
+}

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/app/OutboundUnauthenticatedMessage.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/app/OutboundUnauthenticatedMessage.avsc
@@ -1,0 +1,16 @@
+{
+  "type": "record",
+  "name": "OutboundUnauthenticatedMessage",
+  "namespace": "net.corda.data.p2p.app",
+  "doc": "A message that will be delivered by the p2p layer directly (without using an end-to-end session). If there is a need for authentication, this has to be performed at the application layer.",
+  "fields": [
+    {
+      "name": "header",
+      "type": "net.corda.data.p2p.app.OutboundUnauthenticatedMessageHeader"
+    },
+    {
+      "name": "payload",
+      "type": "bytes"
+    }
+  ]
+}

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/app/OutboundUnauthenticatedMessageHeader.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/app/OutboundUnauthenticatedMessageHeader.avsc
@@ -1,6 +1,6 @@
 {
   "type": "record",
-  "name": "UnauthenticatedMessageHeader",
+  "name": "OutboundUnauthenticatedMessageHeader",
   "namespace": "net.corda.data.p2p.app",
   "fields": [
     {

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/gateway/GatewayMessage.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/gateway/GatewayMessage.avsc
@@ -18,7 +18,7 @@
         "net.corda.data.p2p.crypto.InitiatorHandshakeMessage",
         "net.corda.data.p2p.crypto.ResponderHelloMessage",
         "net.corda.data.p2p.crypto.ResponderHandshakeMessage",
-        "net.corda.data.p2p.app.UnauthenticatedMessage"
+        "net.corda.data.p2p.app.InboundUnauthenticatedMessage"
       ]
     }
   ]

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 755
+cordaApiRevision = 756
 
 # Main
 kotlinVersion = 1.8.21


### PR DESCRIPTION
This pull request removes the source and destination from the inbound unauthenticated message header. It also adds the MGM to the registration request header (to be able to decrypt the message).

The runtime pull request is in https://github.com/corda/corda-runtime-os/pull/3757.