### PR TITLE
CORE-17154 - boot config for state manager

### DIFF
--- a/data/config-schema/src/main/java/net/corda/schema/configuration/BootConfig.java
+++ b/data/config-schema/src/main/java/net/corda/schema/configuration/BootConfig.java
@@ -35,4 +35,10 @@ public final class BootConfig {
     public static final String BOOT_REST_TLS_CA_CRT_PATH = BOOT_REST + ".tls.ca.crt.path";
 
     public static final String BOOT_SECRETS = "secrets";
+
+    public static final String BOOT_STATE_MANAGER = "stateManager";
+    public static final String BOOT_STATE_MANAGER_TYPE = BOOT_STATE_MANAGER + ".type";
+    public static final String BOOT_STATE_MANAGER_DB_USER = BOOT_STATE_MANAGER + ".database.user";
+    public static final String BOOT_STATE_MANAGER_DB_PASS = BOOT_STATE_MANAGER + ".database.pass";
+    public static final String BOOT_STATE_MANAGER_JDBC_URL = BOOT_STATE_MANAGER + ".database.jdbc.url";
 }

--- a/data/config-schema/src/main/java/net/corda/schema/configuration/MessagingConfig.java
+++ b/data/config-schema/src/main/java/net/corda/schema/configuration/MessagingConfig.java
@@ -95,7 +95,7 @@ public final class MessagingConfig {
         public static final String JDBC_PASS = DB_PROPERTIES + ".pass";
 
         public static final String JDBC_URL = DB_PROPERTIES + ".jdbc.url";
-        public static final String JDBC_DRIVER = DB_PROPERTIES + "jdbc.driver";
+        public static final String JDBC_DRIVER = DB_PROPERTIES + ".jdbc.driver";
         public static final String JDBC_DRIVER_DIRECTORY = DB_PROPERTIES + ".jdbc.directory";
         public static final String JDBC_PERSISTENCE_UNIT_NAME = DB_PROPERTIES + ".jdbc.persistenceUnitName";
         public static final String JDBC_POOL_MAX_SIZE = DB_PROPERTIES + ".pool.maxSize";

--- a/data/config-schema/src/main/java/net/corda/schema/configuration/MessagingConfig.java
+++ b/data/config-schema/src/main/java/net/corda/schema/configuration/MessagingConfig.java
@@ -102,7 +102,7 @@ public final class MessagingConfig {
         public static final String JDBC_POOL_MIN_SIZE = DB_PROPERTIES + ".pool.minSize";
         public static final String JDBC_POOL_IDLE_TIMEOUT_SECONDS = DB_PROPERTIES + ".pool.idleTimeoutSeconds";
         public static final String JDBC_POOL_MAX_LIFETIME_SECONDS = DB_PROPERTIES + ".pool.maxLifetimeSeconds";
-        public static final String JDBC_POOL_KEEP_ALIVE_TIME_SECONDS = DB_PROPERTIES + ".pool.keepAliveTimeSeconds";
+        public static final String JDBC_POOL_KEEP_ALIVE_TIME_SECONDS = DB_PROPERTIES + ".pool.keepaliveTimeSeconds";
         public static final String JDBC_POOL_VALIDATION_TIMEOUT_SECONDS = DB_PROPERTIES + ".pool.validationTimeoutSeconds";
     }
 }

--- a/data/config-schema/src/main/java/net/corda/schema/configuration/MessagingConfig.java
+++ b/data/config-schema/src/main/java/net/corda/schema/configuration/MessagingConfig.java
@@ -102,7 +102,7 @@ public final class MessagingConfig {
         public static final String JDBC_POOL_MIN_SIZE = DB_PROPERTIES + ".pool.minSize";
         public static final String JDBC_POOL_IDLE_TIMEOUT_SECONDS = DB_PROPERTIES + ".pool.idleTimeoutSeconds";
         public static final String JDBC_POOL_MAX_LIFETIME_SECONDS = DB_PROPERTIES + ".pool.maxLifetimeSeconds";
-        public static final String JDBC_POOL_KEEP_ALIVE_TIME_SECONDS = DB_PROPERTIES + ".pool.keepaliveTimeSeconds";
+        public static final String JDBC_POOL_KEEP_ALIVE_TIME_SECONDS = DB_PROPERTIES + ".pool.keepAliveTimeSeconds";
         public static final String JDBC_POOL_VALIDATION_TIMEOUT_SECONDS = DB_PROPERTIES + ".pool.validationTimeoutSeconds";
     }
 }

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/messaging/1.0/corda.messaging.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/messaging/1.0/corda.messaging.json
@@ -126,7 +126,7 @@
       "allOf": [
         {
           "if": {
-            "properties": {"type": {"const": "DATABASE"}},
+            "properties": { "type": { "const": "DATABASE" } },
             "required": ["type"]
           },
           "then": {

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/messaging/1.0/state-manager-db-properties.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/messaging/1.0/state-manager-db-properties.json
@@ -51,13 +51,13 @@
           "type": "object",
           "default": {},
           "properties": {
-            "max_size": {
+            "maxSize": {
               "description": "The maximum database pool size.",
               "type": "integer",
               "minimum": 1,
               "default": 10
             },
-            "min_size": {
+            "minSize": {
               "description": "The minimum database pool size. If left null will default to the `max_size` value.",
               "default": null,
               "anyOf": [

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/messaging/1.0/state-manager-db-properties.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/messaging/1.0/state-manager-db-properties.json
@@ -82,7 +82,7 @@
               "minimum": 1,
               "default": 1800
             },
-            "keepAliveTimeSeconds": {
+            "keepaliveTimeSeconds": {
               "description": "The interval time (in seconds) in which connections will be tested for aliveness. Connections which are no longer alive are removed from the pool. A value of 0 means this check is disabled.",
               "type": "integer",
               "minimum": 0,

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/messaging/1.0/state-manager-db-properties.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/messaging/1.0/state-manager-db-properties.json
@@ -82,7 +82,7 @@
               "minimum": 1,
               "default": 1800
             },
-            "keepaliveTimeSeconds": {
+            "keepAliveTimeSeconds": {
               "description": "The interval time (in seconds) in which connections will be tested for aliveness. Connections which are no longer alive are removed from the pool. A value of 0 means this check is disabled.",
               "type": "integer",
               "minimum": 0,


### PR DESCRIPTION
Introduces boot config keys for the state manager. Follows on from [1240](https://github.com/corda/corda-api/pull/1240).

Runtime-os change: https://github.com/corda/corda-runtime-os/pull/4624