### PR TITLE
CORE-15179 - Updated the avro object TokenClaim

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/ledger/utxo/token/selection/data/TokenClaim.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/ledger/utxo/token/selection/data/TokenClaim.avsc
@@ -13,7 +13,7 @@
         "name": "claimedTokenStateRefs",
         "type": {
           "type": "array",
-          "items": "net.corda.data.ledger.utxo.token.selection.data.Token"
+          "items": "string"
         },
         "default": [],
         "doc": "Deprecated. The List of state refs for the claimed tokens"

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/ledger/utxo/token/selection/data/TokenClaim.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/ledger/utxo/token/selection/data/TokenClaim.avsc
@@ -13,9 +13,19 @@
         "name": "claimedTokenStateRefs",
         "type": {
           "type": "array",
-          "items": "string"
+          "items": "net.corda.data.ledger.utxo.token.selection.data.Token"
         },
-        "doc": "The List of state refs for the claimed tokens"
+        "default": [],
+        "doc": "Deprecated. The List of state refs for the claimed tokens"
+      },
+      {
+        "name": "claimedTokens",
+        "type": {
+          "type": "array",
+          "items": "net.corda.data.ledger.utxo.token.selection.data.Token"
+        },
+        "default": [],
+        "doc": "List of claimed tokens"
       }
   ]
 }


### PR DESCRIPTION
The field `claimedTokenStateRefs` has been deprecated. 
The field `claimedTokens` has been added in.
The fields `claimedTokenStateRefs` and `claimedTokens` are by default empty arrays to ensure backwards compatibility.


