### PR TITLE
CORE-13353 Added support for storing flow metric state in the checkpoint

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/flow/state/checkpoint/Checkpoint.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/flow/state/checkpoint/Checkpoint.avsc
@@ -26,6 +26,12 @@
         "net.corda.data.flow.state.checkpoint.FlowState"
       ],
       "doc": "Current flow execution state. Null if the flow has not yet been started, for example in the face of a retry-able error."
+    },
+    {
+      "name": "flowMetricsState",
+      "type": "string",
+      "default": "{}",
+      "doc": "Internal storage for recording flow metrics"
     }
   ]
 }


### PR DESCRIPTION
Adding support for storing flow metric state is the checkpoint. This is used for metrics that span flow suspensions.