### PR TITLE
CORE-11805 - Update json schema spec

### DIFF
--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/crypto/1.0/corda.crypto.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/crypto/1.0/corda.crypto.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://corda.r3.com/net/corda/schema/configuration/crypto/1.0/corda.crypto.json",
   "title": "Corda Crypto Library Configuration Schema",
   "description": "Configuration schema for the crypto library subsection.",

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/crypto/1.0/corda.crypto.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/crypto/1.0/corda.crypto.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "$id": "https://corda.r3.com/net/corda/schema/configuration/crypto/1.0/corda.crypto.json",
   "title": "Corda Crypto Library Configuration Schema",
   "description": "Configuration schema for the crypto library subsection.",

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/db/1.0/corda.db.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/db/1.0/corda.db.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://corda.r3.com/net/corda/schema/configuration/db/1.0/corda.db.json",
   "title": "Corda Database Configuration Schema",
   "description": "Configuration schema for the database section. Note that this configuration cannot be updated dynamically through the REST endpoint.",

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/db/1.0/corda.db.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/db/1.0/corda.db.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "$id": "https://corda.r3.com/net/corda/schema/configuration/db/1.0/corda.db.json",
   "title": "Corda Database Configuration Schema",
   "description": "Configuration schema for the database section. Note that this configuration cannot be updated dynamically through the REST endpoint.",

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/externalMessaging/1.0/corda.externalMessaging.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/externalMessaging/1.0/corda.externalMessaging.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "$id": "https://corda.r3.com/net/corda/schema/configuration/external.messaging/1.0/corda.external.messaging.json",
   "title": "Corda External Messaging Configuration Schema",
   "description": "Configuration schema for external messaging.",

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/externalMessaging/1.0/corda.externalMessaging.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/externalMessaging/1.0/corda.externalMessaging.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://corda.r3.com/net/corda/schema/configuration/external.messaging/1.0/corda.external.messaging.json",
   "title": "Corda External Messaging Configuration Schema",
   "description": "Configuration schema for external messaging.",

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/flow/1.0/corda.flow.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/flow/1.0/corda.flow.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://corda.r3.com/net/corda/schema/configuration/flow/1.0/corda.flow.json",
   "title": "Corda Flow Configuration Schema",
   "description": "Configuration schema for the flow section.",

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/flow/1.0/corda.flow.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/flow/1.0/corda.flow.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "$id": "https://corda.r3.com/net/corda/schema/configuration/flow/1.0/corda.flow.json",
   "title": "Corda Flow Configuration Schema",
   "description": "Configuration schema for the flow section.",

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/ledger.utxo/1.0/corda.ledger.utxo.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/ledger.utxo/1.0/corda.ledger.utxo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "$id": "https://corda.r3.com/net/corda/schema/configuration/ledger/utxo/1.0/corda.ledger.utxo.json",
   "title": "Corda UTXO ledger Configuration Schema",
   "description": "Configuration schema for the UTXO ledger.",

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/ledger.utxo/1.0/corda.ledger.utxo.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/ledger.utxo/1.0/corda.ledger.utxo.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://corda.r3.com/net/corda/schema/configuration/ledger/utxo/1.0/corda.ledger.utxo.json",
   "title": "Corda UTXO ledger Configuration Schema",
   "description": "Configuration schema for the UTXO ledger.",

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/membership/1.0/corda.membership.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/membership/1.0/corda.membership.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "$id": "https://corda.r3.com/net/corda/schema/configuration/membership/1.0/corda.membership.json",
   "title": "Corda Membership Configuration Schema",
   "description": "Configuration schema for the membership subsection.",

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/membership/1.0/corda.membership.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/membership/1.0/corda.membership.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://corda.r3.com/net/corda/schema/configuration/membership/1.0/corda.membership.json",
   "title": "Corda Membership Configuration Schema",
   "description": "Configuration schema for the membership subsection.",

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/messaging/1.0/corda.messaging.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/messaging/1.0/corda.messaging.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://corda.r3.com/net/corda/schema/configuration/messaging/1.0/corda.messaging.json",
   "title": "Corda Messaging Configuration Schema",
   "description": "Configuration schema for the messaging section. This configures the interactions of the workers with the underlying message bus.",

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/messaging/1.0/corda.messaging.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/messaging/1.0/corda.messaging.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "$id": "https://corda.r3.com/net/corda/schema/configuration/messaging/1.0/corda.messaging.json",
   "title": "Corda Messaging Configuration Schema",
   "description": "Configuration schema for the messaging section. This configures the interactions of the workers with the underlying message bus.",

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/messaging/1.0/kafka-properties.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/messaging/1.0/kafka-properties.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "$id": "https://corda.r3.com/net/corda/schema/configuration/messaging/1.0/kafka-properties.json",
   "title": "Kafka properties schema",
   "description": "Schema container for Kafka properties",

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/messaging/1.0/kafka-properties.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/messaging/1.0/kafka-properties.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://corda.r3.com/net/corda/schema/configuration/messaging/1.0/kafka-properties.json",
   "title": "Kafka properties schema",
   "description": "Schema container for Kafka properties",

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/messaging/1.0/publisher.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/messaging/1.0/publisher.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "$id": "https://corda.r3.com/net/corda/schema/configuration/messaging/1.0/publisher.json",
   "title": "Publisher configuration",
   "description": "Settings for all publishers that write to the message bus.",

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/messaging/1.0/publisher.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/messaging/1.0/publisher.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://corda.r3.com/net/corda/schema/configuration/messaging/1.0/publisher.json",
   "title": "Publisher configuration",
   "description": "Settings for all publishers that write to the message bus.",

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/messaging/1.0/subscription.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/messaging/1.0/subscription.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://corda.r3.com/net/corda/schema/configuration/messaging/1.0/subscription.json",
   "title": "Common subscription configuration",
   "description": "Configuration settings for all subscriptions to the message bus.",

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/messaging/1.0/subscription.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/messaging/1.0/subscription.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "$id": "https://corda.r3.com/net/corda/schema/configuration/messaging/1.0/subscription.json",
   "title": "Common subscription configuration",
   "description": "Configuration settings for all subscriptions to the message bus.",

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/p2p.gateway/1.0/corda.p2p.gateway.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/p2p.gateway/1.0/corda.p2p.gateway.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://corda.r3.com/net/corda/schema/configuration/p2p/1.0/corda.p2p.gateway.json",
   "title": "Corda P2P Gateway Configuration Schema",
   "description": "Configuration schema for the P2P gateway.",

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/p2p.gateway/1.0/corda.p2p.gateway.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/p2p.gateway/1.0/corda.p2p.gateway.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "$id": "https://corda.r3.com/net/corda/schema/configuration/p2p/1.0/corda.p2p.gateway.json",
   "title": "Corda P2P Gateway Configuration Schema",
   "description": "Configuration schema for the P2P gateway.",

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/p2p.linkManager/1.0/corda.p2p.linkManager.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/p2p.linkManager/1.0/corda.p2p.linkManager.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://corda.r3.com/net/corda/schema/configuration/p2p/1.0/corda.p2p.linkmanager.json",
   "title": "Corda P2P Link Manager Configuration Schema",
   "description": "Configuration schema for the P2P link manager.",

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/p2p.linkManager/1.0/corda.p2p.linkManager.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/p2p.linkManager/1.0/corda.p2p.linkManager.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "$id": "https://corda.r3.com/net/corda/schema/configuration/p2p/1.0/corda.p2p.linkmanager.json",
   "title": "Corda P2P Link Manager Configuration Schema",
   "description": "Configuration schema for the P2P link manager.",

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/reconciliation/1.0/corda.reconciliation.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/reconciliation/1.0/corda.reconciliation.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "$id": "https://corda.r3.com/net/corda/schema/configuration/reconciliation/1.0/corda.reconciliation.json",
   "title": "Corda Reconciliation Configuration Schema",
   "description": "Configuration schema for the reconciliation section.",

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/reconciliation/1.0/corda.reconciliation.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/reconciliation/1.0/corda.reconciliation.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://corda.r3.com/net/corda/schema/configuration/reconciliation/1.0/corda.reconciliation.json",
   "title": "Corda Reconciliation Configuration Schema",
   "description": "Configuration schema for the reconciliation section.",

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/rest/1.0/corda.rest.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/rest/1.0/corda.rest.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://corda.r3.com/net/corda/schema/configuration/rest/1.0/corda.rest.json",
   "title": "Corda REST Configuration Schema",
   "description": "Configuration schema for the REST section.",

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/rest/1.0/corda.rest.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/rest/1.0/corda.rest.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "$id": "https://corda.r3.com/net/corda/schema/configuration/rest/1.0/corda.rest.json",
   "title": "Corda REST Configuration Schema",
   "description": "Configuration schema for the REST section.",

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/sandbox/1.0/corda.sandbox.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/sandbox/1.0/corda.sandbox.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://corda.r3.com/net/corda/schema/configuration/sandbox/1.0/corda.sandbox.json",
   "title": "Corda Sandbox Configuration Schema",
   "description": "Configuration schema for the sandbox section.",

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/sandbox/1.0/corda.sandbox.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/sandbox/1.0/corda.sandbox.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "$id": "https://corda.r3.com/net/corda/schema/configuration/sandbox/1.0/corda.sandbox.json",
   "title": "Corda Sandbox Configuration Schema",
   "description": "Configuration schema for the sandbox section.",

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/secrets/1.0/corda.secrets.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/secrets/1.0/corda.secrets.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "$id": "https://corda.r3.com/net/corda/schema/configuration/secrets/1.0/corda.secrets.json",
   "title": "Corda Secrets Configuration Schema",
   "description": "Configuration schema for the secrets subsection.",

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/secrets/1.0/corda.secrets.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/secrets/1.0/corda.secrets.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://corda.r3.com/net/corda/schema/configuration/secrets/1.0/corda.secrets.json",
   "title": "Corda Secrets Configuration Schema",
   "description": "Configuration schema for the secrets subsection.",

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/security/1.0/corda.security.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/security/1.0/corda.security.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://corda.r3.com/net/corda/schema/configuration/security/1.0/corda.security.json",
   "title": "Corda Security Configuration Schema",
   "description": "Configuration schema for the security subsection.",

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/security/1.0/corda.security.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/security/1.0/corda.security.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "$id": "https://corda.r3.com/net/corda/schema/configuration/security/1.0/corda.security.json",
   "title": "Corda Security Configuration Schema",
   "description": "Configuration schema for the security subsection.",

