### PR TITLE
CORE-16313: Fix JUnit installation to be compatible with Gradle 9.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -174,6 +174,7 @@ subprojects {
 
             // Test runtime libraries -> also keep consistent
             testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junitVersion"
+            testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
             detektPlugins "io.gitlab.arturbosch.detekt:detekt-formatting:$detektPluginVersion"
         }

--- a/buildSrc/src/main/groovy/corda-api.common-library.gradle
+++ b/buildSrc/src/main/groovy/corda-api.common-library.gradle
@@ -26,8 +26,7 @@ configurations {
 
 dependencies {
     compileOnly "org.jetbrains:annotations:$jetbrainsAnnotationsVersion"
-    testImplementation "org.junit.jupiter:junit-jupiter-api:$junitVersion"
-    testImplementation "org.junit.jupiter:junit-jupiter-params:$junitVersion"
+    testImplementation "org.junit.jupiter:junit-jupiter:$junitVersion"
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junitVersion"
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -50,7 +50,7 @@ jacksonVersion = 2.15.2
 
 # Testing
 assertjVersion = 3.24.+
-junitVersion = 5.9.+
+junitVersion = 5.10.0
 mockitoVersion = 5.3.+
 mockitoKotlinVersion = 4.1.+
 


### PR DESCRIPTION
Replace `junit-jupiter-api` and `junit-jupiter-params` with `junit-jupiter` so that we also get the JUnit BOM.

Also upgrade JUnit 5.9.3 -> 5.10.0.