### PR TITLE
ES-1061: use correct version of shared pipeline along with correct JDK

### DIFF
--- a/.ci/nightly/JenkinsfileWindowsCompatibility
+++ b/.ci/nightly/JenkinsfileWindowsCompatibility
@@ -1,6 +1,7 @@
-@Library('corda-shared-build-pipeline-steps@5.0.1') _
+@Library('corda-shared-build-pipeline-steps@5.1') _
 
 windowsCompatibility(
     runIntegrationTests: false,
-    dailyBuildCron: 'H 02 * * *'
+    dailyBuildCron: 'H 02 * * *',
+    javaVersion: '17'
     )


### PR DESCRIPTION
- Ensure windows nightly use correct shared lib version + override correct JDK 