### PR TITLE
CORE-16244 Adding flow mapper worker to topic config schemas

### DIFF
--- a/data/avro-schema/README.md
+++ b/data/avro-schema/README.md
@@ -1,6 +1,6 @@
 ## Avro Code Source Files
 
-All Arvo definitions should go under `src/main/resources/avro`.  While technically
+All Avro definitions should go under `src/main/resources/avro`.  While technically
 not necessary, it would also be good to put them under the same directory structure as 
 the package (or `namespace` in Avro-speak) that the record will belong.
 

--- a/data/topic-schema/README.md
+++ b/data/topic-schema/README.md
@@ -5,7 +5,7 @@ The schemas for each topic a virtual node uses will be defined here.
 These schemas should be updated here alongside their implementation in an effort to keep this document up-to-date.
 
 ### Kafka Auto-topic creation
-**We must ensure to avoid setting auto-creation of topics is Kafka!**
+**We must ensure we do not enable auto-creation of topics in Kafka!**
 
 This can lead to unnoticed errors in production.  We should adhere to the ethos that if a topic
 we expect doesn't exist then that signifies a setup problem and should immediately cause an error.

--- a/data/topic-schema/src/main/resources/net/corda/schema/AvroSchema.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/AvroSchema.yaml
@@ -5,6 +5,7 @@ topics:
       - crypto
       - db
       - flow
+      - flow-mapper
       - membership
       - gateway
       - link-manager
@@ -15,6 +16,7 @@ topics:
       - crypto
       - db
       - flow
+      - flow-mapper
       - membership
       - gateway
       - link-manager

--- a/data/topic-schema/src/main/resources/net/corda/schema/AvroSchema.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/AvroSchema.yaml
@@ -5,7 +5,7 @@ topics:
       - crypto
       - db
       - flow
-      - flow-mapper
+      - flowMapper
       - membership
       - gateway
       - link-manager
@@ -16,7 +16,7 @@ topics:
       - crypto
       - db
       - flow
-      - flow-mapper
+      - flowMapper
       - membership
       - gateway
       - link-manager

--- a/data/topic-schema/src/main/resources/net/corda/schema/Config.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/Config.yaml
@@ -19,7 +19,8 @@ topics:
       - crypto
       - db
       - flow
-      - flow-mapper
+      - flowMapper
+      - verification
       - membership
       - gateway
       - link-manager

--- a/data/topic-schema/src/main/resources/net/corda/schema/Config.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/Config.yaml
@@ -20,7 +20,6 @@ topics:
       - db
       - flow
       - flowMapper
-      - verification
       - membership
       - gateway
       - link-manager

--- a/data/topic-schema/src/main/resources/net/corda/schema/Config.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/Config.yaml
@@ -19,6 +19,7 @@ topics:
       - crypto
       - db
       - flow
+      - flow-mapper
       - membership
       - gateway
       - link-manager

--- a/data/topic-schema/src/main/resources/net/corda/schema/Flow.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/Flow.yaml
@@ -34,16 +34,18 @@ topics:
     name: flow.mapper.event
     consumers:
       - flow
+      - flow-mapper
     producers:
-      - flow
+      - flow-mapper
       - rest
     config:
   FlowMapperEventStateTopic:
     name: flow.mapper.event.state
     consumers:
       - flow
+      - flow-mapper
     producers:
-      - flow
+      - flow-mapper
     config:
       cleanup.policy: compact
       segment.ms: 600000
@@ -55,8 +57,9 @@ topics:
     name: flow.mapper.event.dlq
     consumers:
       - flow
+      - flow-mapper
     producers:
-      - flow
+      - flow-mapper
     config:
   FlowStatusTopic:
     name: flow.status

--- a/data/topic-schema/src/main/resources/net/corda/schema/Flow.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/Flow.yaml
@@ -3,10 +3,12 @@ topics:
     name: flow.event
     consumers:
       - flow
+      - flowMapper
     producers:
       - db
       - crypto
       - flow
+      - flowMapper
       - persistence
       - uniqueness
     config:

--- a/data/topic-schema/src/main/resources/net/corda/schema/Flow.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/Flow.yaml
@@ -39,6 +39,7 @@ topics:
       - flow
       - flowMapper
     producers:
+      - flow
       - flowMapper
       - rest
     config:

--- a/data/topic-schema/src/main/resources/net/corda/schema/Flow.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/Flow.yaml
@@ -34,18 +34,19 @@ topics:
     name: flow.mapper.event
     consumers:
       - flow
-      - flow-mapper
+      - flowMapper
     producers:
-      - flow-mapper
+      - flowMapper
       - rest
     config:
   FlowMapperEventStateTopic:
     name: flow.mapper.event.state
     consumers:
       - flow
-      - flow-mapper
+      - flowMapper
     producers:
