### PR TITLE
ES-1123: Build the project using k8s pod rather than full EC2 instance

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 @Library('corda-shared-build-pipeline-steps@5.0.1') _
 
-cordaPipeline(
+cordaPipelineKubernetesAgent(
     runIntegrationTests: false,
     dependentJobsNames: ['/Corda5/corda-runtime-os-version-compatibility/release%2Fos%2F5.0'],
     dependentJobsNonBlocking: ['/Corda5/corda-api-compatibility/'],


### PR DESCRIPTION
Migrate to use cordaPipelineKubernetesAgent.groovy

- Functionally identical except for the fact we now build in a k8s pod, thus using less cloud resource as each build no longer needs a full EC2 instance
- No application-level change , this only affects infra this project is built on