### PR TITLE
ES-371/set correct license

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -20,9 +20,8 @@ kotlin.stdlib.default.dependency = false
 jetbrainsAnnotationsVersion = 13.0
 
 # License
-## TODO: Change to correct name and URL
-licenseName = Corda Pre-Release Software License Agreement
-licenseUrl = https://www.r3.com/wp-content/uploads/2020/07/Corda-Pre-Release-Software-License-Agreement.pdf
+licenseName = The Apache License, Version 2.0
+licenseUrl = http://www.apache.org/licenses/LICENSE-2.0.txt
 
 # Artifactory
 artifactoryContextUrl = https://software.r3.com/artifactory


### PR DESCRIPTION
As part of the C5 build process a license file is injected into the pom.xml of a produced Jar this license file is specified as part of the gradle.properties of each repo the current license properties are not correct / outdated and should be updated pre GA
