### PR TITLE
NOTICK Recurring merge from main onto interop API version 1

### DIFF
--- a/.ci/JenkinsApiCompatibility
+++ b/.ci/JenkinsApiCompatibility
@@ -1,4 +1,4 @@
 // Check corda-api compatibility with downstream consumers which implement CordApps
-@Library('corda-shared-build-pipeline-steps@5.0.1') _
+@Library('corda-shared-build-pipeline-steps@5.1') _
 
 cordaApiCompatibilityCheck()

--- a/.ci/JenkinsfileSnykDelta
+++ b/.ci/JenkinsfileSnykDelta
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@5.0.1') _
+@Library('corda-shared-build-pipeline-steps@5.1') _
 
 snykDelta(
   snykOrgId: 'corda5-snyk-org-id',

--- a/.ci/nightly/JenkinsfileNightly
+++ b/.ci/nightly/JenkinsfileNightly
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@5.0.1') _
+@Library('corda-shared-build-pipeline-steps@5.1') _
 
 cordaPipelineKubernetesAgent(
     nexusAppId: 'net.corda-api-5.0',

--- a/.ci/nightly/JenkinsfileSnykScan
+++ b/.ci/nightly/JenkinsfileSnykScan
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@5.0.1') _
+@Library('corda-shared-build-pipeline-steps@5.1') _
 
 cordaSnykScanPipeline (
     snykTokenId: 'r3-snyk-corda5'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@5.0.1') _
+@Library('corda-shared-build-pipeline-steps@5.1') _
 
 cordaPipeline(
     runIntegrationTests: false,

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/p2p.gateway/1.0/corda.p2p.gateway.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/p2p.gateway/1.0/corda.p2p.gateway.json
@@ -8,7 +8,7 @@
     "serversConfiguration": {
       "type": "array",
       "minItems": 1,
-      "description": "The HTTP servers. The hostAddress and hostPort pair must be unique for each server.",
+      "description": "A list of HTTP servers that Corda listens to. The list is specified as an array of hostAddress, hostPort, and urlPath values. The hostAddress and hostPort pair must be unique for each server.",
       "default": [{
         "hostAddress": "0.0.0.0",
         "hostPort": 8080,

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/sandbox/1.0/corda.sandbox.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/sandbox/1.0/corda.sandbox.json
@@ -7,19 +7,19 @@
   "additionalProperties": false,
   "properties": {
     "flow": {
-      "description": "Settings for flow sandbox",
+      "description": "Settings for the flow sandbox.",
       "type": "object",
       "default": {},
       "additionalProperties": false,
       "properties": {
         "cache": {
-          "description": "Settings for flow sandbox caching",
+          "description": "Settings for flow sandbox caching.",
           "type": "object",
           "default": {},
           "additionalProperties": false,
           "properties": {
             "size": {
-              "description": "The maximum number cached flow sandboxes.",
+              "description": "The maximum number of cached flow sandboxes.",
               "type": "integer",
               "minimum": 0,
               "default": 10
@@ -29,19 +29,19 @@
       }
     },
     "persistence": {
-      "description": "Settings for db sandbox",
+      "description": "Settings for the database sandbox.",
       "type": "object",
       "default": {},
       "additionalProperties": false,
       "properties": {
         "cache": {
-          "description": "Settings for db sandbox caching",
+          "description": "Settings for database sandbox caching.",
           "type": "object",
           "default": {},
           "additionalProperties": false,
           "properties": {
             "size": {
-              "description": "The maximum number cached db sandboxes.",
+              "description": "The maximum number of cached database sandboxes.",
               "type": "integer",
               "minimum": 0,
               "default": 10
@@ -51,7 +51,7 @@
       }
     },
     "verification": {
-      "description": "Settings for verification sandbox",
+      "description": "Settings for the verification sandbox.",
       "type": "object",
       "default": {},
       "additionalProperties": false,

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,11 +6,11 @@ org.gradle.java.installations.auto-download=false
 org.gradle.jvmargs=-Dfile.encoding=UTF-8
 
 # Versioning
-cordaProductVersion = 5.0.0
+cordaProductVersion = 5.1.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 763
+cordaApiRevision = 1
 
 # Main
 kotlinVersion = 1.8.21


### PR DESCRIPTION
No conflicts, moving Cora version `5.0.0` -> `5.1.0`, API version set back to `1` on the main (see https://github.com/corda/corda-api/commit/6028bb677d518f3cfbcc4f8dda7a917fe0a85bda), Interop version set back to `1` as well.