### PR TITLE
CORE-14685: Corda 5.1 cannot use SLF4J 2.x yet.

### DIFF
--- a/corda-api/build.gradle
+++ b/corda-api/build.gradle
@@ -57,8 +57,9 @@ dependencies {
             }
         }
         api('org.slf4j:slf4j-api') {
+            because 'Corda 5.1 only supports SLF4J 1.x'
             version {
-                require slf4jVersion
+                strictly slf4jVersion
             }
         }
     }


### PR DESCRIPTION
Force Gradle to resolve SLF4J 1.7.36, even if SLF4J 2.x has been provided, because Corda 5.1 doesn't support SLF4J 2.x yet.