### PR TITLE
ES-1031: Restore CODEOWNERS file for 5.0 branch

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,14 @@
-# Reduced list for the duration of 5.0 code freeze 
-* @mnesbit @driessamyn @ronanbrowne @rick-r3 @fenryka @yarivus 
+# Build scripts and Jenkins files should be audited by BLT
+# Any changes to source code of corda-api to be reviewed by C5 team leads
 
+Jenkinsfile        @corda/blt
+.ci/**             @corda/blt
+
+gradle/*           @corda/blt
+*.gradle           @corda/blt
+gradle.properties  @corda/corda5-team-leads
+
+*.kt               @corda/corda5-team-leads
+*.java             @corda/corda5-team-leads
+
+CODEOWNERS         @corda/blt @corda/corda5-team-leads


### PR DESCRIPTION
Restoring `CODEOWNERS` file to its original format, as part of this the GitHub freeze branch feature will be active on 5.0 streams.

Meaning PR's will still go through the normal review process and need to be approved by relevant groups in the CODEOWNERS file but, Merging will be blocked on that branch at a configuration level, until a repo admin temporarily lifts the freeze

