### PR TITLE
CORE-14015: merge  forward 5.0 changes to 5.1

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/flow/state/checkpoint/Checkpoint.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/flow/state/checkpoint/Checkpoint.avsc
@@ -26,6 +26,12 @@
         "net.corda.data.flow.state.checkpoint.FlowState"
       ],
       "doc": "Current flow execution state. Null if the flow has not yet been started, for example in the face of a retry-able error."
+    },
+    {
+      "name": "flowMetricsState",
+      "type": "string",
+      "default": "{}",
+      "doc": "Internal storage for recording flow metrics"
     }
   ]
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ cordaProductVersion = 5.0.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 763
+cordaApiRevision = 764
 
 # Main
 kotlinVersion = 1.8.21


### PR DESCRIPTION
Forward merge CORE-13353 Add a metrics state to the flow checkpoint for holding onto flow metrics (https://github.com/corda/corda-api/pull/1125)

Matching corda-runtime-os change: https://github.com/corda/corda-runtime-os/pull/3972