### PR TITLE
CORE-15787: fix downstream compatibility jobs which now compile against J17

### DIFF
--- a/.ci/JenkinsApiCompatibility
+++ b/.ci/JenkinsApiCompatibility
@@ -1,5 +1,5 @@
 // Check corda-api compatibility with downstream consumers which implement CordApps
-@Library('corda-shared-build-pipeline-steps@test-prgate') _
+@Library('corda-shared-build-pipeline-steps@ronanb/J17-downstream-jobs') _
 
 cordaApiCompatibilityCheck(
     javaVersion: '17'

--- a/.ci/JenkinsApiCompatibility
+++ b/.ci/JenkinsApiCompatibility
@@ -1,4 +1,6 @@
 // Check corda-api compatibility with downstream consumers which implement CordApps
-@Library('corda-shared-build-pipeline-steps@5.1') _
+@Library('corda-shared-build-pipeline-steps@test-prgate') _
 
-cordaApiCompatibilityCheck()
+cordaApiCompatibilityCheck(
+    javaVersion: '17'
+)

--- a/.ci/JenkinsApiCompatibility
+++ b/.ci/JenkinsApiCompatibility
@@ -1,5 +1,5 @@
 // Check corda-api compatibility with downstream consumers which implement CordApps
-@Library('corda-shared-build-pipeline-steps@ronanb/J17-downstream-jobs') _
+@Library('corda-shared-build-pipeline-steps@5.1') _
 
 cordaApiCompatibilityCheck(
     javaVersion: '17'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@test-prgate') _
+@Library('corda-shared-build-pipeline-steps@ronanb/J17-downstream-jobs') _
 
 cordaPipeline(
     runIntegrationTests: false,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@ronanb/J17-downstream-jobs') _
+@Library('corda-shared-build-pipeline-steps@5.1') _
 
 cordaPipeline(
     runIntegrationTests: false,

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('corda-shared-build-pipeline-steps@5.1') _
+@Library('corda-shared-build-pipeline-steps@test-prgate') _
 
 cordaPipeline(
     runIntegrationTests: false,


### PR DESCRIPTION
This PR is associated with updates made in two related pull requests:

-  corda-non-functional-test repository ([#221](https://github.com/corda/corda-non-functional-test/pull/221))
-  corda-shared-build-pipeline-steps repository ([#1007](https://github.com/corda/corda-shared-build-pipeline-steps/pull/1007))


As a part of these updates, both corda5-e2e-tests and corda-non-functional-test have been configured to compile using Java JDK 17. Additionally, the PR gate for corda-api passes the PRs binary artifacts to a downstream job that builds both above-mentioned projects using these artifacts. To ensure compatibility, we need to set the JDK version to 17 when triggering this downstream job.


Note: This update does not affect the JDK version used within the corda-api repository. The changes specifically relate to the configuration of downstream builds and their JDK version setting.