### PR TITLE
CORE-13257: Don't allow other sandbox types in configuration

### DIFF
--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/sandbox/1.0/corda.sandbox.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/sandbox/1.0/corda.sandbox.json
@@ -4,8 +4,8 @@
   "title": "Corda Sandbox Configuration Schema",
   "description": "Configuration schema for the sandbox section.",
   "type": "object",
+  "additionalProperties": false,
   "properties": {
-    "additionalProperties": false,
     "flow": {
       "description": "Settings for flow sandbox",
       "type": "object",

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/sandbox/1.0/corda.sandbox.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/sandbox/1.0/corda.sandbox.json
@@ -10,11 +10,13 @@
       "description": "Settings for flow sandbox",
       "type": "object",
       "default": {},
+      "additionalProperties": false,
       "properties": {
         "cache": {
           "description": "Settings for flow sandbox caching",
           "type": "object",
           "default": {},
+          "additionalProperties": false,
           "properties": {
             "size": {
               "description": "The maximum number cached flow sandboxes.",
@@ -30,11 +32,13 @@
       "description": "Settings for db sandbox",
       "type": "object",
       "default": {},
+      "additionalProperties": false,
       "properties": {
         "cache": {
           "description": "Settings for db sandbox caching",
           "type": "object",
           "default": {},
+          "additionalProperties": false,
           "properties": {
             "size": {
               "description": "The maximum number cached db sandboxes.",
@@ -50,11 +54,13 @@
       "description": "Settings for verification sandbox",
       "type": "object",
       "default": {},
+      "additionalProperties": false,
       "properties": {
         "cache": {
           "description": "Settings for verification sandbox caching.",
           "type": "object",
           "default": {},
+          "additionalProperties": false,
           "properties": {
             "size": {
               "description": "The maximum number of cached verification sandboxes.",

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/sandbox/1.0/corda.sandbox.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/sandbox/1.0/corda.sandbox.json
@@ -5,6 +5,7 @@
   "description": "Configuration schema for the sandbox section.",
   "type": "object",
   "properties": {
+    "additionalProperties": false,
     "flow": {
       "description": "Settings for flow sandbox",
       "type": "object",


### PR DESCRIPTION
We have three different types of sandbox.  Adding a field in the schema to disallow configuration of other types (that don't actually exist in code) will keep users from accidentally setting the wrong thing.  (eg. `db` instead of `persistence`)