### PR TITLE
CORE-9519 Add schemas for group parameters update

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/actions.request/DistributeGroupParameters.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/actions.request/DistributeGroupParameters.avsc
@@ -1,0 +1,18 @@
+{
+  "type": "record",
+  "name": "DistributeGroupParameters",
+  "namespace": "net.corda.data.membership.actions.request",
+  "doc": "Distribute group parameters to the rest of the network.",
+  "fields": [
+    {
+      "name": "mgm",
+      "doc": "The membership group manager of the group.",
+      "type": "net.corda.data.identity.HoldingIdentity"
+    },
+    {
+      "name": "minimumGroupParametersEpoch",
+      "doc": "The minimum group parameters epoch to be distributed (if null, the latest version is used). If the group parameters with this epoch have not been published, then the membership actions processor will requeue this request to be retried later.",
+      "type": ["null", "int"]
+    }
+  ]
+}

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/actions.request/MembershipActionsRequest.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/actions.request/MembershipActionsRequest.avsc
@@ -7,7 +7,10 @@
     {
       "name": "request",
       "doc": "Request's payload, depends on the requested action.",
-      "type": ["DistributeMemberInfo"]
+      "type": [
+        "DistributeMemberInfo",
+        "DistributeGroupParameters"
+      ]
     }
   ]
 }

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/request/MembershipPersistenceRequest.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/request/MembershipPersistenceRequest.avsc
@@ -31,6 +31,7 @@
         "net.corda.data.membership.db.request.command.SuspendMember",
         "net.corda.data.membership.db.request.command.ActivateMember",
         "net.corda.data.membership.db.request.command.UpdateStaticNetworkInfo",
+        "net.corda.data.membership.db.request.command.UpdateGroupParameters",
         "net.corda.data.membership.db.request.query.QueryGroupPolicy",
         "net.corda.data.membership.db.request.query.QueryMemberInfo",
         "net.corda.data.membership.db.request.query.QueryMemberSignature",

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/request/command/UpdateGroupParameters.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/request/command/UpdateGroupParameters.avsc
@@ -1,0 +1,17 @@
+{
+  "type": "record",
+  "name": "UpdateGroupParameters",
+  "namespace": "net.corda.data.membership.db.request.command",
+  "doc": "Update group parameters",
+  "fields": [
+    {
+      "name": "update",
+      "doc": "Updated version of the group parameters.",
+      "type":
+        {
+          "type": "map",
+          "values": "string"
+        }
+    }
+  ]
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ cordaProductVersion = 5.1.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 6
+cordaApiRevision = 7
 
 # Main
 kotlinVersion = 1.8.21


### PR DESCRIPTION
Adds avro schemas `UpdateGroupParameters` and `DistributeGroupParameters` required for group parameters update functionality via MGM API.
https://github.com/corda/corda-runtime-os/pull/4284