### PR TITLE
CORE-15641 Revise character limit on custom metadata values

### DIFF
--- a/data/membership-schema/src/main/resources/net/corda/schema/membership/group/policy/1.0/corda.group.policy.json
+++ b/data/membership-schema/src/main/resources/net/corda/schema/membership/group/policy/1.0/corda.group.policy.json
@@ -267,7 +267,7 @@
                 "^ext\\.[a-zA-Z0-9.]+$": {
                   "description": "Optional. User-specified additional properties, which must be prefixed with `ext.`.",
                   "type": "string",
-                  "maxLength": 256
+                  "maxLength": 800
                 }
               },
               "properties": {

--- a/data/membership-schema/src/main/resources/net/corda/schema/membership/member/dynamic/registration/1.0/corda.member.dynamic.registration.json
+++ b/data/membership-schema/src/main/resources/net/corda/schema/membership/member/dynamic/registration/1.0/corda.member.dynamic.registration.json
@@ -51,9 +51,9 @@
       "type": "string"
     },
     "^ext\\.[a-zA-Z0-9.]+$": {
-      "description": "Optional. A user can specify additional properties, they must be prefixed with `ext.`.",
+      "description": "Optional. User-specified additional properties, which must be prefixed with `ext.`.",
       "type": "string",
-      "maxLength": 256
+      "maxLength": 800
     }
   },
   "properties": {

--- a/data/membership-schema/src/main/resources/net/corda/schema/membership/member/static/registration/1.0/corda.member.static.registration.json
+++ b/data/membership-schema/src/main/resources/net/corda/schema/membership/member/static/registration/1.0/corda.member.static.registration.json
@@ -21,7 +21,7 @@
     "^ext\\.[a-zA-Z0-9.]+$": {
       "description": "Optional. User-specified additional properties, which must be prefixed with `ext.`.",
       "type": "string",
-      "maxLength": 256
+      "maxLength": 800
     }
   },
   "properties": {

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ cordaProductVersion = 5.1.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 10
+cordaApiRevision = 11
 
 # Main
 kotlinVersion = 1.8.21


### PR DESCRIPTION
Update registration context and group policy schemas to apply revised character limit on custom metadata values.

The character limit is raised to 800 to allow for PEM values. Public key lengths of the following key schemes were used for reference: CORDA.RSA(BC,RSA), CORDA.ECDSA.SECP256K1(BC,EC), CORDA.ECDSA.SECP256R1(BC,EC), CORDA.EDDSA.ED25519(BC,Ed25519), CORDA.X25519(BC,X25519), CORDA.SM2(BC,EC), CORDA.GOST3410.GOST3411(BC,GOST3410).

https://github.com/corda/corda-runtime-os/pull/4388