### PR TITLE
CORE-14685: Add Corda-Api tag to all API artifacts.

### DIFF
--- a/buildSrc/src/main/groovy/corda-api.common-library.gradle
+++ b/buildSrc/src/main/groovy/corda-api.common-library.gradle
@@ -32,9 +32,14 @@ dependencies {
 }
 
 tasks.named('jar', Jar) {
-    archiveBaseName = "corda-" + project.name
+    archiveBaseName = "corda-${project.name}"
+    ext {
+        cordaApiVersion = "${cordaProductVersion}.${cordaApiRevision}"
+    }
+
     bundle {
         bnd '''\
+Corda-Api: \${task.cordaApiVersion}
 Bundle-Name: \${project.description}
 Bundle-SymbolicName: \${project.group}.\${project.name}
 '''


### PR DESCRIPTION
Add `Corda-Api` tag to every API jar that we build. The proposed value of this tag is
```
${cordaProductVersion}.${cordaApiRevision}
```
although my intended use-case is just to allow me to identify Corda's API jars for use in my "test driver".