-      - flow-mapper
+      - flow
+      - flowMapper
     config:
       cleanup.policy: compact
       segment.ms: 600000
@@ -57,9 +58,9 @@ topics:
     name: flow.mapper.event.dlq
     consumers:
       - flow
-      - flow-mapper
+      - flowMapper
     producers:
-      - flow-mapper
+      - flowMapper
     config:
   FlowStatusTopic:
     name: flow.status

--- a/data/topic-schema/src/main/resources/net/corda/schema/Flow.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/Flow.yaml
@@ -3,7 +3,6 @@ topics:
     name: flow.event
     consumers:
       - flow
-      - flowMapper
     producers:
       - db
       - crypto

--- a/data/topic-schema/src/main/resources/net/corda/schema/Membership.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/Membership.yaml
@@ -93,6 +93,7 @@ topics:
     consumers:
       - db
       - flow
+      - flowMapper
     producers:
       - link-manager
       - membership
@@ -106,6 +107,7 @@ topics:
       - membership
       - rest
       - flow
+      - flowMapper
       - db
     producers:
       - db

--- a/data/topic-schema/src/main/resources/net/corda/schema/Membership.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/Membership.yaml
@@ -63,7 +63,7 @@ topics:
       - membership
       - rest
       - flow
-      - flowWorker
+      - flowMapper
       - db
     producers:
       - membership

--- a/data/topic-schema/src/main/resources/net/corda/schema/Membership.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/Membership.yaml
@@ -4,6 +4,7 @@ topics:
     consumers:
       - db
       - flow
+      - flowMapper
       - link-manager
       - membership
       - rest
@@ -62,6 +63,7 @@ topics:
       - membership
       - rest
       - flow
+      - flowWorker
       - db
     producers:
       - membership

--- a/data/topic-schema/src/main/resources/net/corda/schema/P2P.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/P2P.yaml
@@ -3,6 +3,7 @@ topics:
     name: p2p.in
     consumers:
       - flow
+      - flow-mapper
       - membership
     producers:
       - link-manager
@@ -13,6 +14,7 @@ topics:
       - link-manager
     producers:
       - flow
+      - flow-mapper
       - membership
     config:
   P2POutDlqTopic:

--- a/data/topic-schema/src/main/resources/net/corda/schema/P2P.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/P2P.yaml
@@ -2,7 +2,6 @@ topics:
   P2PInTopic:
     name: p2p.in
     consumers:
-      - flow
       - flowMapper
       - membership
     producers:
@@ -13,7 +12,6 @@ topics:
     consumers:
       - link-manager
     producers:
-      - flow
       - flowMapper
       - membership
     config:

--- a/data/topic-schema/src/main/resources/net/corda/schema/P2P.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/P2P.yaml
@@ -3,7 +3,7 @@ topics:
     name: p2p.in
     consumers:
       - flow
-      - flow-mapper
+      - flowMapper
       - membership
     producers:
       - link-manager
@@ -14,7 +14,7 @@ topics:
       - link-manager
     producers:
       - flow
-      - flow-mapper
+      - flowMapper
       - membership
     config:
   P2POutDlqTopic:

--- a/data/topic-schema/src/main/resources/net/corda/schema/VirtualNode.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/VirtualNode.yaml
@@ -4,6 +4,7 @@ topics:
     consumers:
       - db
       - flow
+      - flow-mapper
       - membership
       - link-manager
       - persistence

--- a/data/topic-schema/src/main/resources/net/corda/schema/VirtualNode.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/VirtualNode.yaml
@@ -4,7 +4,7 @@ topics:
     consumers:
       - db
       - flow
-      - flow-mapper
+      - flowMapper
       - membership
       - link-manager
       - persistence

--- a/data/topic-schema/src/main/resources/net/corda/schema/VirtualNode.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/VirtualNode.yaml
@@ -67,6 +67,7 @@ topics:
       - crypto
       - db
       - flow
+      - flowWorker
       - membership
       - link-manager
       - persistence

--- a/data/topic-schema/src/main/resources/net/corda/schema/VirtualNode.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/VirtualNode.yaml
@@ -67,7 +67,7 @@ topics:
       - crypto
       - db
       - flow
-      - flowWorker
+      - flowMapper
       - membership
       - link-manager
       - persistence


### PR DESCRIPTION
### Overview
A new `FlowMapperWorker` is being created, removing the flow mapper from the `FlowWorker` and moving it to its own dedicated processor and worker which can be deployed and scaled separately. As part of this, we need to add the `flow-mapper` as a producer/consumer in the requisite topic schemas.

### Related PRs:
- https://github.com/corda/corda-runtime-os/pull/4513
- https://github.com/corda/corda-shared-build-pipeline-steps/pull/1103
- https://github.com/corda/corda-e2e-tests/pull/222