### PR TITLE
CORE-13621 Idempotency id table definition

### DIFF
--- a/data/db-schema/src/main/java/net/corda/db/schema/DbSchema.java
+++ b/data/db-schema/src/main/java/net/corda/db/schema/DbSchema.java
@@ -38,6 +38,7 @@ public final class DbSchema {
     public static final String VNODE_GROUP_PARAMETERS = "vnode_group_parameters";
     public static final String VNODE_GROUP_APPROVAL_RULES = "vnode_group_approval_rules";
     public static final String VNODE_PRE_AUTH_TOKENS = "vnode_pre_auth_tokens";
+    public static final String VNODE_PERSISTENCE_REQUEST_ID_TABLE = "vnode_persistence_request_id";
 
     public static final String LEDGER_CONSENSUAL_TRANSACTION_TABLE = "consensual_transaction";
     public static final String LEDGER_CONSENSUAL_TRANSACTION_STATUS_TABLE = "consensual_transaction_status";

--- a/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/vnode-vault-creation-v5.1.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/vnode-vault-creation-v5.1.xml
@@ -6,5 +6,10 @@
         <addColumn tableName="vnode_member_info">
             <column name="is_deleted" type="BOOLEAN" defaultValueBoolean="false"/>
         </addColumn>
+        <createTable tableName="vnode_persistence_request_id">
+            <column name="request_id" type="NVARCHAR(255)">
+                <constraints nullable="false" primaryKey="true"/>
+            </column>
+        </createTable>
     </changeSet>
 </databaseChangeLog>

--- a/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/vnode-vault-creation-v5.1.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/vnode-vault-creation-v5.1.xml
@@ -6,6 +6,7 @@
         <addColumn tableName="vnode_member_info">
             <column name="is_deleted" type="BOOLEAN" defaultValueBoolean="false"/>
         </addColumn>
+
         <createTable tableName="vnode_persistence_request_id">
             <column name="request_id" type="NVARCHAR(255)">
                 <constraints nullable="false" primaryKey="true"/>


### PR DESCRIPTION
Introduces table in vnode-vault schema which holds executed persistence requests (ids) from `PersistenceService`, to be used for deduplicating them.

runtime-os PR: [#4491](https://github.com/corda/corda-runtime-os/pull/4491)