### PR TITLE
CORE-15103: Constrain version of Jackson used for Avro

### DIFF
--- a/data/avro-schema/build.gradle
+++ b/data/avro-schema/build.gradle
@@ -12,6 +12,11 @@ plugins {
 
 dependencies {
     api "org.apache.avro:avro:$avroVersion"
+    constraints {
+        implementation("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion") {
+            because "required until new version of Avro available which updates Jackson"
+        }
+    }
 
     implementation platform(project(':corda-api'))
     implementation project(':base')

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,6 @@
 # their own projects. So don't get fancy with syntax!
 
 org.gradle.java.installations.auto-download=false
-org.gradle.jvmargs=-Dfile.encoding=UTF-8
 
 # Versioning
 cordaProductVersion = 5.0.0
@@ -28,7 +27,7 @@ artifactoryContextUrl = https://software.r3.com/artifactory
 
 # Gradle
 # dokka need more metaspace - https://github.com/Kotlin/dokka/issues/1405
-org.gradle.jvmargs=-XX:MaxMetaspaceSize=2g
+org.gradle.jvmargs=-Dfile.encoding=UTF-8 -XX:MaxMetaspaceSize=2g
 internalPublishVersion = 1.+
 dokkaVersion = 1.8.+
 detektPluginVersion = 1.22.+
@@ -46,7 +45,7 @@ bouncycastleVersion = 1.73
 grgitPluginVersion = 5.2.0
 taskTreePluginVersion = 2.1.1
 javaxPersistenceApiVersion = 2.2
-jacksonVersion = 2.15.0
+jacksonVersion = 2.15.2
 
 # Testing
 assertjVersion = 3.24.+


### PR DESCRIPTION
Also update version of Jackson to the latest.

This is a cherry-pick of: d25d569709dcfe1b4b413c72539f96dd127d5792 from `5.1` branch. 