--- a/data/config-schema/src/main/resources/net/corda/schema/cordapp/configuration/external.messaging/1.0/corda.external.messaging.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/cordapp/configuration/external.messaging/1.0/corda.external.messaging.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://corda.r3.com/net/corda/schema/cordapp/configuration/external/messaging/1.0/corda.external.messaging.json",
   "title": "Corda External Messaging Configuration Schema",
   "description": "Configuration schema for the external messaging.",

--- a/data/config-schema/src/main/resources/net/corda/schema/cordapp/configuration/external.messaging/1.0/corda.external.messaging.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/cordapp/configuration/external.messaging/1.0/corda.external.messaging.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "$id": "https://corda.r3.com/net/corda/schema/cordapp/configuration/external/messaging/1.0/corda.external.messaging.json",
   "title": "Corda External Messaging Configuration Schema",
   "description": "Configuration schema for the external messaging.",

--- a/data/config-schema/src/test/resources/net/corda/schema/configuration/test/1.0/schema-fragment.json
+++ b/data/config-schema/src/test/resources/net/corda/schema/configuration/test/1.0/schema-fragment.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://corda.r3.com/net/corda/schema/configuration/test/1.0/schema-fragment.json",
   "title": "Test schema fragment",
   "description": "Schema fragment for testing",

