### PR TITLE
ES-852/point at public repos

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -24,6 +24,7 @@ licenseUrl = http://www.apache.org/licenses/LICENSE-2.0.txt
 
 # Artifactory
 artifactoryContextUrl = https://software.r3.com/artifactory
+publicArtifactURL = https://download.corda.net/maven
 
 # Gradle
 # dokka need more metaspace - https://github.com/Kotlin/dokka/issues/1405

--- a/settings.gradle
+++ b/settings.gradle
@@ -15,7 +15,7 @@ pluginManagement {
             }
         } else {
             maven {
-                url "$artifactoryContextUrl/corda-releases"
+                url "${publicArtifactURL}/corda-releases"
                 content {
                     includeGroupByRegex 'net\\.corda\\.plugins(\\..*)?'
                 }
@@ -67,7 +67,7 @@ dependencyResolutionManagement {
             mavenCentral()
 
             maven {
-                url = "$artifactoryContextUrl/corda-dependencies"
+                url = "${publicArtifactURL}/corda-dependencies"
             }
 
             maven {


### PR DESCRIPTION
A number of artifactory repos are migrating to be private, to ensure the open source community can continue to build Corda. These have been mirrored at https://download.corda.net/maven

Tested : https://gradle.dev.r3.com/s/l5pvc4zbyrn5e