### PR TITLE
CORE-15179 Added the property `cachedTokenPageSize` to the `corda.ledger.utxo` configuration.

### DIFF
--- a/data/config-schema/src/main/java/net/corda/schema/configuration/LedgerConfig.java
+++ b/data/config-schema/src/main/java/net/corda/schema/configuration/LedgerConfig.java
@@ -10,4 +10,5 @@ public final class LedgerConfig {
     public static final String UTXO_TOKEN_PERIODIC_CHECK_BLOCK_SIZE = "tokens.periodCheckBlockSize";
     public static final String UTXO_TOKEN_SEND_WAKEUP_MAX_RETRY_ATTEMPTS = "tokens.sendWakeUpMaxRetryAttempts";
     public static final String UTXO_TOKEN_SEND_WAKEUP_MAX_RETRY_DELAY = "tokens.sendWakeUpMaxRetryDelay";
+    public static final String UTXO_TOKEN_CACHED_TOKEN_PAGE_SIZE= "tokens.cachedTokenPageSize";
 }

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/ledger.utxo/1.0/corda.ledger.utxo.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/ledger.utxo/1.0/corda.ledger.utxo.json
@@ -46,6 +46,12 @@
           "type": "integer",
           "minimum": 1,
           "default": 10
+        },
+        "cachedTokenPageSize": {
+          "description": "The page size of the query that retrieves tokens from the database",
+          "type": "integer",
+          "minimum": 0,
+          "default": 1500
         }
       }
     }

--- a/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/config-creation-v1.0.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/config-creation-v1.0.xml
@@ -114,6 +114,17 @@
         </insert>
 
         <insert tableName="config">
+            <column name="section" value="corda.ledger.utxo"/>
+            <column name="config" value=""/>
+            <column name="schema_version_major" value="1"/>
+            <column name="schema_version_minor" value="0"/>
+            <column name="version" value="0"/>
+            <column name="is_deleted" value="false"/>
+            <column name="update_ts" valueDate="${now}"/>
+            <column name="update_actor" value="admin"/>
+        </insert>
+
+        <insert tableName="config">
             <column name="section" value="corda.flow"/>
             <column name="config" value=""/>
             <column name="schema_version_major" value="1"/>


### PR DESCRIPTION
Added the property cachedTokenPageSize to the `corda.ledger.utxo` configuration.
Added an entry row to the file `config-creation-v1.0.xml` so the default configuration for `corda.ledger.utxo` is generated.