### PR TITLE
CORE-15789: upgrade api repo to use Java 17 but compile to 11 bytecode

### DIFF
--- a/.ci/JenkinsfileSnykDelta
+++ b/.ci/JenkinsfileSnykDelta
@@ -2,5 +2,6 @@
 
 snykDelta(
   snykOrgId: 'corda5-snyk-org-id',
-  snykTokenId: 'r3-snyk-corda5'
+  snykTokenId: 'r3-snyk-corda5',
+  javaVersion: '17'
 )

--- a/.ci/nightly/JenkinsfileNightly
+++ b/.ci/nightly/JenkinsfileNightly
@@ -4,5 +4,6 @@ cordaPipelineKubernetesAgent(
     runIntegrationTests: false,
     dailyBuildCron: 'H 02 * * *',
     gradleAdditionalArgs: '-Dscan.tag.Nightly-Build',
-    generateSbom: true
+    generateSbom: true,
+    javaVersion: '17'
     )

--- a/.ci/nightly/JenkinsfileSnykScan
+++ b/.ci/nightly/JenkinsfileSnykScan
@@ -1,5 +1,6 @@
 @Library('corda-shared-build-pipeline-steps@5.1') _
 
 cordaSnykScanPipeline (
-    snykTokenId: 'r3-snyk-corda5'
+    snykTokenId: 'r3-snyk-corda5',
+    javaVersion: '17'
 )

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,4 +9,5 @@ cordaPipeline(
     localPublishVersionSuffixOverride: '-beta-9999999999999',
     // allow publishing artifacts to S3 bucket
     publishToMavenS3Repository: true,
+    javaVersion: '17'
     )

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-import static org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+import static org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
 import static org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_1_8
 import static org.gradle.api.JavaVersion.VERSION_17
 import static org.gradle.jvm.toolchain.JavaLanguageVersion.of
@@ -201,7 +201,7 @@ subprojects {
                 languageVersion = KOTLIN_1_8
                 apiVersion = KOTLIN_1_8
                 verbose = true
-                jvmTarget = JVM_17
+                jvmTarget = JVM_11
                 javaParameters = true   // Useful for reflection.
                 freeCompilerArgs.addAll([
                     "-Xjvm-default=all"

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-import static org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
+import static org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
 import static org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_1_8
-import static org.gradle.api.JavaVersion.VERSION_11
+import static org.gradle.api.JavaVersion.VERSION_17
 import static org.gradle.jvm.toolchain.JavaLanguageVersion.of
 import org.jetbrains.dokka.gradle.DokkaTask
 
@@ -71,7 +71,7 @@ void configureKotlinForOSGi(Configuration configuration) {
 }
 
 def releaseType = System.getenv('RELEASE_TYPE') ?: "SNAPSHOT"
-def javaVersion = VERSION_11
+def javaVersion = VERSION_17
 
 logger.quiet("********************** CORDA BUILD **********************")
 if (!JavaVersion.current().isCompatibleWith(javaVersion)) {
@@ -129,8 +129,8 @@ subprojects {
 
         tasks.withType(JavaCompile).configureEach {
             options.compilerArgs << '-parameters'
-
             options.encoding = 'UTF-8'
+            options.release.set(11)
         }
 
         // Added to support junit5 tests
@@ -201,7 +201,7 @@ subprojects {
                 languageVersion = KOTLIN_1_8
                 apiVersion = KOTLIN_1_8
                 verbose = true
-                jvmTarget = JVM_11
+                jvmTarget = JVM_17
                 javaParameters = true   // Useful for reflection.
                 freeCompilerArgs.addAll([
                     "-Xjvm-default=all"


### PR DESCRIPTION
## Description
upgraded API repo to use Java 17 but made it compile to 11 bytecode

**.class files are compiled to Java 11**
```
javap -verbose /Users/eunjee.yang/corda/corda-api/ledger/ledger-utxo/build/classes/java/main/net/corda/v5/ledger/utxo/Command.class | grep "major version:"
  major version: 55
```
