### PR TITLE
CORE-13119 Add `resumePoint` Avro field to support stable query paging

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/persistence/EntityResponse.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/persistence/EntityResponse.avsc
@@ -16,6 +16,12 @@
       "name": "metadata",
       "doc": "Metadata returned from the execution of the persistence operation",
       "type": "net.corda.data.KeyValuePairList"
+    },
+    {
+      "name": "resumePoint",
+      "doc": "Used by queries that support stable paging to return opaque data that indicates where the next page should resume from",
+      "type": ["null", "bytes"],
+      "default": null
     }
   ]
 }

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/persistence/FindWithNamedQuery.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/persistence/FindWithNamedQuery.avsc
@@ -1,7 +1,7 @@
 {
   "type": "record",
   "name": "FindWithNamedQuery",
-  "doc": "Find entities matched by a named query. Parameters for the query may be specified. Pagination is supported, but there's no guarantee of consistency if the underlying data changes. The data will not be sorted in Corda; if the database returns an unpredictable order that must be handled by the caller. FindWithNamedQuery can be used to enforce ordering if required. Replies with {@link EntityResponse}",
+  "doc": "Find entities matched by a named query. Parameters for the query may be specified. Pagination is supported, but there's no guarantee of consistency if the underlying data changes and using offset-based pagination. The data will not be sorted in Corda; if the database returns an unpredictable order that must be handled by the caller. FindWithNamedQuery can be used to enforce ordering if required. Replies with {@link EntityResponse}",
   "namespace": "net.corda.data.persistence",
   "fields": [
     {
@@ -26,6 +26,12 @@
         "name": "limit",
         "type": "int",
         "doc": "Limit number of rows in the output query results, after applying the offset. Use the maximum int value if you do not want a lower limit."
+    },
+    {
+      "name": "resumePoint",
+      "type": ["null", "bytes"],
+      "default": null,
+      "doc": "When a query supports stable paging, contains opaque data telling the query where to resume from when making queries for subsequent pages."
     }
   ]
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ cordaProductVersion = 5.1.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 19
+cordaApiRevision = 20
 
 # Main
 kotlinVersion = 1.8.21


### PR DESCRIPTION
This is a pre-requisite change to enable a `resumePoint` field to be passed back and forth between ledger custom queries initiated in a flow processor and the query execution logic in a ledger persistence processor.

See https://github.com/corda/corda-runtime-os/pull/4548 for full details of the changes.