### PR TITLE
CORE-9483 Adding clear comments to session send/receive APIs describing accepted types

### DIFF
--- a/application/src/main/java/net/corda/v5/application/messaging/FlowMessaging.java
+++ b/application/src/main/java/net/corda/v5/application/messaging/FlowMessaging.java
@@ -128,8 +128,13 @@ public interface FlowMessaging {
      * Suspends until a message has been received for each session in the specified {@code sessions}.
      * <p>
      * Consider {@link #receiveAllMap(Map)} when sessions are expected to receive different types.
+     * <p>
+     * The {@code receiveType} should be of a type that is annotated with @CordaSerializable or a primitive type. This
+     * function cannot handle types that do not meet these criteria.
      *
-     * @param receiveType type of object to be received for all {@code sessions}.
+     * @param <R> type of object to be received for all {@code sessions}.
+     * @param receiveType Type of object to be received for all {@code sessions}, which should be either a primitive type
+     *                    or a type annotated with @CordaSerializable.
      * @param sessions Set of sessions to receive from.
      * @return a {@link List} containing the objects received from the {@code sessions}.
      *
@@ -143,6 +148,9 @@ public interface FlowMessaging {
      * Suspends until a message has been received for each session in the specified {@code sessions}.
      * <p>
      * Consider {@link #receiveAll(Class, Set)} when the same type is expected from all sessions.
+     * <p>
+     * The types of objects expected to be received should be annotated with @CordaSerializable or be a primitive type. This
+     * function cannot handle types that do not meet these criteria.
      *
      * @param sessions Map of session to the type of object that is expected to be received
      * @return a {@link Map} containing the objects received by the {@link FlowSession}s who sent them.
@@ -159,8 +167,11 @@ public interface FlowMessaging {
      * Note that the other parties may receive the message at some arbitrary later point or not at all: if one of the provided [sessions]
      * is offline then message delivery will be retried until the session expires. Sessions are deemed to be expired when this session
      * stops receiving heartbeat messages from the counterparty within the configurable timeout.
+     * <p>
+     * The {@code payload} object should be of a type that is annotated with @CordaSerializable or a primitive type. This
+     * function cannot handle types that do not meet these criteria.
      *
-     * @param payload the payload to send.
+     * @param payload the payload to send, which should be either a primitive type or a type annotated with @CordaSerializable.
      * @param sessions the sessions to send the provided payload to.
      *
      * @throws CordaRuntimeException if any session is closed or in a failed state.
@@ -174,8 +185,12 @@ public interface FlowMessaging {
      * Note that the other parties may receive the message at some arbitrary later point or not at all: if one of the provided [sessions]
      * is offline then message delivery will be retried until the session expires. Sessions are deemed to be expired when this session
      * stops receiving heartbeat messages from the counterparty within the configurable timeout.
+     * <p>
+     * The objects in {@code payloadsPerSession} should be of types that are annotated with @CordaSerializable or be primitive types. This
+     * function cannot handle types that do not meet these criteria.
      *
      * @param payloadsPerSession a mapping that contains the payload to be sent to each session.
+     *                           The payloads should be either of primitive types or types annotated with @CordaSerializable.
      *
      * @throws CordaRuntimeException if any session is closed or in a failed state.
      */

--- a/application/src/main/java/net/corda/v5/application/messaging/FlowSession.java
+++ b/application/src/main/java/net/corda/v5/application/messaging/FlowSession.java
@@ -71,10 +71,14 @@ public interface FlowSession {
      * Note that this function is not just a simple send and receive pair. It is more efficient and more correct to use
      * sendAndReceive when you expect to do a message swap rather than use {@link FlowSession#send} and then
      * {@link FlowSession#receive}.
+     * <p>
+     * Both the {@code payload} object and the {@code receiveType} should be of a type that is annotated
+     * with @CordaSerializable or a primitive type. This function cannot handle types that do not meet these criteria.
      *
      * @param <R> The data type received from the counterparty.
      * @param receiveType The data type received from the counterparty.
-     * @param payload The data sent to the counterparty.
+     * @param payload The data sent to the counterparty, which should be either a primitive type
+     *                or a type annotated with @CordaSerializable.
      *
      * @return The received data <R>
      *
@@ -87,9 +91,13 @@ public interface FlowSession {
 
     /**
      * Suspends until a message of type <R> is received from {@link #getCounterparty}.
+     * <p>
+     * The {@code receiveType} should be a type that is annotated with @CordaSerializable or a primitive type. This
+     * function cannot handle types that do not meet these criteria.
      *
      * @param <R> The data type received from the counterparty.
-     * @param receiveType The data type received from the counterparty.
+     * @param receiveType The data type received from the counterparty, which should be either a primitive type
+     *                    or a type annotated with @CordaSerializable.
      *
      * @return The received data <R>
      *
@@ -106,8 +114,12 @@ public interface FlowSession {
      * Note that the other party may receive the message at some arbitrary later point or not at all: if {@link #getCounterparty}
      * is offline then message delivery will be retried until it comes back or until the message is older than the
      * network's event horizon time.
+     * <p>
+     * The {@code payload} object should be of a type that is annotated with @CordaSerializable or a primitive type. This
+     * function cannot handle types that do not meet these criteria.
      *
-     * @param payload The data sent to the counterparty.
+     * @param payload The data sent to the counterparty, which should be either a primitive type
+     *                or a type annotated with @CordaSerializable.
      *
      * @throws CordaRuntimeException if the session is closed or in a failed state.
      */


### PR DESCRIPTION
These API changes are relating to the PR https://github.com/corda/corda-runtime-os/pull/4291, which enables the sending of primitive values through session events.

The change makes it clear to customers that the send and receive APIs can only accept types which are `@CordaSerializable` or, now, primitives types which do not need to be annotated as such.