### PR TITLE
CORE-13740: Add minimal db connection pool size

### DIFF
--- a/data/config-schema/src/main/java/net/corda/schema/configuration/DatabaseConfig.java
+++ b/data/config-schema/src/main/java/net/corda/schema/configuration/DatabaseConfig.java
@@ -10,4 +10,5 @@ public final class DatabaseConfig {
     public static final String JDBC_DRIVER_DIRECTORY = "database.jdbc.directory";
     public static final String JDBC_URL = "database.jdbc.url";
     public static final String DB_POOL_MAX_SIZE = "database.pool.max_size";
+    public static final String DB_POOL_MIN_SIZE = "database.pool.min_size";
 }

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/db/1.0/corda.db.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/db/1.0/corda.db.json
@@ -53,7 +53,7 @@
               "default": 10
             },
             "min_size": {
-              "description": "The minimal database pool size.",
+              "description": "The minimum database pool size.",
               "default": null,
               "anyOf": [
                 {

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/db/1.0/corda.db.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/db/1.0/corda.db.json
@@ -53,7 +53,7 @@
               "default": 10
             },
             "min_size": {
-              "description": "The minimum database pool size.",
+              "description": "The minimum database pool size. If left null will default to the `max_size` value.",
               "default": null,
               "anyOf": [
                 {

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/db/1.0/corda.db.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/db/1.0/corda.db.json
@@ -51,6 +51,19 @@
               "type": "integer",
               "minimum": 1,
               "default": 10
+            },
+            "min_size": {
+              "description": "The minimal database pool size.",
+              "default": null,
+              "anyOf": [
+                {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                {
+                  "type": "null"
+                }
+              ]
             }
           },
           "additionalProperties": false

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ cordaProductVersion = 5.1.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 312
+cordaApiRevision = 3
 
 # Main
 kotlinVersion = 1.8.21

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ cordaProductVersion = 5.1.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 2
+cordaApiRevision = 312
 
 # Main
 kotlinVersion = 1.8.21


### PR DESCRIPTION
The runtime pull request is in https://github.com/corda/corda-runtime-os/pull/3909

This will add a minimal size of the connection pool size.

Additional properties will be added in CORE-11035. The minimal pool size is needed to cache a pool for each virtual node without having too many concurrent open connections.