### PR TITLE
CORE-13567 Add extra datasource properties to Db config schema

### DIFF
--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/db/1.0/corda.db.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/db/1.0/corda.db.json
@@ -66,19 +66,19 @@
               ]
             },
             "idleTimeout": {
-              "description": "The maximum time (in minutes) a connection can stay idle in the pool. A value of 0 means that idle connections are never removed from the pool.",
+              "description": "The maximum time (in seconds) a connection can stay idle in the pool. A value of 0 means that idle connections are never removed from the pool.",
               "type": "integer",
               "minimum": 0,
-              "default": 2
+              "default": 120
             },
             "maxLifetime": {
-              "description": "The maximum time (in minutes) a connection can stay in the pool, regardless if it is idle or not.",
+              "description": "The maximum time (in seconds) a connection can stay in the pool, regardless if it has been idle or has been recently used. If a connection is in-use and has reached \"maxLifetime\" timeout, it will be removed only when it becomes idle.",
               "type": "integer",
               "minimum": 1,
-              "default": 30
+              "default": 1800
             },
             "keepaliveTime": {
-              "description": "The interval time (in seconds) in which connections will be tested for aliveness, keeping them alive by the act of checking. A value of 0 means this is disabled.",
+              "description": "The interval time (in seconds) in which connections will be tested for aliveness. Connections which are no longer alive are removed from the pool. A value of 0 means this check is disabled.",
               "type": "integer",
               "minimum": 0,
               "default": 0

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/db/1.0/corda.db.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/db/1.0/corda.db.json
@@ -66,23 +66,27 @@
               ]
             },
             "idleTimeout": {
-              "description": "The TODO time in minutes.",
+              "description": "The maximum time (in minutes) a connection can stay idle in the pool. A value of 0 means that idle connections are never removed from the pool.",
               "type": "integer",
+              "minimum": 0,
               "default": 2
             },
             "maxLifetime": {
-              "description": "The TODO time in minutes.",
+              "description": "The maximum time (in minutes) a connection can stay in the pool, regardless if it is idle or not.",
               "type": "integer",
+              "minimum": 1,
               "default": 30
             },
             "keepaliveTime": {
-              "description": "The TODO time in seconds.",
+              "description": "The interval time (in seconds) in which connections will be tested for aliveness, keeping them alive by the act of checking. A value of 0 means this is disabled.",
               "type": "integer",
+              "minimum": 0,
               "default": 0
             },
             "validationTimeout": {
-              "description": "The TODO time in seconds.",
+              "description": "The maximum time (in seconds) that the pool will wait for a connection to be validated as alive.",
               "type": "integer",
+              "minimum": 1,
               "default": 5
             }
           },

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/db/1.0/corda.db.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/db/1.0/corda.db.json
@@ -64,6 +64,26 @@
                   "type": "null"
                 }
               ]
+            },
+            "idleTimeout": {
+              "description": "The TODO time in minutes.",
+              "type": "integer",
+              "default": 2
+            },
+            "maxLifetime": {
+              "description": "The TODO time in minutes.",
+              "type": "integer",
+              "default": 30
+            },
+            "keepaliveTime": {
+              "description": "The TODO time in seconds.",
+              "type": "integer",
+              "default": 0
+            },
+            "validationTimeout": {
+              "description": "The TODO time in seconds.",
+              "type": "integer",
+              "default": 5
             }
           },
           "additionalProperties": false

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/db/1.0/corda.db.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/db/1.0/corda.db.json
@@ -72,7 +72,7 @@
               "default": 120
             },
             "maxLifetime": {
-              "description": "The maximum time (in seconds) a connection can stay in the pool, regardless if it has been idle or has been recently used. If a connection is in-use and has reached \"maxLifetime\" timeout, it will be removed only when it becomes idle.",
+              "description": "The maximum time (in seconds) a connection can stay in the pool, regardless if it has been idle or has been recently used. If a connection is in-use and has reached \"maxLifetime\" timeout, it will be removed from the pool only when it becomes idle.",
               "type": "integer",
               "minimum": 1,
               "default": 1800


### PR DESCRIPTION
- adds configuration for the following datasource properties:
  - `idleTimeout`
  - `maxLifetime`
  - `keepaliveTime`
  - `validationTimeout`