### PR TITLE
CORE-16313: Downgrade Gradle Enterprise plugin 3.14.1 -> 3.12.2.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -61,7 +61,7 @@ osgiVersion = 8.0.0
 osgiAnnotationVersion = 8.1.0
 osgiScrAnnotationVersion = 1.5.1
 
-gradleEnterpriseVersion = 3.14.1
+gradleEnterpriseVersion = 3.12.2
 gradleDataPlugin = 1.8.2
 org.gradle.caching = true
 gradleEnterpriseUrl = https://gradle.dev.r3.com


### PR DESCRIPTION
"Downgradle" the Enterprise plugin to resolve:
```
The request was rejected.
Gradle Enterprise plugin version 3.14.1 is newer than the newest version supported by Gradle Enterprise 2022.4.1 which is 3.12. Please update to a newer version of Gradle Enterprise.
```