### PR TITLE
CORE-14866, CORE-14867, CORE-14921, CORE-14922, CORE-14987, CORE-14988: Constrain version of Jackson used for Avro

### DIFF
--- a/data/avro-schema/build.gradle
+++ b/data/avro-schema/build.gradle
@@ -11,6 +11,11 @@ plugins {
 
 dependencies {
     api "org.apache.avro:avro:$avroVersion"
+    constraints {
+        implementation("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion") {
+            because "required until new version of Avro available which updates Jackson"
+        }
+    }
 
     implementation platform(project(':corda-api'))
     implementation project(':base')

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,6 @@
 # their own projects. So don't get fancy with syntax!
 
 org.gradle.java.installations.auto-download=false
-org.gradle.jvmargs=-Dfile.encoding=UTF-8
 
 # Versioning
 cordaProductVersion = 5.1.0
@@ -28,7 +27,7 @@ artifactoryContextUrl = https://software.r3.com/artifactory
 
 # Gradle
 # dokka need more metaspace - https://github.com/Kotlin/dokka/issues/1405
-org.gradle.jvmargs=-XX:MaxMetaspaceSize=2g
+org.gradle.jvmargs=-Dfile.encoding=UTF-8 -XX:MaxMetaspaceSize=2g
 internalPublishVersion = 1.+
 dokkaVersion = 1.8.+
 detektPluginVersion = 1.22.+
@@ -46,7 +45,7 @@ bouncycastleVersion = 1.73
 grgitPluginVersion = 5.2.0
 taskTreePluginVersion = 2.1.1
 javaxPersistenceApiVersion = 2.2
-jacksonVersion = 2.15.0
+jacksonVersion = 2.15.2
 
 # Testing
 assertjVersion = 3.24.+


### PR DESCRIPTION
Also update version of Jackson to the latest.

Before:

```
PS Z:\corda-api> ./gradlew -q :data:avro-schema:dependencyInsight --dependency jackson-databind --configuration runtimeClasspath
********************** CORDA BUILD **********************
SDK version: 11
JAVA HOME Z:\tools\adoptOpenJDK-11.0.9.11
Corda release version: 5.1.0.5-SNAPSHOT
Corda baseVersion: 5.1.0.5
Release Type: SNAPSHOT
com.fasterxml.jackson.core:jackson-databind:2.12.7
  Variant runtime:
    | Attribute Name                     | Provided     | Requested    |
    |------------------------------------|--------------|--------------|
    | org.gradle.status                  | release      |              |
    | org.gradle.category                | library      | library      |
    | org.gradle.libraryelements         | jar          | jar          |
    | org.gradle.usage                   | java-runtime | java-runtime |
    | org.gradle.dependency.bundling     |              | external     |
    | org.gradle.jvm.environment         |              | standard-jvm |
    | org.gradle.jvm.version             |              | 11           |
    | org.jetbrains.kotlin.platform.type |              | jvm          |

com.fasterxml.jackson.core:jackson-databind:2.12.7
\--- org.apache.avro:avro:1.11.1
     \--- runtimeClasspath
```	 
	 
After:

```
PS Z:\corda-api> ./gradlew -q :data:avro-schema:dependencyInsight --dependency jackson-databind --configuration runtimeClasspath
********************** CORDA BUILD **********************
SDK version: 11
JAVA HOME Z:\tools\adoptOpenJDK-11.0.9.11
Corda release version: 5.1.0.5-SNAPSHOT
Corda baseVersion: 5.1.0.5
Release Type: SNAPSHOT
com.fasterxml.jackson.core:jackson-databind:2.15.2
  Variant runtimeElements:
    | Attribute Name                     | Provided     | Requested    |
    |------------------------------------|--------------|--------------|
    | org.gradle.status                  | release      |              |
    | org.gradle.category                | library      | library      |
    | org.gradle.dependency.bundling     | external     | external     |
    | org.gradle.libraryelements         | jar          | jar          |
    | org.gradle.usage                   | java-runtime | java-runtime |
    | org.gradle.jvm.environment         |              | standard-jvm |
    | org.gradle.jvm.version             |              | 11           |
    | org.jetbrains.kotlin.platform.type |              | jvm          |
   Selection reasons:
      - By constraint: required until new version of Avro available which updates Jackson
      - By constraint
      - By conflict resolution: between versions 2.15.2 and 2.12.7

com.fasterxml.jackson.core:jackson-databind:2.15.2
+--- runtimeClasspath
\--- com.fasterxml.jackson:jackson-bom:2.15.2
     +--- com.fasterxml.jackson.core:jackson-core:2.15.2
     |    +--- org.apache.avro:avro:1.11.1 (requested com.fasterxml.jackson.core:jackson-core:2.12.7)
     |    |    \--- runtimeClasspath
     |    +--- com.fasterxml.jackson:jackson-bom:2.15.2 (*)
     |    \--- com.fasterxml.jackson.core:jackson-databind:2.15.2 (*)
     +--- com.fasterxml.jackson.core:jackson-annotations:2.15.2
     |    +--- com.fasterxml.jackson:jackson-bom:2.15.2 (*)
     |    \--- com.fasterxml.jackson.core:jackson-databind:2.15.2 (*)
     \--- com.fasterxml.jackson.core:jackson-databind:2.15.2 (*)

com.fasterxml.jackson.core:jackson-databind:2.12.7 -> 2.15.2
\--- org.apache.avro:avro:1.11.1
     \--- runtimeClasspath
```	 
