### PR TITLE
CORE-10329 Create new context map for non-member context properties

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/SignedData.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/SignedData.avsc
@@ -1,0 +1,23 @@
+{
+  "type": "record",
+  "name": "SignedData",
+  "namespace": "net.corda.data.membership",
+  "doc": "Data serialized to a byte array and a signature over the resulting byte array.",
+  "fields": [
+    {
+      "name": "data",
+      "doc": "Data serialized to a byte array and signed.",
+      "type": "bytes"
+    },
+    {
+      "name": "signature",
+      "doc": "Signature over the data byte array.",
+      "type": "net.corda.data.crypto.wire.CryptoSignatureWithKey"
+    },
+    {
+      "name": "signatureSpec",
+      "doc": "Signature spec of the signature.",
+      "type": "net.corda.data.crypto.wire.CryptoSignatureSpec"
+    }
+  ]
+}

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/SignedMemberInfo.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/SignedMemberInfo.avsc
@@ -6,33 +6,13 @@
   "fields": [
     {
       "name": "memberContext",
-      "doc": "Member provided data in MemberInfo serialised as byte array by using KeyValuePairList.",
-      "type": "bytes"
+      "doc": "Signed member provided data in MemberInfo serialised as byte array by using KeyValuePairList.",
+      "type": "net.corda.data.membership.SignedData"
     },
     {
       "name": "mgmContext",
-      "doc": "MGM provided data in MemberInfo serialised as byte array by using KeyValuePairList.",
-      "type": "bytes"
-    },
-    {
-      "name": "memberSignature",
-      "doc": "Signature of the member over the memberContext.",
-      "type": "net.corda.data.crypto.wire.CryptoSignatureWithKey"
-    },
-    {
-      "name": "memberSignatureSpec",
-      "type": "net.corda.data.crypto.wire.CryptoSignatureSpec",
-      "doc": "Signature spec of member signature."
-    },
-    {
-      "name": "mgmSignature",
-      "doc": "Signature of the MGM over both the mgmContext and memberContext using MerkleTree.",
-      "type": "net.corda.data.crypto.wire.CryptoSignatureWithKey"
-    },
-    {
-      "name": "mgmSignatureSpec",
-      "type": "net.corda.data.crypto.wire.CryptoSignatureSpec",
-      "doc": "Signature spec of MGM signature."
+      "doc": "Signed MGM provided data in MemberInfo serialised as byte array by using KeyValuePairList.",
+      "type": "net.corda.data.membership.SignedData"
     }
   ]
 }

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/common/RegistrationRequestDetails.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/common/RegistrationRequestDetails.avsc
@@ -56,12 +56,12 @@
       "type": "net.corda.data.KeyValuePairList"
     },
     {
-      "name": "registrationSignature",
+      "name": "registrationContextSignature",
       "doc": "Signature of the member over the registrationContext.",
       "type": "net.corda.data.crypto.wire.CryptoSignatureWithKey"
     },
     {
-      "name": "registrationSignatureSpec",
+      "name": "registrationContextSignatureSpec",
       "doc": "Signature spec of member signature over the registrationContext.",
       "type": "net.corda.data.crypto.wire.CryptoSignatureSpec"
     },

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/common/RegistrationRequestDetails.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/common/RegistrationRequestDetails.avsc
@@ -51,6 +51,21 @@
       "type": "net.corda.data.crypto.wire.CryptoSignatureSpec"
     },
     {
+      "name": "registrationContext",
+      "doc": "Registration context submitted for registration.",
+      "type": "net.corda.data.KeyValuePairList"
+    },
+    {
+      "name": "registrationSignature",
+      "doc": "Signature of the member over the registrationContext.",
+      "type": "net.corda.data.crypto.wire.CryptoSignatureWithKey"
+    },
+    {
+      "name": "registrationSignatureSpec",
+      "doc": "Signature spec of member signature over the registrationContext.",
+      "type": "net.corda.data.crypto.wire.CryptoSignatureSpec"
+    },
+    {
       "name": "reason",
       "doc": "Reason why the request is in the status specified by [registrationStatus].",
       "type": ["string", "null"]

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/p2p/MembershipRegistrationRequest.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/p2p/MembershipRegistrationRequest.avsc
@@ -14,18 +14,13 @@
     },
     {
       "name": "memberContext",
-      "doc": "Member provided data in MemberInfo serialised as byte array by using KeyValuePairList.",
-      "type": "bytes"
+      "doc": "Member provided data in MemberInfo which has been signed by the registering member. The data must be a serialised KeyValuePairList.",
+      "type": "net.corda.data.membership.SignedData"
     },
     {
-      "name": "memberSignature",
-      "doc": "Signature of the member over the memberContext.",
-      "type": "net.corda.data.crypto.wire.CryptoSignatureWithKey"
-    },
-    {
-      "name": "memberSignatureSpec",
-      "type": "net.corda.data.crypto.wire.CryptoSignatureSpec",
-      "doc": "Signature spec of member signature."
+      "name": "registrationContext",
+      "doc": "Additional registration context which has been signed by the registering member and is not part of the MemberInfo. The data must be a serialised KeyValuePairList.",
+      "type": "net.corda.data.membership.SignedData"
     },
     {
       "name": "serial",

--- a/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/vnode-vault-creation-v1.0.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/vnode-vault-creation-v1.0.xml
@@ -73,16 +73,28 @@
             <column name="last_modified" type="TIMESTAMP">
                 <constraints nullable="false"/>
             </column>
-            <column name="context" type="VARBINARY(1048576)">
+            <column name="member_context" type="VARBINARY(1048576)">
                 <constraints nullable="false"/>
             </column>
-            <column name="signature_key" type="VARBINARY(1024)">
+            <column name="member_context_signature_key" type="VARBINARY(1024)">
                 <constraints nullable="false"/>
             </column>
-            <column name="signature_content" type="VARBINARY(4096)">
+            <column name="member_context_signature_content" type="VARBINARY(4096)">
                 <constraints nullable="false"/>
             </column>
-            <column name="signature_spec" type="NVARCHAR(255)">
+            <column name="member_context_signature_spec" type="NVARCHAR(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="registration_context" type="VARBINARY(1048576)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="registration_context_signature_key" type="VARBINARY(1024)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="registration_context_signature_content" type="VARBINARY(4096)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="registration_context_signature_spec" type="NVARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
             <column name="reason" type="NVARCHAR(255)">

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 755
+cordaApiRevision = 756
 
 # Main
 kotlinVersion = 1.8.21

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 756
+cordaApiRevision = 757
 
 # Main
 kotlinVersion = 1.8.21

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 760
+cordaApiRevision = 761
 
 # Main
 kotlinVersion = 1.8.21


### PR DESCRIPTION
This change introduces an additional context map to the internal network registration request. This is because the original context map is signed over and the signature becomes invalid if the map is modified so whatever is submitted in that context map became part of the member's member context map. It's preferred to not include the pre-auth token in the member info distributed across the network. To support this and other properties in the future which should not be distributed, an additional context map has been added. 

This new context map is also signed. To avoid duplication, data and a signature over that data was pulled out in to it's own schema and membership schemas were updated where the same structure is already in use. 

Runtime OS PR: https://github.com/corda/corda-runtime-os/pull/3781