### PR TITLE
ES-617: Add Gradle Version Catalog implementation for corda-api

### DIFF
--- a/application/build.gradle
+++ b/application/build.gradle
@@ -20,5 +20,5 @@ dependencies {
     compileOnly 'org.osgi:osgi.core'
 
     testApi 'org.jetbrains.kotlin:kotlin-osgi-bundle'
-    testImplementation "org.assertj:assertj-core:$assertjVersion"
+    testImplementation libs.assertj.core
 }

--- a/base/build.gradle
+++ b/base/build.gradle
@@ -15,5 +15,5 @@ dependencies {
     compileOnly 'org.osgi:osgi.annotation'
 
     testApi 'org.jetbrains.kotlin:kotlin-osgi-bundle'
-    testImplementation "org.assertj:assertj-core:$assertjVersion"
+    testImplementation libs.assertj.core
 }

--- a/build.gradle
+++ b/build.gradle
@@ -155,8 +155,8 @@ subprojects {
         dependencies {
             // Test libraries -> keep consistent across modules
             testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlinVersion"
-            testImplementation "org.mockito:mockito-core:$mockitoVersion"
-            testImplementation("org.mockito.kotlin:mockito-kotlin:$mockitoKotlinVersion") {
+            testImplementation libs.mockito.core
+            testImplementation(libs.mockito.kotlin) {
                 // Excluding mockito-core and adding it implicitly above. This is done to allow the use of the latest version of mockito.
                 exclude group: 'mockito-core'
             }
@@ -253,7 +253,7 @@ subprojects {
         dependencies {
         detekt "io.gitlab.arturbosch.detekt:detekt-cli:$detektPluginVersion"
             constraints {
-                detekt("org.yaml:snakeyaml:$snakeyamlVersion") {
+                detekt(libs.snakeyaml) {
                     because "required until detekt plugin updates it's internal version of snakeYaml, not fixed as of detekt version 1.21"
                 }
             }

--- a/buildSrc/src/main/groovy/corda-api.common-library.gradle
+++ b/buildSrc/src/main/groovy/corda-api.common-library.gradle
@@ -25,7 +25,7 @@ configurations {
 
 
 dependencies {
-    compileOnly "org.jetbrains:annotations:$jetbrainsAnnotationsVersion"
+    compileOnly libs.jetbrains.annotations
     testImplementation "org.junit.jupiter:junit-jupiter-api:$junitVersion"
     testImplementation "org.junit.jupiter:junit-jupiter-params:$junitVersion"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junitVersion"

--- a/corda-api/build.gradle
+++ b/corda-api/build.gradle
@@ -38,7 +38,7 @@ dependencies {
         }
         api('org.jetbrains:annotations') {
             version {
-                require jetbrainsAnnotationsVersion
+                require libs.versions.jetbrainsAnnotationsVersion.get()
             }
         }
         api('org.osgi:osgi.annotation') {
@@ -58,7 +58,7 @@ dependencies {
         }
         api('org.slf4j:slf4j-api') {
             version {
-                require slf4jVersion
+                require libs.versions.slf4jVersion.get()
             }
         }
     }

--- a/crypto/build.gradle
+++ b/crypto/build.gradle
@@ -14,9 +14,9 @@ dependencies {
     api platform(project(':corda-api'))
     api project(':base')
 
-    testImplementation "org.bouncycastle:bcprov-jdk18on:$bouncycastleVersion"
-    testImplementation "org.bouncycastle:bcpkix-jdk18on:$bouncycastleVersion"
-    testImplementation "org.assertj:assertj-core:$assertjVersion"
+    testImplementation libs.bouncycastle.bcprov
+    testImplementation libs.bouncycastle.bcpkix
+    testImplementation libs.assertj.core
     testImplementation "org.junit.jupiter:junit-jupiter-api:$junitVersion"
 }
 

--- a/data/avro-schema/build.gradle
+++ b/data/avro-schema/build.gradle
@@ -11,9 +11,9 @@ plugins {
 }
 
 dependencies {
-    api "org.apache.avro:avro:$avroVersion"
+    api libs.apache.avro
     constraints {
-        implementation("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion") {
+        implementation(libs.jackson.databind) {
             because "required until new version of Avro available which updates Jackson"
         }
     }

--- a/data/topic-schema/build.gradle
+++ b/data/topic-schema/build.gradle
@@ -9,9 +9,9 @@ description 'Definition of Topics'
 dependencies {
     implementation platform(project(':corda-api'))
 
-    testImplementation "org.assertj:assertj-core:$assertjVersion"
-    testImplementation "com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion"
-    testImplementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jacksonVersion"
+    testImplementation libs.assertj.core
+    testImplementation libs.jackson.module
+    testImplementation libs.jackson.dataformat
 
     compileOnly 'org.osgi:osgi.annotation'
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,9 +15,6 @@ cordaApiRevision = 765
 kotlinVersion = 1.8.21
 kotlin.stdlib.default.dependency = false
 
-# These are the same annotations that Kotlin uses.
-jetbrainsAnnotationsVersion = 13.0
-
 # License
 licenseName = The Apache License, Version 2.0
 licenseUrl = http://www.apache.org/licenses/LICENSE-2.0.txt
@@ -33,25 +30,15 @@ dokkaVersion = 1.8.+
 detektPluginVersion = 1.22.+
 dependencyCheckVersion=0.46.+
 artifactoryPluginVersion = 4.28.2
-snakeyamlVersion=2.0
-
-# Logging
-slf4jVersion = 1.7.36
 
 # Main implementation dependencies
 avroGradlePluginVersion=1.3.0
-avroVersion = 1.11.1
-bouncycastleVersion = 1.73
 grgitPluginVersion = 5.2.0
 taskTreePluginVersion = 2.1.1
 javaxPersistenceApiVersion = 2.2
-jacksonVersion = 2.15.2
 
 # Testing
-assertjVersion = 3.24.+
 junitVersion = 5.9.+
-mockitoVersion = 5.3.+
-mockitoKotlinVersion = 4.1.+
 
 # OSGi
 bndVersion = 6.4.0
@@ -69,3 +56,7 @@ snykVersion = 0.4
 
 # Kotlin build
 kotlin.build.report.output=file,build_scan
+
+# Gradle Version Catalog
+cordaVersionCatalog=1.0.0-beta-+
+releaseVersionCatalog=release-5.0

--- a/ledger/ledger-common/build.gradle
+++ b/ledger/ledger-common/build.gradle
@@ -13,5 +13,5 @@ dependencies {
     api project(':application')
 
     testImplementation project(':crypto')
-    testImplementation "org.assertj:assertj-core:$assertjVersion"
+    testImplementation libs.assertj.core
 }

--- a/ledger/ledger-consensual/build.gradle
+++ b/ledger/ledger-consensual/build.gradle
@@ -11,5 +11,5 @@ dependencies {
 
     api project(':ledger:ledger-common')
 
-    testImplementation "org.assertj:assertj-core:$assertjVersion"
+    testImplementation libs.assertj.core
 }

--- a/ledger/ledger-utxo/build.gradle
+++ b/ledger/ledger-utxo/build.gradle
@@ -11,5 +11,5 @@ dependencies {
 
     api project(':ledger:ledger-common')
 
-    testImplementation "org.assertj:assertj-core:$assertjVersion"
+    testImplementation libs.assertj.core
 }

--- a/membership/build.gradle
+++ b/membership/build.gradle
@@ -14,6 +14,6 @@ dependencies {
 
     api project(':base')
 
-    testImplementation "org.assertj:assertj-core:$assertjVersion"
-    testImplementation "org.mockito:mockito-core:$mockitoVersion"
+    testImplementation libs.assertj.core
+    testImplementation libs.mockito.core
 }

--- a/serialization/build.gradle
+++ b/serialization/build.gradle
@@ -13,5 +13,5 @@ dependencies {
     compileOnly 'org.jetbrains:annotations'
     compileOnly 'org.osgi:osgi.annotation'
 
-    testImplementation "org.assertj:assertj-core:$assertjVersion"
+    testImplementation libs.assertj.core
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -79,6 +79,11 @@ dependencyResolutionManagement {
             }
         }
     }
+    versionCatalogs {
+        libs {
+            from("net.corda:$releaseVersionCatalog:$cordaVersionCatalog")
+        }
+    }
 }
 
 rootProject.name = "corda-api"


### PR DESCRIPTION
**Description:**
As part improving version dependencies within Corda we have added [Gradle Version Catalog](https://docs.gradle.org/current/userguide/platforms.html) for corda-api. This will allow us to use the newly created central repository [corda-version-catalog](https://github.com/corda/corda-version-catalog) for maintaining and managing 3rd parties dependency that is use within corda-api.

**Changes:**
Added implementation of using Gradle Version Catalog for corda-api repo in build.gradle file
Replace all version reference occurrences which use gradle.properties to version catalog in build.gradle files.

jetbrainsAnnotationsVersion = 13.0
snakeyamlVersion=2.0
slf4jVersion = 1.7.36
avroVersion = 1.11.1
bouncycastleVersion = 1.73
jacksonVersion = 2.15.2
assertjVersion = 3.24.+
mockitoVersion = 5.3.+
mockitoKotlinVersion = 4.1.+

**Testing**
Tested with release-5.0 for Artifactory cordaVersionCatalog=1.0.0-beta-+ created in [corda-version-catalog](https://github.com/corda/corda-version-catalog) repo.

**Documentation**
Rendered version: https://github.com/corda/platform-eng-design/blob/knguyen/ES-374/gradle_version_catalog/core/corda-5/corda-5.0/infrastructure/build/build-dependencies/corda5-version-catalog.md