### PR TITLE
CORE-15804: Make uniquenessDmlConnectionId nullable in VirtualNodeInfo

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/virtualnode/VirtualNodeInfo.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/virtualnode/VirtualNodeInfo.avsc
@@ -39,7 +39,7 @@
     },
     {
       "name": "uniquenessDmlConnectionId",
-      "type": "string",
+      "type": ["null", "string"],
       "doc": "ID of virtual node Uniqueness DB connection for DML operations."
     },
     {


### PR DESCRIPTION
Allows uniquenessDmlConnectionId to be nullable to support not setting a uniqueness DB connection string during vNode creation. 

Related change here: https://github.com/corda/corda-runtime-os/pull/4585
e2e test: https://github.com/corda/corda-e2e-tests/pull/217