### PR TITLE
ES-383: use classic JavaDoc style when generating api docs 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -348,6 +348,10 @@ tasks.register('generateMultiModuleDocs', Zip) {
 
 }
 
+tasks.named('dokkaJavadocCollector') {
+    dependsOn ':data:avro-schema:generateAvro', 'data:avro-schema:generateOSGiPackageInfo'
+}
+
 if (project.hasProperty('publishMultiModulekDocs')) {
     publishing {
         publications {

--- a/build.gradle
+++ b/build.gradle
@@ -341,10 +341,11 @@ tasks.register('generateMultiModuleDocs', Zip) {
     description = 'Create mutli module docs Site Jar'
     group = 'documentation'
 
-    dependsOn dokkaHtmlMultiModule
+    dependsOn dokkaJavadocCollector
     archiveFileName = "corda-api-docs-${project.version}.zip"
-    from(dokkaHtmlMultiModule.outputDirectory)
+    from("${buildDir}/dokka/javadocCollector")
     destinationDirectory = (file("$buildDir/corda-api-docs"))
+
 }
 
 if (project.hasProperty('publishMultiModulekDocs')) {


### PR DESCRIPTION
With the removal of Kotlin code from this repo, we should be producing classic-styled JavaDoc rather than Dokka-style Kotlin docs.

This change modified the existing `generateMultiModuleDocs` task to hook into the `dokkaJavadocCollector` task rather than `dokkaHtmlMultiModule`.

Also, since Gradle 8.1.1 Gradle has become more opinionated about [implicit dependencies ](https://docs.gradle.org/8.1.1/userguide/validation_problems.html#implicit_dependency)between tasks that are not explicitly declared - this is why we need to change the configuration of `dokkaJavadocCollector` to add a dependency on `generateAvro `and `generateOSGiPackageInfo` without these the build will fail with the following 

`    Reason: Task ':dokkaJavadocCollector' uses this output of task ':data:avro-schema:generateOSGiPackageInfo' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.`

The resulting output here is an archive containing JavaDoc in the classic style, as can be seen in the screen grab below taken from files generated in the local execution of this task:

![image](https://github.com/corda/corda-api/assets/5963044/d95908b0-bff1-4df3-ae0c-8091e0df3464)

Previous output with Kotlin styling:
![image](https://github.com/corda/corda-api/assets/5963044/a7ab0fda-fa0f-4920-ab9d-d0b66d84ad7b)

