### PR TITLE
CORE-15586 Split verification from TransactionSignatureService into TransactionSignatureVerificationService

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ cordaProductVersion = 5.1.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 13
+cordaApiRevision = 14
 
 # Main
 kotlinVersion = 1.8.21

--- a/ledger/ledger-common/src/main/java/net/corda/v5/ledger/common/transaction/TransactionSignatureService.java
+++ b/ledger/ledger-common/src/main/java/net/corda/v5/ledger/common/transaction/TransactionSignatureService.java
@@ -13,9 +13,10 @@ import java.util.List;
 /**
  * TransactionSignatureService can be used to sign and verify transaction signatures.
  * It supports both single and batch signatures.
+ * It can be used only in flows.
  */
 @DoNotImplement
-public interface TransactionSignatureService {
+public interface TransactionSignatureService extends TransactionSignatureVerificationService{
 
     /**
      * Signs a transaction ID with all the available keys.
@@ -52,21 +53,5 @@ public interface TransactionSignatureService {
     List<List<DigitalSignatureAndMetadata>> signBatch(
             @NotNull final List<TransactionWithMetadata> transactions,
             @NotNull final Iterable<PublicKey> publicKeys
-    );
-
-    /**
-     * Verifies a signature against a transaction.
-     * The underlying verification service signals the verification failures with different exceptions.
-     * {@link DigitalSignatureVerificationService}
-     *
-     * @param transaction           The original transaction.
-     * @param signatureWithMetadata The signature to be verified.
-     * @param publicKey             The public key to verify against. It must match with signatureWithMetadata's keyId.
-     * @throws RuntimeException if the signature could not be verified.
-     */
-    void verifySignature(
-            @NotNull final TransactionWithMetadata transaction,
-            @NotNull final DigitalSignatureAndMetadata signatureWithMetadata,
-            @NotNull final PublicKey publicKey
     );
 }

--- a/ledger/ledger-common/src/main/java/net/corda/v5/ledger/common/transaction/TransactionSignatureVerificationService.java
+++ b/ledger/ledger-common/src/main/java/net/corda/v5/ledger/common/transaction/TransactionSignatureVerificationService.java
@@ -1,0 +1,54 @@
+package net.corda.v5.ledger.common.transaction;
+
+import net.corda.v5.application.crypto.DigitalSignatureAndMetadata;
+import net.corda.v5.application.crypto.DigitalSignatureVerificationService;
+import net.corda.v5.base.annotations.DoNotImplement;
+import net.corda.v5.base.annotations.Suspendable;
+import net.corda.v5.crypto.SecureHash;
+import net.corda.v5.crypto.merkle.MerkleProof;
+import org.jetbrains.annotations.NotNull;
+
+import java.security.PublicKey;
+import java.util.List;
+
+/**
+ * TransactionSignatureVerificationService can be used to verify transaction signatures.
+ * It supports both single and batch signatures.
+ * It can be used in both flows and contracts.
+ */
+@DoNotImplement
+public interface TransactionSignatureVerificationService {
+    /**
+     * Verifies a signature against a transaction.
+     * The underlying verification service signals the verification failures with different exceptions.
+     * {@link DigitalSignatureVerificationService}
+     *
+     * @param transaction           The original transaction.
+     * @param signatureWithMetadata The signature to be verified.
+     * @param publicKey             The public key to verify against. It must match with signatureWithMetadata's keyId.
+     * @throws RuntimeException if the signature could not be verified.
+     */
+    void verifySignature(
+            @NotNull final TransactionWithMetadata transaction,
+            @NotNull final DigitalSignatureAndMetadata signatureWithMetadata,
+            @NotNull final PublicKey publicKey
+    );
+
+    /**
+     * Verifies a signature against a SecureHash.
+     * The underlying verification service signals the verification failures with different exceptions.
+     * {@link DigitalSignatureVerificationService}
+     *
+     * @param secureHash            The original secureHash.
+     * @param signatureWithMetadata The signature to be verified.
+     * @param publicKey             The public key to verify against. It must match with signatureWithMetadata's keyId.
+     * @throws RuntimeException if the signature could not be verified.
+     */
+    void verifySignature(
+            @NotNull final SecureHash secureHash,
+            @NotNull final DigitalSignatureAndMetadata signatureWithMetadata,
+            @NotNull final PublicKey publicKey
+    );
+
+}
+


### PR DESCRIPTION
CORE-15586 Split verification from TransactionSignatureService into TransactionSignatureVerificationService to let it be injected separately in the verification sandbox. That way, we can keep the verification sandbox more streamlined.