### PR TITLE
CORE-13495 Improve Query API JavaDocs

### DIFF
--- a/application/src/main/java/net/corda/v5/application/persistence/PagedQuery.java
+++ b/application/src/main/java/net/corda/v5/application/persistence/PagedQuery.java
@@ -54,6 +54,32 @@ public interface PagedQuery<R> {
 
     /**
      * A result set containing the results of calling {@link PagedQuery#execute()}.
+     * <p>
+     * Use this class to access the results of a query and to re-execute the query to retrieve following pages of
+     * results by using {@link #hasNext()} and {@link #next()}.
+     * <p>
+     * Example usage:
+     <ul>
+     * <li>Kotlin:<pre>{@code
+     * val resultSet = query.execute()
+     *
+     * processResultsWithApplicationLogic(resultSet.results)
+     *
+     * while (resultSet.hasNext()) {
+     *     val results = resultSet.next()
+     *     processResultsWithApplicationLogic(results)
+     * }
+     * }</pre></li>
+     * <li>Java:<pre>{@code
+     * PagedQuery.ResultSet<Integer> resultSet = query.execute();
+     *
+     * processResultsWithApplicationLogic(resultSet.getResults());
+     *
+     * while (resultSet.hasNext()) {
+     *     List<Integer> results = resultSet.next();
+     *     processResultsWithApplicationLogic(results);
+     * }
+     * }</pre></li>
      *
      * @param <R> The type of the results contained in the result set.
      */
@@ -79,8 +105,6 @@ public interface PagedQuery<R> {
          * behaviour when calling this method.
          *
          * @return {@code true} if the {@link ResultSet} has more results to retrieve.
-         *
-         * @return
          */
         boolean hasNext();
 

--- a/application/src/main/java/net/corda/v5/application/persistence/PersistenceService.java
+++ b/application/src/main/java/net/corda/v5/application/persistence/PersistenceService.java
@@ -157,26 +157,23 @@ public interface PersistenceService {
      *     // ...
      * }
      *
-     * // create a named query setting parameters one-by-one, that returns the second page of up to 100 records
+     * // Create a named query that returns pages of up to 100 records
      * val pagedQuery = persistenceService
      *     .query("find_by_name_and_age", Dog::class.java)
      *     .setParameter("name", "Felix")
      *     .setParameter("maxAge", 5)
      *     .setLimit(100)
-     *     .setOffset(200)
+     *     .setOffset(0)
      *
-     * // execute the query and return the results as a List
-     * val result1 = pagedQuery.execute()
+     * // Execute the query and return a ResultSet
+     * val resultSet = pagedQuery.execute()
      *
-     * // create a named query setting parameters as Map, that returns the second page of up to 100 records
-     * val paramQuery = persistenceService
-     *     .query("find_by_name_and_age", Dog::class.java)
-     *     .setParameters(mapOf(Pair("name", "Felix"), Pair("maxAge", 5)))
-     *     .setLimit(100)
-     *     .setOffset(200)
+     * processResultsWithApplicationLogic(resultSet.results)
      *
-     * // execute the query and return the results as a List
-     * val result2 = pagedQuery.execute()
+     * while (resultSet.hasNext()) {
+     *     val results = resultSet.next()
+     *     processResultsWithApplicationLogic(results)
+     * }
      * }</pre></li>
      * <li>Java:<pre>{@code
      * // For JPA Entity:
@@ -196,26 +193,23 @@ public interface PersistenceService {
      *      ...
      * }
      *
-     * // create a named query setting parameters one-by-one, that returns the second page of up to 100 records
+     * // Create a named query that returns pages of up to 100 records
      * ParameterizedQuery<Dog> pagedQuery = persistenceService
      *         .query("find_by_name_and_age", Dog.class)
      *         .setParameter("name", "Felix")
      *         .setParameter("maxAge", 5)
      *         .setLimit(100)
-     *         .setOffset(200);
+     *         .setOffset(0);
      *
-     * // execute the query and return the results as a List
-     * List<Dog> result1 = pagedQuery.execute();
+     * // Execute the query and return a ResultSet
+     * ResultSet<Dog> resultSet = pagedQuery.execute();
      *
-     * // create a named query setting parameters as Map, that returns the second page of up to 100 records
-     * ParameterizedQuery<Dog> paramQuery = persistenceService
-     *         .query("find_by_name_and_age", Dog.class)
-     *         .setParameters(Map.of("name", "Felix", "maxAge", 5))
-     *         .setLimit(100)
-     *         .setOffset(200);
+     * processResultsWithApplicationLogic(resultSet.getResults());
      *
-     * // execute the query and return the results as a List
-     * List<Dog> result2 = pagedQuery.execute();
+     * while (resultSet.hasNext()) {
+     *     List<Integer> results = resultSet.next();
+     *     processResultsWithApplicationLogic(results);
+     * }
      * }</pre></li>
      * </ul>
      * @param queryName The name of the named query registered in the persistence context.

--- a/ledger/ledger-utxo/src/main/java/net/corda/v5/ledger/utxo/query/VaultNamedParameterizedQuery.java
+++ b/ledger/ledger-utxo/src/main/java/net/corda/v5/ledger/utxo/query/VaultNamedParameterizedQuery.java
@@ -13,10 +13,10 @@ import java.util.Map;
 
 /**
  * Representation of a vault named query.
- * </p>
+ * <p>
  * Ensure that {@link R} matches the type returned from the {@link VaultNamedQueryTransformer} and/or
- * {@link VaultNamedQueryCollector} (both optional) for the vault named query this object represents.
- * </p>
+ * {@link VaultNamedQueryCollector} (both optional) for the vault named query that this query object executes.
+ * <p>
  * If no {@link VaultNamedQueryTransformer} or {@link VaultNamedQueryCollector} is applied to the vault named query,
  * the {@link ResultSet} from executing this query will contain {@link StateAndRef}s.
  *
@@ -56,6 +56,7 @@ public interface VaultNamedParameterizedQuery<R> extends ParameterizedQuery<R> {
 
     /**
      * Sets the timestamp limit for the query. This will influence which results are returned.
+     *
      * @param timestampLimit The timestamp limit the query should enforce.
      * @return A {@link VaultNamedParameterizedQuery} object with the timestamp limit set.
      */
@@ -63,8 +64,8 @@ public interface VaultNamedParameterizedQuery<R> extends ParameterizedQuery<R> {
     VaultNamedParameterizedQuery<R> setCreatedTimestampLimit(@NotNull Instant timestampLimit);
 
     /**
-     * Executes the {@link VaultNamedParameterizedQuery} and creates a {@link PagedQuery.ResultSet} contains the results
-     * of the query.
+     * Executes the {@link VaultNamedParameterizedQuery} and creates a {@link PagedQuery.ResultSet} containing the
+     * results of the query.
      * <p>
      * The results of the query depends on the executed named query and the {@link VaultNamedQueryTransformer} and/or
      * {@link VaultNamedQueryCollector} (both optional) applied to it.

--- a/ledger/ledger-utxo/src/main/java/net/corda/v5/ledger/utxo/query/VaultNamedQueryFactory.java
+++ b/ledger/ledger-utxo/src/main/java/net/corda/v5/ledger/utxo/query/VaultNamedQueryFactory.java
@@ -8,8 +8,6 @@ import org.jetbrains.annotations.NotNull;
  * The main interface that needs to be implemented by the named ledger queries. Implementing this interface will define how
  * the named query will be built and stored.
  *
- * @see ContractStateVaultJsonFactory to define how a given state type will be represented as a JSON string.
- *
  * <p>
  * Example usage:
  * <ul>
@@ -51,12 +49,10 @@ import org.jetbrains.annotations.NotNull;
  * }
  * }</pre></li></ul>
  *
- * For more details on how to use filters, mappers and collectors, refer to the following documentation:
- * <ul>
- * <li> For filters, see {@link VaultNamedQueryFilter}. </li>
- * <li> For mappers, see {@link VaultNamedQueryTransformer}. </li>
- * <li> For collectors, see {@link VaultNamedQueryCollector}. </li>
- * </ul>
+ * @see ContractStateVaultJsonFactory To define how a given state type will be represented as a JSON string
+ * @see VaultNamedQueryFilter
+ * @see VaultNamedQueryTransformer
+ * @see VaultNamedQueryCollector
  */
 public interface VaultNamedQueryFactory {
     void create(@NotNull VaultNamedQueryBuilderFactory vaultNamedQueryBuilderFactory);

--- a/ledger/ledger-utxo/src/main/java/net/corda/v5/ledger/utxo/query/registration/VaultNamedQueryBuilder.java
+++ b/ledger/ledger-utxo/src/main/java/net/corda/v5/ledger/utxo/query/registration/VaultNamedQueryBuilder.java
@@ -1,5 +1,6 @@
 package net.corda.v5.ledger.utxo.query.registration;
 
+import net.corda.v5.ledger.utxo.StateAndRef;
 import net.corda.v5.ledger.utxo.query.VaultNamedQueryCollector;
 import net.corda.v5.ledger.utxo.query.VaultNamedQueryFilter;
 import net.corda.v5.ledger.utxo.query.VaultNamedQueryTransformer;
@@ -12,8 +13,12 @@ import org.jetbrains.annotations.NotNull;
  * later on.
  */
 public interface VaultNamedQueryBuilder extends VaultNamedQueryBuilderBase {
+
     /**
      * Sets the where clause of the named query.
+     * <p>
+     * Vault named queries defined with {@link #whereJson(String)} return {@link StateAndRef}s when executed.
+     *
      * @param query The JSON query representation.
      *
      * @return A builder instance with the where clause set.
@@ -23,6 +28,7 @@ public interface VaultNamedQueryBuilder extends VaultNamedQueryBuilderBase {
 
     /**
      * Sets the filter function of the named query.
+     * <p>
      * Note that filtering will always be applied before mapping.
      *
      * @param filter A filter object.
@@ -33,6 +39,7 @@ public interface VaultNamedQueryBuilder extends VaultNamedQueryBuilderBase {
 
     /**
      * Sets the mapper function of the named query.
+     * <p>
      * Note that the transformation will always be applied after filtering.
      *
      * @param transformer A transformer object.
@@ -43,6 +50,7 @@ public interface VaultNamedQueryBuilder extends VaultNamedQueryBuilderBase {
 
     /**
      * Sets the collector function of the named query.
+     *
      * @param collector A collector object.
      *
      * @return A builder instance with the collector function set.


### PR DESCRIPTION
Update to use `ResultSet.next` for examples of executing paged queries.

Tidied up other querying documentation.