### PR TITLE
CORE-14564 - Review backward compatibility for RegistrationStatus

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/command/registration/member/PersistMemberRegistrationState.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/command/registration/member/PersistMemberRegistrationState.avsc
@@ -12,7 +12,7 @@
     {
       "name": "setStatusRequest",
       "doc" : "The request to set the status.",
-      "type": "net.corda.data.membership.p2p.SetOwnRegistrationStatus"
+      "type": "net.corda.data.membership.p2p.v2.SetOwnRegistrationStatus"
     }
   ]
 }

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/common/RegistrationRequestDetails.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/common/RegistrationRequestDetails.avsc
@@ -23,7 +23,7 @@
     {
       "name": "registrationStatus",
       "doc": "Status of the registration request.",
-      "type": "RegistrationStatus"
+      "type": "net.corda.data.membership.common.v2.RegistrationStatus"
     },
     {
       "name": "registrationId",

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/common/RegistrationStatus.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/common/RegistrationStatus.avsc
@@ -15,5 +15,6 @@
     "INVALID",
     "FAILED",
     "APPROVED"
-  ]
+  ],
+  "default": "NEW"
 }

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/common/v2/RegistrationStatus.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/common/v2/RegistrationStatus.avsc
@@ -1,12 +1,13 @@
 {
   "type": "enum",
   "name": "RegistrationStatus",
-  "namespace": "net.corda.data.membership.common",
+  "namespace": "net.corda.data.membership.common.v2",
   "doc": "Registration request status.",
   "symbols": [
     "NEW",
     "SENT_TO_MGM",
     "RECEIVED_BY_MGM",
+    "STARTED_PROCESSING_BY_MGM",
     "PENDING_MEMBER_VERIFICATION",
     "PENDING_MANUAL_APPROVAL",
     "PENDING_AUTO_APPROVAL",
@@ -14,5 +15,6 @@
     "INVALID",
     "FAILED",
     "APPROVED"
-  ]
+  ],
+  "default": "NEW"
 }

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/request/command/PersistRegistrationRequest.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/request/command/PersistRegistrationRequest.avsc
@@ -7,7 +7,7 @@
     {
       "name": "status",
       "doc": "Indicator of the current status of the request.",
-      "type": "net.corda.data.membership.common.RegistrationStatus"
+      "type": "net.corda.data.membership.common.v2.RegistrationStatus"
     },
     {
       "name": "registeringHoldingIdentity",

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/request/command/UpdateRegistrationRequestStatus.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/request/command/UpdateRegistrationRequestStatus.avsc
@@ -15,7 +15,7 @@
     {
       "name": "registrationStatus",
       "doc": "The new status for this registration request.",
-      "type": "net.corda.data.membership.common.RegistrationStatus"
+      "type": "net.corda.data.membership.common.v2.RegistrationStatus"
     },
     {
       "name": "reason",

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/request/query/QueryRegistrationRequests.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/request/query/QueryRegistrationRequests.avsc
@@ -14,7 +14,7 @@
       "doc": "Requests in the specified statuses will be included in the query result.",
       "type": {
         "type": "array",
-        "items": "net.corda.data.membership.common.RegistrationStatus"
+        "items": "net.corda.data.membership.common.v2.RegistrationStatus"
       }
     },
     {

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/p2p/v2/SetOwnRegistrationStatus.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/p2p/v2/SetOwnRegistrationStatus.avsc
@@ -1,0 +1,21 @@
+{
+  "type": "record",
+  "name": "SetOwnRegistrationStatus",
+  "namespace": "net.corda.data.membership.p2p.v2",
+  "doc": "Set the member registration status.",
+  "fields": [
+    {
+      "name": "registrationId",
+      "doc": "ID of the registration to set the status.",
+      "type": {
+        "type": "string",
+        "logicalType": "uuid"
+      }
+    },
+    {
+      "name": "newStatus",
+      "doc": "The new registration status.",
+      "type": "net.corda.data.membership.common.v2.RegistrationStatus"
+    }
+  ]
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ cordaProductVersion = 5.1.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 746-MGM
+cordaApiRevision = 747-MGM
 
 # Main
 kotlinVersion = 1.8.21


### PR DESCRIPTION
Adding new values for enums in avro is not considered as a backward compatible change.
We’ve added a new value STARTED_PROCESSING_BY_MGM to flag in-progress registrations. This change unfortunately broke the registration when doing cross-version testing. This PR contains the fix for this issue.