### PR TITLE
CORE-14685: Use corda-api.common-library to build Avro bundle.

### DIFF
--- a/data/avro-schema/build.gradle
+++ b/data/avro-schema/build.gradle
@@ -3,11 +3,10 @@ import groovy.io.FileType
 import groovy.text.SimpleTemplateEngine
 
 plugins {
-    id 'java-library'
-    id 'corda.java-only'
+    id 'corda-api.common-library'
     id 'corda.common-publishing'
+    id 'corda.java-only'
     id "com.github.davidmc24.gradle.plugin.avro-base"
-    id 'biz.aQute.bnd.builder'
 }
 
 dependencies {
@@ -143,12 +142,8 @@ tasks.named('processResources', ProcessResources) {
  * all the classes from this bundle.
  */
 tasks.named('jar', Jar) {
-    archiveBaseName = "corda-" + project.name
-
     bundle {
         bnd '''\
-Bundle-Name: \${project.description}
-Bundle-SymbolicName: \${project.group}.\${project.name}
 Fragment-Host: avro
 '''
     }


### PR DESCRIPTION
Now that all Corda's APIs are written in Java, we can use the `corda-api.common-library` Gradle extension plugin to build the `avro-schema` bundle.

This allows us to remove some duplication from the `avro-schema` bundle's build script.