### PR TITLE
CORE-15539: Increase actor user column character length

### DIFF
--- a/data/db-schema/src/main/resources/net/corda/db/schema/rbac/migration/rbac-creation-v1.0.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/rbac/migration/rbac-creation-v1.0.xml
@@ -134,7 +134,7 @@
             <column name="update_ts" type="TIMESTAMP">
                 <constraints nullable="false"/>
             </column>
-            <column name="actor_user" type="VARCHAR(36)">
+            <column name="actor_user" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
             <column name="change_type" type="VARCHAR(255)">

--- a/data/db-schema/src/main/resources/net/corda/db/schema/rbac/migration/rbac-creation-v1.0.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/rbac/migration/rbac-creation-v1.0.xml
@@ -5,7 +5,7 @@
 
     <changeSet author="R3.Corda" id="rbac-creation-v1.0">
         <createTable tableName="rbac_user">
-            <column name="id" type="VARCHAR(255)">
+            <column name="id" type="VARCHAR(36)">
                 <constraints nullable="false"/>
             </column>
             <column name="update_ts" type="TIMESTAMP">
@@ -32,7 +32,7 @@
             <column name="password_expiry" type="TIMESTAMP">
                 <constraints nullable="true"/>
             </column>
-            <column name="parent_group" type="VARCHAR(255)">
+            <column name="parent_group" type="VARCHAR(36)">
                 <constraints nullable="true"/>
             </column>
         </createTable>
@@ -41,7 +41,7 @@
 
         <createTable tableName="rbac_user_props"
                      remarks="Holds properties for an individual user">
-            <column name="id" type="VARCHAR(255)">
+            <column name="id" type="VARCHAR(36)">
                 <constraints nullable="false"/>
             </column>
             <column name="update_ts" type="TIMESTAMP">
@@ -69,7 +69,7 @@
                                  onDelete="CASCADE"/>
 
         <createTable tableName="rbac_group">
-            <column name="id" type="VARCHAR(255)">
+            <column name="id" type="VARCHAR(36)">
                 <constraints nullable="false"/>
             </column>
             <column name="update_ts" type="TIMESTAMP">
@@ -81,7 +81,7 @@
             <column name="name" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="parent_group" type="VARCHAR(255)">
+            <column name="parent_group" type="VARCHAR(36)">
                 <constraints nullable="true"/>
             </column>
         </createTable>
@@ -99,7 +99,7 @@
                                  onDelete="SET NULL"/>
 
         <createTable tableName="rbac_group_props" remarks="Holds properties of the group">
-            <column name="id" type="VARCHAR(255)">
+            <column name="id" type="VARCHAR(36)">
                 <constraints nullable="false"/>
             </column>
             <column name="update_ts" type="TIMESTAMP">
@@ -108,7 +108,7 @@
             <column name="version" type="INT">
                 <constraints nullable="false"/>
             </column>
-            <column name="group_ref" type="VARCHAR(255)">
+            <column name="group_ref" type="VARCHAR(36)">
                 <constraints nullable="false"/>
             </column>
             <column name="key" type="VARCHAR(255)">
@@ -128,7 +128,7 @@
                                  onDelete="CASCADE"/>
 
         <createTable tableName="rbac_change_audit">
-            <column name="id" type="VARCHAR(255)">
+            <column name="id" type="VARCHAR(36)">
                 <constraints nullable="false"/>
             </column>
             <column name="update_ts" type="TIMESTAMP">
@@ -147,7 +147,7 @@
         <addPrimaryKey tableName="rbac_change_audit" columnNames="id" constraintName="rbac_change_audit_pkey"/>
 
         <createTable tableName="rbac_role">
-            <column name="id" type="VARCHAR(255)">
+            <column name="id" type="VARCHAR(36)">
                 <constraints nullable="false"/>
             </column>
             <column name="update_ts" type="TIMESTAMP">
@@ -159,7 +159,7 @@
             <column name="name" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="group_vis" type="VARCHAR(255)"
+            <column name="group_vis" type="VARCHAR(36)"
                     remarks="Indicates which group which has visibility on a given role">
                 <constraints nullable="true"/>
             </column>
@@ -177,7 +177,7 @@
 
         <createTable tableName="rbac_role_user_rel"
                      remarks="Represents 1-n relationship between user and roles">
-            <column name="id" type="VARCHAR(255)">
+            <column name="id" type="VARCHAR(36)">
                 <constraints nullable="false"/>
             </column>
             <column name="update_ts" type="TIMESTAMP">
@@ -206,16 +206,16 @@
 
         <createTable tableName="rbac_role_group_rel"
                      remarks="Represents 1-n relationship between group and roles">
