### PR TITLE
CORE-10114 Schema update for custom metadata

### DIFF
--- a/data/membership-schema/src/main/resources/net/corda/schema/membership/group/policy/1.0/corda.group.policy.json
+++ b/data/membership-schema/src/main/resources/net/corda/schema/membership/group/policy/1.0/corda.group.policy.json
@@ -263,8 +263,18 @@
             "groupParameters": {
               "description": "Custom key-value properties to be included in the group parameters of a static network.",
               "type": "object",
-              "additionalProperties": {
-                "type": "string"
+              "patternProperties": {
+                "^corda.minimum.platform.version$": {
+                  "description": "Optional. The minimum platform version of the static network.",
+                  "type": "integer",
+                  "minimum": 50000,
+                  "maximum": 99999
+                },
+                "^ext\\.[a-zA-Z0-9.]+$": {
+                  "description": "Optional. User-specified additional properties, which must be prefixed with `ext.`.",
+                  "type": "string",
+                  "maxLength": 256
+                }
               }
             }
           }

--- a/data/membership-schema/src/main/resources/net/corda/schema/membership/group/policy/1.0/corda.group.policy.json
+++ b/data/membership-schema/src/main/resources/net/corda/schema/membership/group/policy/1.0/corda.group.policy.json
@@ -259,6 +259,13 @@
                 "description": "A member template as a map of values for a member to be added to the static network member list.",
                 "type": "object"
               }
+            },
+            "groupParameters": {
+              "description": "Custom key-value properties to be included in the group parameters of a static network.",
+              "type": "object",
+              "additionalProperties": {
+                "type": "string"
+              }
             }
           }
         }

--- a/data/membership-schema/src/main/resources/net/corda/schema/membership/group/policy/1.0/corda.group.policy.json
+++ b/data/membership-schema/src/main/resources/net/corda/schema/membership/group/policy/1.0/corda.group.policy.json
@@ -264,16 +264,18 @@
               "description": "Custom key-value properties to be included in the group parameters of a static network.",
               "type": "object",
               "patternProperties": {
-                "^corda.minimum.platform.version$": {
-                  "description": "Optional. The minimum platform version of the static network.",
-                  "type": "integer",
-                  "minimum": 50000,
-                  "maximum": 99999
-                },
                 "^ext\\.[a-zA-Z0-9.]+$": {
                   "description": "Optional. User-specified additional properties, which must be prefixed with `ext.`.",
                   "type": "string",
                   "maxLength": 256
+                }
+              },
+              "properties": {
+                "corda.minimum.platform.version": {
+                  "description": "Optional. The minimum platform version of the static network.",
+                  "type": "integer",
+                  "minimum": 50000,
+                  "maximum": 99999
                 }
               }
             }

--- a/data/membership-schema/src/main/resources/net/corda/schema/membership/member/static/registration/1.0/corda.member.static.registration.json
+++ b/data/membership-schema/src/main/resources/net/corda/schema/membership/member/static/registration/1.0/corda.member.static.registration.json
@@ -19,7 +19,7 @@
       "minimum": 1
     },
     "^ext\\.[a-zA-Z0-9.]+$": {
-      "description": "Optional. A user can specify additional properties, they must be prefixed with `ext.`.",
+      "description": "Optional. User-specified additional properties, which must be prefixed with `ext.`.",
       "type": "string",
       "maxLength": 256
     }

--- a/data/membership-schema/src/main/resources/net/corda/schema/membership/member/static/registration/1.0/corda.member.static.registration.json
+++ b/data/membership-schema/src/main/resources/net/corda/schema/membership/member/static/registration/1.0/corda.member.static.registration.json
@@ -17,6 +17,11 @@
       "description": "Version supported for the flow protocol used by the notary service. Valid only when one of the roles is notary.",
       "type": "integer",
       "minimum": 1
+    },
+    "^ext\\.[a-zA-Z0-9.]+$": {
+      "description": "Optional. A user can specify additional properties, they must be prefixed with `ext.`.",
+      "type": "string",
+      "maxLength": 256
     }
   },
   "properties": {

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ cordaProductVersion = 5.1.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 7
+cordaApiRevision = 8
 
 # Main
 kotlinVersion = 1.8.21

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ cordaProductVersion = 5.1.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 8
+cordaApiRevision = 9
 
 # Main
 kotlinVersion = 1.8.21


### PR DESCRIPTION
Update static registration context and group policy schemas to allow custom properties to be added to the MemberInfo and group parameters.
https://github.com/corda/corda-runtime-os/pull/4330