### PR TITLE
CORE-9004: Update version os SnakeYaml to 2.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -35,7 +35,7 @@ dokkaVersion = 1.8.+
 detektPluginVersion = 1.22.+
 dependencyCheckVersion=0.46.+
 artifactoryPluginVersion = 4.28.2
-snakeyamlVersion=1.32
+snakeyamlVersion=2.0
 
 # Logging
 slf4jVersion = 1.7.36


### PR DESCRIPTION
This is meant to resolve [CVE-2022-1471](https://www.cve.org/CVERecord?id=CVE-2022-1471).
Earlier upgrade of Jackson library to 2.15.0 enabled us to move on to SnakeYaml 2.0.