-            <column name="id" type="VARCHAR(255)">
+            <column name="id" type="VARCHAR(36)">
                 <constraints nullable="false"/>
             </column>
             <column name="update_ts" type="TIMESTAMP">
                 <constraints nullable="false"/>
             </column>
-            <column name="group_id" type="VARCHAR(255)">
+            <column name="group_id" type="VARCHAR(36)">
                 <constraints nullable="false"/>
             </column>
-            <column name="role_id" type="VARCHAR(255)">
+            <column name="role_id" type="VARCHAR(36)">
                 <constraints nullable="false"/>
             </column>
         </createTable>
@@ -234,7 +234,7 @@
                                  onDelete="CASCADE"/>
 
         <createTable tableName="rbac_perm">
-            <column name="id" type="VARCHAR(255)">
+            <column name="id" type="VARCHAR(36)">
                 <constraints nullable="false"/>
             </column>
             <column name="update_ts" type="TIMESTAMP">
@@ -243,7 +243,7 @@
             <column name="version" type="INT">
                 <constraints nullable="false"/>
             </column>
-            <column name="group_vis" type="VARCHAR(255)"
+            <column name="group_vis" type="VARCHAR(36)"
                     remarks="Indicates which group which has visibility on a given permission">
                 <constraints nullable="true"/>
             </column>
@@ -269,16 +269,16 @@
 
         <createTable tableName="rbac_role_perm_rel"
                      remarks="Represents n-n relationship between roles and permissions">
-            <column name="id" type="VARCHAR(255)">
+            <column name="id" type="VARCHAR(36)">
                 <constraints nullable="false"/>
             </column>
             <column name="update_ts" type="TIMESTAMP">
                 <constraints nullable="false"/>
             </column>
-            <column name="role_id" type="VARCHAR(255)">
+            <column name="role_id" type="VARCHAR(36)">
                 <constraints nullable="false"/>
             </column>
-            <column name="perm_id" type="VARCHAR(255)">
+            <column name="perm_id" type="VARCHAR(36)">
                 <constraints nullable="false"/>
             </column>
         </createTable>

--- a/data/db-schema/src/main/resources/net/corda/db/schema/rbac/migration/rbac-creation-v1.0.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/rbac/migration/rbac-creation-v1.0.xml
@@ -50,7 +50,7 @@
             <column name="version" type="INT">
                 <constraints nullable="false"/>
             </column>
-            <column name="user_ref" type="VARCHAR(255)">
+            <column name="user_ref" type="VARCHAR(36)">
                 <constraints nullable="false"/>
             </column>
             <column name="key" type="VARCHAR(255)">
@@ -183,10 +183,10 @@
             <column name="update_ts" type="TIMESTAMP">
                 <constraints nullable="false"/>
             </column>
-            <column name="user_id" type="VARCHAR(255)">
+            <column name="user_id" type="VARCHAR(36)">
                 <constraints nullable="false"/>
             </column>
-            <column name="role_id" type="VARCHAR(255)">
+            <column name="role_id" type="VARCHAR(36)">
                 <constraints nullable="false"/>
             </column>
         </createTable>

--- a/data/db-schema/src/main/resources/net/corda/db/schema/rbac/migration/rbac-creation-v1.0.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/rbac/migration/rbac-creation-v1.0.xml
@@ -5,7 +5,7 @@
 
     <changeSet author="R3.Corda" id="rbac-creation-v1.0">
         <createTable tableName="rbac_user">
-            <column name="id" type="VARCHAR(36)">
+            <column name="id" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
             <column name="update_ts" type="TIMESTAMP">
@@ -32,7 +32,7 @@
             <column name="password_expiry" type="TIMESTAMP">
                 <constraints nullable="true"/>
             </column>
-            <column name="parent_group" type="VARCHAR(36)">
+            <column name="parent_group" type="VARCHAR(255)">
                 <constraints nullable="true"/>
             </column>
         </createTable>
@@ -41,7 +41,7 @@
 
         <createTable tableName="rbac_user_props"
                      remarks="Holds properties for an individual user">
-            <column name="id" type="VARCHAR(36)">
+            <column name="id" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
             <column name="update_ts" type="TIMESTAMP">
@@ -50,7 +50,7 @@
             <column name="version" type="INT">
                 <constraints nullable="false"/>
             </column>
-            <column name="user_ref" type="VARCHAR(36)">
+            <column name="user_ref" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
             <column name="key" type="VARCHAR(255)">
