### PR TITLE
CORE-13570 Align schema version of vnode datasource schema

### DIFF
--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/vnode.datasource/1.0/corda.vnode.datasource.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/vnode.datasource/1.0/corda.vnode.datasource.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
   "$id": "https://corda.r3.com/net/corda/schema/configuration/db/1.0/corda.db.json",
   "title": "Corda Virtual Node Datasource Configuration Schema",
   "description": "Configuration schema for the Virtual Node Datasource section.",


### PR DESCRIPTION
This PR aligns the schema version of the vnode datasource schema added in [CORE-13570 Default datasource properties for vnode connections](https://github.com/corda/corda-api/pull/1186) with the schema version update for all schemas done in [CORE-11805 - Update json schema spec](https://github.com/corda/corda-api/pull/1183). 