### PR TITLE
ES-89: Merging forward updates from release/os/5.0 to release/os/5.1

### DIFF
--- a/.ci/nightly/JenkinsfileNightly
+++ b/.ci/nightly/JenkinsfileNightly
@@ -1,7 +1,6 @@
 @Library('corda-shared-build-pipeline-steps@5.0.1') _
 
 cordaPipelineKubernetesAgent(
-    nexusAppId: 'net.corda-api-5.0',
     runIntegrationTests: false,
     dailyBuildCron: 'H 02 * * *',
     gradleAdditionalArgs: '-Dscan.tag.Nightly-Build',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,6 @@
 
 cordaPipeline(
     runIntegrationTests: false,
-    nexusAppId: 'net.corda-api-5.0',
     dependentJobsNames: ['/Corda5/corda-runtime-os-version-compatibility/release%2Fos%2F5.0'],
     dependentJobsNonBlocking: ['/Corda5/corda-api-compatibility/'],
     // always use -beta-9999999999999 for local publication as this is used for the version compatibility checks,


### PR DESCRIPTION
Includes:
* ES-89: removed obsolete parameter of shared pipeline (https://github.com/corda/corda-api/pull/1144)