@@ -69,7 +69,7 @@
                                  onDelete="CASCADE"/>
 
         <createTable tableName="rbac_group">
-            <column name="id" type="VARCHAR(36)">
+            <column name="id" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
             <column name="update_ts" type="TIMESTAMP">
@@ -81,7 +81,7 @@
             <column name="name" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="parent_group" type="VARCHAR(36)">
+            <column name="parent_group" type="VARCHAR(255)">
                 <constraints nullable="true"/>
             </column>
         </createTable>
@@ -99,7 +99,7 @@
                                  onDelete="SET NULL"/>
 
         <createTable tableName="rbac_group_props" remarks="Holds properties of the group">
-            <column name="id" type="VARCHAR(36)">
+            <column name="id" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
             <column name="update_ts" type="TIMESTAMP">
@@ -108,7 +108,7 @@
             <column name="version" type="INT">
                 <constraints nullable="false"/>
             </column>
-            <column name="group_ref" type="VARCHAR(36)">
+            <column name="group_ref" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
             <column name="key" type="VARCHAR(255)">
@@ -128,7 +128,7 @@
                                  onDelete="CASCADE"/>
 
         <createTable tableName="rbac_change_audit">
-            <column name="id" type="VARCHAR(36)">
+            <column name="id" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
             <column name="update_ts" type="TIMESTAMP">
@@ -147,7 +147,7 @@
         <addPrimaryKey tableName="rbac_change_audit" columnNames="id" constraintName="rbac_change_audit_pkey"/>
 
         <createTable tableName="rbac_role">
-            <column name="id" type="VARCHAR(36)">
+            <column name="id" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
             <column name="update_ts" type="TIMESTAMP">
@@ -159,7 +159,7 @@
             <column name="name" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="group_vis" type="VARCHAR(36)"
+            <column name="group_vis" type="VARCHAR(255)"
                     remarks="Indicates which group which has visibility on a given role">
                 <constraints nullable="true"/>
             </column>
@@ -177,16 +177,16 @@
 
         <createTable tableName="rbac_role_user_rel"
                      remarks="Represents 1-n relationship between user and roles">
-            <column name="id" type="VARCHAR(36)">
+            <column name="id" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
             <column name="update_ts" type="TIMESTAMP">
                 <constraints nullable="false"/>
             </column>
-            <column name="user_id" type="VARCHAR(36)">
+            <column name="user_id" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="role_id" type="VARCHAR(36)">
+            <column name="role_id" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
         </createTable>
@@ -206,16 +206,16 @@
 
         <createTable tableName="rbac_role_group_rel"
                      remarks="Represents 1-n relationship between group and roles">
-            <column name="id" type="VARCHAR(36)">
+            <column name="id" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
             <column name="update_ts" type="TIMESTAMP">
                 <constraints nullable="false"/>
             </column>
-            <column name="group_id" type="VARCHAR(36)">
+            <column name="group_id" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="role_id" type="VARCHAR(36)">
+            <column name="role_id" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
         </createTable>
@@ -234,7 +234,7 @@
                                  onDelete="CASCADE"/>
 
         <createTable tableName="rbac_perm">
-            <column name="id" type="VARCHAR(36)">
+            <column name="id" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
             <column name="update_ts" type="TIMESTAMP">
@@ -243,7 +243,7 @@
             <column name="version" type="INT">
                 <constraints nullable="false"/>
             </column>
-            <column name="group_vis" type="VARCHAR(36)"
+            <column name="group_vis" type="VARCHAR(255)"
                     remarks="Indicates which group which has visibility on a given permission">
                 <constraints nullable="true"/>
             </column>
@@ -269,16 +269,16 @@
 
         <createTable tableName="rbac_role_perm_rel"
                      remarks="Represents n-n relationship between roles and permissions">
-            <column name="id" type="VARCHAR(36)">
+            <column name="id" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
             <column name="update_ts" type="TIMESTAMP">
                 <constraints nullable="false"/>
             </column>
-            <column name="role_id" type="VARCHAR(36)">
+            <column name="role_id" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="perm_id" type="VARCHAR(36)">
+            <column name="perm_id" type="VARCHAR(255)">
                 <constraints nullable="false"/>
             </column>
         </createTable>


### PR DESCRIPTION
- Increased the character length of `actor_user` in the `rbac_change_audit` table

Related E2E test: [CORE-15539: Revert loginName truncation #158](https://github.com/corda/corda-e2e-tests/pull/158)
Test in `corda-runtime-os:` [CORE-15539: Extend RbacEntitiesTest to check ChangeAudit #4327](https://github.com/corda/corda-runtime-os/pull/4327)