### PR TITLE
CORE-11037 Add constants for datasource properties config keys

### DIFF
--- a/data/config-schema/src/main/java/net/corda/schema/configuration/DatabaseConfig.java
+++ b/data/config-schema/src/main/java/net/corda/schema/configuration/DatabaseConfig.java
@@ -11,4 +11,8 @@ public final class DatabaseConfig {
     public static final String JDBC_URL = "database.jdbc.url";
     public static final String DB_POOL_MAX_SIZE = "database.pool.max_size";
     public static final String DB_POOL_MIN_SIZE = "database.pool.min_size";
+    public static final String DB_POOL_IDLE_TIMEOUT = "database.pool.idleTimeout";
+    public static final String DB_POOL_MAX_LIFETIME = "database.pool.maxLifetime";
+    public static final String DB_POOL_KEEP_ALIVE_TIME = "database.pool.keepaliveTime";
+    public static final String DB_POOL_VALIDATION_TIMEOUT = "database.pool.validationTimeout";
 }

--- a/data/config-schema/src/main/java/net/corda/schema/configuration/DatabaseConfig.java
+++ b/data/config-schema/src/main/java/net/corda/schema/configuration/DatabaseConfig.java
@@ -13,6 +13,6 @@ public final class DatabaseConfig {
     public static final String DB_POOL_MIN_SIZE = "database.pool.min_size";
     public static final String DB_POOL_IDLE_TIMEOUT = "database.pool.idleTimeout";
     public static final String DB_POOL_MAX_LIFETIME = "database.pool.maxLifetime";
-    public static final String DB_POOL_KEEP_ALIVE_TIME = "database.pool.keepaliveTime";
+    public static final String DB_POOL_KEEPALIVE_TIME = "database.pool.keepaliveTime";
     public static final String DB_POOL_VALIDATION_TIMEOUT = "database.pool.validationTimeout";
 }


### PR DESCRIPTION
- adds constants for config keys for the following datasource  properties:
  - `idleTimeout`
  - `maxLifetime`
  - `keepaliveTime`
  - `validationTimeout`
