### PR TITLE
CORE-5533 Moving additionalProperties: false flag for the corda flow configuration schema

### DIFF
--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/flow/1.0/corda.flow.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/flow/1.0/corda.flow.json
@@ -106,7 +106,7 @@
         }
       },
       "additionalProperties": false
-    },
-    "additionalProperties": false
-  }
+    }
+  },
+  "additionalProperties": false
 }


### PR DESCRIPTION
### Context
The `corda.flow.json` schema was allowing for the creation of additional properties because of a misplaced `"additionalProperties": false` flag.
### Solution
Moving the `"additionalProperties": false` flag to outside the correct properties field