### PR TITLE
CORE-15778: add meaningful exception messages in StateRef.parse()

### DIFF
--- a/ledger/ledger-utxo/src/main/java/net/corda/v5/ledger/utxo/StateRef.java
+++ b/ledger/ledger-utxo/src/main/java/net/corda/v5/ledger/utxo/StateRef.java
@@ -68,20 +68,20 @@ public final class StateRef {
      * @return Returns a {@link StateRef} parsed from the specified {@link String} value.
      * @throws IllegalArgumentException if the specified value cannot be parsed.
      */
-    public static StateRef parse(@NotNull final String value, DigestService digestService) {
-        try {
-            if (value.replaceAll("[^" + DELIMITER + "]", "").length() != 2) {
-                throw new IllegalArgumentException(
-                        MessageFormat.format("Failed to parse a StateRef from the specified value. The number of delimiter ({0}) should be two in value: {1}.", DELIMITER, value)
-                );
-            }
 
-            final int lastIndexOfDelimiter = value.lastIndexOf(DELIMITER);
+    public static StateRef parse(@NotNull final String value, DigestService digestService) {
+        final int lastIndexOfDelimiter = value.lastIndexOf(DELIMITER);
+        if (lastIndexOfDelimiter == -1) {
+            throw new IllegalArgumentException(
+                    MessageFormat.format("Failed to parse a StateRef from the specified value. At least one delimiter ({0}) is expected in value: {1}.", DELIMITER, value)
+            );
+        }
+
+        try {
             final String subStringBeforeDelimiter = value.substring(0, lastIndexOfDelimiter);
             final String subStringAfterDelimiter = value.substring(lastIndexOfDelimiter + 1);
             final int index = Integer.parseUnsignedInt(subStringAfterDelimiter);
             final SecureHash transactionId = digestService.parseSecureHash(subStringBeforeDelimiter);
-
             return new StateRef(transactionId, index);
         } catch (NumberFormatException numberFormatException) {
             throw new IllegalArgumentException(
@@ -89,6 +89,7 @@ public final class StateRef {
                     numberFormatException
             );
         } catch (IllegalArgumentException illegalArgumentException) {
+            System.out.println("another transaction id invalid exception");
             throw new IllegalArgumentException(
                     MessageFormat.format("Failed to parse a StateRef from the specified value. The transaction ID is malformed: {0}.", value),
                     illegalArgumentException

--- a/ledger/ledger-utxo/src/main/java/net/corda/v5/ledger/utxo/StateRef.java
+++ b/ledger/ledger-utxo/src/main/java/net/corda/v5/ledger/utxo/StateRef.java
@@ -89,7 +89,6 @@ public final class StateRef {
                     numberFormatException
             );
         } catch (IllegalArgumentException illegalArgumentException) {
-            System.out.println("another transaction id invalid exception");
             throw new IllegalArgumentException(
                     MessageFormat.format("Failed to parse a StateRef from the specified value. The transaction ID is malformed: {0}.", value),
                     illegalArgumentException

--- a/ledger/ledger-utxo/src/main/java/net/corda/v5/ledger/utxo/StateRef.java
+++ b/ledger/ledger-utxo/src/main/java/net/corda/v5/ledger/utxo/StateRef.java
@@ -68,7 +68,6 @@ public final class StateRef {
      * @return Returns a {@link StateRef} parsed from the specified {@link String} value.
      * @throws IllegalArgumentException if the specified value cannot be parsed.
      */
-
     public static StateRef parse(@NotNull final String value, DigestService digestService) {
         final int lastIndexOfDelimiter = value.lastIndexOf(DELIMITER);
         if (lastIndexOfDelimiter == -1) {

--- a/ledger/ledger-utxo/src/main/java/net/corda/v5/ledger/utxo/StateRef.java
+++ b/ledger/ledger-utxo/src/main/java/net/corda/v5/ledger/utxo/StateRef.java
@@ -19,10 +19,6 @@ public final class StateRef {
      * Specifies the delimiter that separates transaction ID and output index.
      */
     private static final String DELIMITER = ":";
-    /**
-     * The minimum SHA-256D algorithm hash length including SHA-256D: prefix
-     */
-    private static final Integer MINIMUM_HASH_LENGTH = 73;
 
     /**
      * The ID of the transaction in which the referenced state was created.
@@ -74,21 +70,17 @@ public final class StateRef {
      */
     public static StateRef parse(@NotNull final String value, DigestService digestService) {
         try {
-            if (!value.contains(DELIMITER)) {
+            final int lastIndexOfDelimiter = value.lastIndexOf(DELIMITER);
+            if (lastIndexOfDelimiter == -1) {
                 throw new IllegalArgumentException(
-                        MessageFormat.format("Failed to parse a StateRef from the specified value. The value: {0} doesn't contain expected delimiter (:)", value)
-                        );
-            }
-            if (value.length() < MINIMUM_HASH_LENGTH) {
-                throw new IllegalArgumentException(
-                        MessageFormat.format("Failed to parse a StateRef from the specified value. The length of the value: {0} doesn't meet the required SHA-256D algorithm length: 73", value.length())
+                        MessageFormat.format("Failed to parse a StateRef from the specified value. The delimiter (:) is missing: {0}.", value)
                 );
             }
-            final int lastIndexOfDelimiter = value.lastIndexOf(DELIMITER);
             final String subStringBeforeDelimiter = value.substring(0, lastIndexOfDelimiter);
             final String subStringAfterDelimiter = value.substring(lastIndexOfDelimiter + 1);
+            final int index = Integer.parseUnsignedInt(subStringAfterDelimiter);
             final SecureHash transactionId = digestService.parseSecureHash(subStringBeforeDelimiter);
-            final int index = Integer.parseInt(subStringAfterDelimiter);
+
             return new StateRef(transactionId, index);
         } catch (NumberFormatException numberFormatException) {
             throw new IllegalArgumentException(

--- a/ledger/ledger-utxo/src/main/java/net/corda/v5/ledger/utxo/StateRef.java
+++ b/ledger/ledger-utxo/src/main/java/net/corda/v5/ledger/utxo/StateRef.java
@@ -70,12 +70,13 @@ public final class StateRef {
      */
     public static StateRef parse(@NotNull final String value, DigestService digestService) {
         try {
-            final int lastIndexOfDelimiter = value.lastIndexOf(DELIMITER);
-            if (lastIndexOfDelimiter == -1) {
+            if (value.replaceAll("[^" + DELIMITER + "]", "").length() != 2) {
                 throw new IllegalArgumentException(
-                        MessageFormat.format("Failed to parse a StateRef from the specified value. The delimiter (:) is missing: {0}.", value)
+                        MessageFormat.format("Failed to parse a StateRef from the specified value. The number of delimiter ({0}) should be two in value: {1}.", DELIMITER, value)
                 );
             }
+
+            final int lastIndexOfDelimiter = value.lastIndexOf(DELIMITER);
             final String subStringBeforeDelimiter = value.substring(0, lastIndexOfDelimiter);
             final String subStringAfterDelimiter = value.substring(lastIndexOfDelimiter + 1);
             final int index = Integer.parseUnsignedInt(subStringAfterDelimiter);

--- a/ledger/ledger-utxo/src/main/java/net/corda/v5/ledger/utxo/StateRef.java
+++ b/ledger/ledger-utxo/src/main/java/net/corda/v5/ledger/utxo/StateRef.java
@@ -19,6 +19,10 @@ public final class StateRef {
      * Specifies the delimiter that separates transaction ID and output index.
      */
     private static final String DELIMITER = ":";
+    /**
+     * The minimum SHA-256D algorithm hash length including SHA-256D: prefix
+     */
+    private static final Integer MINIMUM_HASH_LENGTH = 73;
 
     /**
      * The ID of the transaction in which the referenced state was created.
@@ -70,6 +74,16 @@ public final class StateRef {
      */
     public static StateRef parse(@NotNull final String value, DigestService digestService) {
         try {
+            if (!value.contains(DELIMITER)) {
+                throw new IllegalArgumentException(
+                        MessageFormat.format("Failed to parse a StateRef from the specified value. The value: {0} doesn't contain expected delimiter (:)", value)
+                        );
+            }
+            if (value.length() < MINIMUM_HASH_LENGTH) {
+                throw new IllegalArgumentException(
+                        MessageFormat.format("Failed to parse a StateRef from the specified value. The length of the value: {0} doesn't meet the required SHA-256D algorithm length: 73", value.length())
+                );
+            }
             final int lastIndexOfDelimiter = value.lastIndexOf(DELIMITER);
             final String subStringBeforeDelimiter = value.substring(0, lastIndexOfDelimiter);
             final String subStringAfterDelimiter = value.substring(lastIndexOfDelimiter + 1);

--- a/ledger/ledger-utxo/src/test/java/net/corda/v5/ledger/utxo/StateRefParseTest.java
+++ b/ledger/ledger-utxo/src/test/java/net/corda/v5/ledger/utxo/StateRefParseTest.java
@@ -1,10 +1,10 @@
-package net.corda.v5.ledger.utxo.uniqueness.client;
+package net.corda.v5.ledger.utxo;
 
 import net.corda.v5.application.crypto.DigestService;
 import net.corda.v5.crypto.SecureHash;
-import net.corda.v5.ledger.utxo.StateRef;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -36,21 +36,18 @@ public class StateRefParseTest {
 
         Assertions.assertEquals(StateRef.parse(value, digestService).getTransactionId().toString(), stateRef.getTransactionId().toString());
     }
+
     @Test
     void parseMalformedWithZeroDelimiter() {
         final String value = "XXX";
-        final String errorMessage = assertThrows(IllegalArgumentException.class, () -> {
-            StateRef.parse(value, digestService);
-        }).getMessage();
+        final String errorMessage = assertThrows(IllegalArgumentException.class, () -> StateRef.parse(value, digestService)).getMessage();
         Assertions.assertEquals(String.format("Failed to parse a StateRef from the specified value. At least one delimiter (%s) is expected in value: %s.", DELIMITER, value), errorMessage);
     }
 
     @Test
     void parseMalformedIndex() {
         final String value = ":asdf:a";
-        final String errorMessage = assertThrows(IllegalArgumentException.class, () -> {
-            StateRef.parse(value, digestService);
-        }).getMessage();
+        final String errorMessage = assertThrows(IllegalArgumentException.class, () -> StateRef.parse(value, digestService)).getMessage();
         Assertions.assertEquals(String.format("Failed to parse a StateRef from the specified value. The index is malformed: %s.", value), errorMessage);
     }
 
@@ -66,9 +63,7 @@ public class StateRefParseTest {
                 "is not met by hex string: \"%s\"", digestName, digestHexStringLength, hexString))).when(digestService).parseSecureHash(valueBeforeDelimiter);
 
 
-        final String errorMessage = assertThrows(IllegalArgumentException.class, () -> {
-            StateRef.parse(value, digestService);
-        }).getMessage();
+        final String errorMessage = assertThrows(IllegalArgumentException.class, () -> StateRef.parse(value, digestService)).getMessage();
 
         Assertions.assertEquals(String.format("Failed to parse a StateRef from the specified value. The transaction ID is malformed: %s.", value), errorMessage);
     }

--- a/ledger/ledger-utxo/src/test/java/net/corda/v5/ledger/utxo/StateRefParseTest.java
+++ b/ledger/ledger-utxo/src/test/java/net/corda/v5/ledger/utxo/StateRefParseTest.java
@@ -18,21 +18,12 @@ public class StateRefParseTest {
     @Test
     void parseValidValue() {
         final String value = "SHA-256D:ED87C7285E1E34BF5E46302086F76317ACE9B17AEF7BD086EE09A5ACBD17CEA4:0";
-
-        final int lastIndexOfDelimiter = value.lastIndexOf(DELIMITER);
-        final String subStringBeforeDelimiter = value.substring(0, lastIndexOfDelimiter);
-        final String subStringAfterDelimiter = value.substring(lastIndexOfDelimiter + 1);
-        final int index = Integer.parseUnsignedInt(subStringAfterDelimiter);
+        final String subStringBeforeDelimiter = value.substring(0, value.lastIndexOf(DELIMITER));
         final SecureHash secureHash = mock(SecureHash.class);
-        final String digestName = "SHA-256D";
-        final String hexString = subStringBeforeDelimiter.substring(digestName.length() + 1);
 
-        doReturn(digestName).when(secureHash).getAlgorithm();
-        doReturn(hexString).when(secureHash).toHexString();
-        doReturn(subStringBeforeDelimiter).when(secureHash).toString();
         doReturn(secureHash).when(digestService).parseSecureHash(subStringBeforeDelimiter);
 
-        final StateRef stateRef = new StateRef(secureHash, index);
+        final StateRef stateRef = new StateRef(secureHash, 0);
 
         Assertions.assertEquals(StateRef.parse(value, digestService).getTransactionId().toString(), stateRef.getTransactionId().toString());
     }

--- a/ledger/ledger-utxo/src/test/java/net/corda/v5/ledger/utxo/StateRefParseTest.java
+++ b/ledger/ledger-utxo/src/test/java/net/corda/v5/ledger/utxo/StateRefParseTest.java
@@ -18,12 +18,13 @@ public class StateRefParseTest {
     @Test
     void parseValidValue() {
         final String value = "SHA-256D:ED87C7285E1E34BF5E46302086F76317ACE9B17AEF7BD086EE09A5ACBD17CEA4:0";
-        final String subStringBeforeDelimiter = value.substring(0, value.lastIndexOf(DELIMITER));
+        final int lastIndexOfDelimiter = value.lastIndexOf(DELIMITER);
+        final String subStringBeforeDelimiter = value.substring(0, lastIndexOfDelimiter);
         final SecureHash secureHash = mock(SecureHash.class);
 
         doReturn(secureHash).when(digestService).parseSecureHash(subStringBeforeDelimiter);
 
-        final StateRef stateRef = new StateRef(secureHash, 0);
+        final StateRef stateRef = new StateRef(secureHash, Integer.parseUnsignedInt(value.substring(lastIndexOfDelimiter + 1)));
 
         Assertions.assertEquals(StateRef.parse(value, digestService).getTransactionId().toString(), stateRef.getTransactionId().toString());
     }

--- a/ledger/ledger-utxo/src/test/java/net/corda/v5/ledger/utxo/uniqueness/client/StateRefParseTest.java
+++ b/ledger/ledger-utxo/src/test/java/net/corda/v5/ledger/utxo/uniqueness/client/StateRefParseTest.java
@@ -1,0 +1,75 @@
+package net.corda.v5.ledger.utxo.uniqueness.client;
+
+import net.corda.v5.application.crypto.DigestService;
+import net.corda.v5.crypto.SecureHash;
+import net.corda.v5.ledger.utxo.StateRef;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+
+
+public class StateRefParseTest {
+    private static final String DELIMITER = ":";
+    private final DigestService digestService = mock(DigestService.class);
+
+    @Test
+    void parseValidValue() {
+        final String value = "SHA-256D:ED87C7285E1E34BF5E46302086F76317ACE9B17AEF7BD086EE09A5ACBD17CEA4:0";
+
+        final int lastIndexOfDelimiter = value.lastIndexOf(DELIMITER);
+        final String subStringBeforeDelimiter = value.substring(0, lastIndexOfDelimiter);
+        final String subStringAfterDelimiter = value.substring(lastIndexOfDelimiter + 1);
+        final int index = Integer.parseUnsignedInt(subStringAfterDelimiter);
+        final SecureHash secureHash = mock(SecureHash.class);
+        final String digestName = "SHA-256D";
+        final String hexString = subStringBeforeDelimiter.substring(digestName.length() + 1);
+
+        doReturn(digestName).when(secureHash).getAlgorithm();
+        doReturn(hexString).when(secureHash).toHexString();
+        doReturn(subStringBeforeDelimiter).when(secureHash).toString();
+        doReturn(secureHash).when(digestService).parseSecureHash(subStringBeforeDelimiter);
+
+        final StateRef stateRef = new StateRef(secureHash, index);
+
+        Assertions.assertEquals(StateRef.parse(value, digestService).getTransactionId().toString(), stateRef.getTransactionId().toString());
+    }
+    @Test
+    void parseMalformedWithZeroDelimiter() {
+        final String value = "XXX";
+        final String errorMessage = assertThrows(IllegalArgumentException.class, () -> {
+            StateRef.parse(value, digestService);
+        }).getMessage();
+        Assertions.assertEquals(String.format("Failed to parse a StateRef from the specified value. At least one delimiter (%s) is expected in value: %s.", DELIMITER, value), errorMessage);
+    }
+
+    @Test
+    void parseMalformedIndex() {
+        final String value = ":asdf:a";
+        final String errorMessage = assertThrows(IllegalArgumentException.class, () -> {
+            StateRef.parse(value, digestService);
+        }).getMessage();
+        Assertions.assertEquals(String.format("Failed to parse a StateRef from the specified value. The index is malformed: %s.", value), errorMessage);
+    }
+
+    @Test
+    void parseMalformedTransactionId() {
+        final String value = "SHA-256D:asdf:0";
+        final String valueBeforeDelimiter = value.substring(0, value.lastIndexOf(DELIMITER));
+        final String digestName = "SHA-256D";
+        final String hexString = valueBeforeDelimiter.substring(digestName.length() + 1);
+        final Integer digestHexStringLength = 64;
+
+        doThrow(new IllegalArgumentException(String.format("Digest algorithm's: \"%s\" required hex string length: %s " +
+                "is not met by hex string: \"%s\"", digestName, digestHexStringLength, hexString))).when(digestService).parseSecureHash(valueBeforeDelimiter);
+
+
+        final String errorMessage = assertThrows(IllegalArgumentException.class, () -> {
+            StateRef.parse(value, digestService);
+        }).getMessage();
+
+        Assertions.assertEquals(String.format("Failed to parse a StateRef from the specified value. The transaction ID is malformed: %s.", value), errorMessage);
+    }
+}


### PR DESCRIPTION
### Overview
The PR 
- added an exception in malformed value in StateRef where delimiter, ":", isn't in value.
- optimise the method by utilising an existing index exception.

### Testing
I added a unit test for StateRef.parse() method, testing if:
- valid StateRef is parsed correctly
- value with zero delimiter throws a correct exception
- value with missing index throws a correct exception
- any other malformed value throws transaction Id exception