### PR TITLE
CORE-13610 add JDocs for zero limit

### DIFF
--- a/application/src/main/java/net/corda/v5/application/persistence/PagedQuery.java
+++ b/application/src/main/java/net/corda/v5/application/persistence/PagedQuery.java
@@ -22,7 +22,7 @@ public interface PagedQuery<R> {
      *
      * @return The same {@link PagedQuery} instance.
      *
-     * @throws IllegalArgumentException If {@code limit} is negative.
+     * @throws IllegalArgumentException If {@code limit} is negative or zero.
      */
     @NotNull
     PagedQuery<R> setLimit(int limit);

--- a/application/src/main/java/net/corda/v5/application/persistence/ParameterizedQuery.java
+++ b/application/src/main/java/net/corda/v5/application/persistence/ParameterizedQuery.java
@@ -20,7 +20,7 @@ public interface ParameterizedQuery<R> extends PagedQuery<R> {
      *
      * @return The same {@link ParameterizedQuery} instance.
      *
-     * @throws IllegalArgumentException If {@code limit} is negative.
+     * @throws IllegalArgumentException If {@code limit} is negative or zero.
      *
      * @see PagedQuery#setLimit
      */


### PR DESCRIPTION
After https://github.com/corda/corda-runtime-os/pull/3849, setting the limit in `PagedQuery`, `ParameterizedQuery` and `VaultNamedParameterizedQuery` implementations will not be possible so modifying the docs accordingly.