--- a/data/config-schema/src/test/resources/net/corda/schema/configuration/test/1.0/schema-fragment.json
+++ b/data/config-schema/src/test/resources/net/corda/schema/configuration/test/1.0/schema-fragment.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "$id": "https://corda.r3.com/net/corda/schema/configuration/test/1.0/schema-fragment.json",
   "title": "Test schema fragment",
   "description": "Schema fragment for testing",

--- a/data/config-schema/src/test/resources/net/corda/schema/cordapp/configuration/test/1.0/schema-fragment.json
+++ b/data/config-schema/src/test/resources/net/corda/schema/cordapp/configuration/test/1.0/schema-fragment.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://corda.r3.com/net/corda/schema/cordapp/configuration/test/1.0/schema-fragment.json",
   "title": "Test schema fragment",
   "description": "Schema fragment for testing",

--- a/data/config-schema/src/test/resources/net/corda/schema/cordapp/configuration/test/1.0/schema-fragment.json
+++ b/data/config-schema/src/test/resources/net/corda/schema/cordapp/configuration/test/1.0/schema-fragment.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "$id": "https://corda.r3.com/net/corda/schema/cordapp/configuration/test/1.0/schema-fragment.json",
   "title": "Test schema fragment",
   "description": "Schema fragment for testing",

