### PR TITLE
CORE-14504: Upgrade to Bndlib 6.4.1.

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -11,6 +11,7 @@ repositories {
 def constants = new Properties()
 file("$rootDir/../gradle.properties").withInputStream { InputStream input -> constants.load(input) }
 def bndVersion = constants.getProperty('bndVersion')
+def bndlibVersion = constants.getProperty('bndlibVersion')
 def internalPublishVersion = constants.getProperty('internalPublishVersion')
 def artifactoryContextUrl = constants.getProperty('artifactoryContextUrl')
 
@@ -49,6 +50,23 @@ repositories {
 }
 
 dependencies {
+    constraints {
+        implementation('biz.aQute.bnd:biz.aQute.bndlib') {
+            version {
+                require bndlibVersion
+            }
+        }
+        implementation('biz.aQute.bnd:biz.aQute.bnd.embedded-repo') {
+            version {
+                require bndlibVersion
+            }
+        }
+        implementation('biz.aQute.bnd:biz.aQute.resolve') {
+            version {
+                require bndlibVersion
+            }
+        }
+    }
     implementation "biz.aQute.bnd:biz.aQute.bnd.gradle:$bndVersion"
 
     if (System.getenv('CORDA_ARTIFACTORY_USERNAME') != null || project.hasProperty('cordaArtifactoryUsername')) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -56,6 +56,7 @@ mockitoKotlinVersion = 4.1.+
 
 # OSGi
 bndVersion = 6.4.0
+bndlibVersion = 6.4.1
 osgiVersion = 8.0.0
 osgiAnnotationVersion = 8.1.0
 osgiScrAnnotationVersion = 1.5.1


### PR DESCRIPTION
Bndlib 6.4.1 has been released, although the latest Bnd Gradle plugin is still 6.4.0.