--- a/data/membership-schema/src/main/resources/net/corda/schema/membership/group/policy/1.0/corda.group.policy.json
+++ b/data/membership-schema/src/main/resources/net/corda/schema/membership/group/policy/1.0/corda.group.policy.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "$id": "https://corda.r3.com/net/corda/schema/membership/group/policy/1.0/corda.group.policy.json",
   "title": "Corda Group Policy Schema",
   "description": "Schema for the group policy file included in distributed CPIs.",

--- a/data/membership-schema/src/main/resources/net/corda/schema/membership/group/policy/1.0/corda.group.policy.json
+++ b/data/membership-schema/src/main/resources/net/corda/schema/membership/group/policy/1.0/corda.group.policy.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://corda.r3.com/net/corda/schema/membership/group/policy/1.0/corda.group.policy.json",
   "title": "Corda Group Policy Schema",
   "description": "Schema for the group policy file included in distributed CPIs.",

--- a/data/membership-schema/src/main/resources/net/corda/schema/membership/member/dynamic/registration/1.0/corda.member.dynamic.registration.json
+++ b/data/membership-schema/src/main/resources/net/corda/schema/membership/member/dynamic/registration/1.0/corda.member.dynamic.registration.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://corda.r3.com/net/corda/schema/membership/member/dynamic/registration/1.0/corda.member.dynamic.registration.json",
   "title": "Corda dynamic member registration context schema",
   "type": "object",

--- a/data/membership-schema/src/main/resources/net/corda/schema/membership/member/dynamic/registration/1.0/corda.member.dynamic.registration.json
+++ b/data/membership-schema/src/main/resources/net/corda/schema/membership/member/dynamic/registration/1.0/corda.member.dynamic.registration.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "$id": "https://corda.r3.com/net/corda/schema/membership/member/dynamic/registration/1.0/corda.member.dynamic.registration.json",
   "title": "Corda dynamic member registration context schema",
   "type": "object",

--- a/data/membership-schema/src/main/resources/net/corda/schema/membership/member/static/registration/1.0/corda.member.static.registration.json
+++ b/data/membership-schema/src/main/resources/net/corda/schema/membership/member/static/registration/1.0/corda.member.static.registration.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "$id": "https://corda.r3.com/net/corda/schema/membership/member/static/registration/1.0/corda.member.static.registration.json",
   "title": "Corda static member registration context schema",
   "description": "Definition of the registration context required for registering a member in a static group.",

--- a/data/membership-schema/src/main/resources/net/corda/schema/membership/member/static/registration/1.0/corda.member.static.registration.json
+++ b/data/membership-schema/src/main/resources/net/corda/schema/membership/member/static/registration/1.0/corda.member.static.registration.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://corda.r3.com/net/corda/schema/membership/member/static/registration/1.0/corda.member.static.registration.json",
   "title": "Corda static member registration context schema",
   "description": "Definition of the registration context required for registering a member in a static group.",

--- a/data/membership-schema/src/main/resources/net/corda/schema/membership/mgm/registration/1.0/corda.mgm.registration.json
+++ b/data/membership-schema/src/main/resources/net/corda/schema/membership/mgm/registration/1.0/corda.mgm.registration.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://corda.r3.com/net/corda/schema/membership/mgm/registration/1.0/corda.mgm.registration.json",
   "title": "Corda MGM registration context schema",
   "type": "object",

--- a/data/membership-schema/src/main/resources/net/corda/schema/membership/mgm/registration/1.0/corda.mgm.registration.json
+++ b/data/membership-schema/src/main/resources/net/corda/schema/membership/mgm/registration/1.0/corda.mgm.registration.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "$id": "https://corda.r3.com/net/corda/schema/membership/mgm/registration/1.0/corda.mgm.registration.json",
   "title": "Corda MGM registration context schema",
   "type": "object",

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ cordaProductVersion = 5.1.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 9
+cordaApiRevision = 10
 
 # Main
 kotlinVersion = 1.8.21

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ cordaProductVersion = 5.1.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 8
+cordaApiRevision = 9
 
 # Main
 kotlinVersion = 1.8.21


### PR DESCRIPTION
Upgrade json schema spec to 2019-09. This is pre-requisite in order to be aligned with the latest spec version specified when building `JsonSchemaFactory` as used by https://github.com/corda/corda-runtime-os/pull/4341