### PR TITLE
CORE-16614: index utxo_visible_transaction_state.consumed

### DIFF
--- a/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/db.changelog-master.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/db.changelog-master.xml
@@ -5,6 +5,6 @@
     <include file="net/corda/db/schema/vnode-vault/migration/vnode-vault-creation-v1.0.xml"/>
     <include file="net/corda/db/schema/vnode-vault/migration/ledger-consensual-creation-v1.0.xml"/>
     <include file="net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v1.0.xml"/>
-
+    <include file="net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v5.1.xml"/>
     <include file="net/corda/db/schema/vnode-vault/migration/vnode-vault-creation-v5.1.xml"/>
 </databaseChangeLog>

--- a/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v5.1.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v5.1.xml
@@ -7,8 +7,9 @@
        <createIndex
            indexName="idx_consumed"
            tableName="utxo_visible_transaction_state">
-           <column name="consumed"/>
-           <where>consumed IS NULL</where>
+           <column name="consumed">
+               <where>consumed IS NULL</where>
+           </column>
        </createIndex>
     </changeSet>
 

--- a/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v5.1.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v5.1.xml
@@ -7,9 +7,8 @@
        <createIndex
            indexName="idx_consumed"
            tableName="utxo_visible_transaction_state">
-           <column name="consumed">
-               <where>consumed IS NULL</where>
-           </column>
+           <column name="consumed"/>
+           <where>consumed IS NULL</where>
        </createIndex>
     </changeSet>
 

--- a/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v5.1.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v5.1.xml
@@ -7,10 +7,9 @@
        <createIndex
            indexName="idx_consumed"
            tableName="utxo_visible_transaction_state">
-           <column name="consumed"/>
-           <constraints>
+           <column name="consumed">
                <where>consumed IS NULL</where>
-           </constraints>
+           </column>
        </createIndex>
     </changeSet>
 

--- a/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v5.1.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v5.1.xml
@@ -8,7 +8,6 @@
            indexName="idx_consumed"
            tableName="utxo_visible_transaction_state">
            <column name="consumed"/>
-           <where>consumed IS NULL</where>
        </createIndex>
     </changeSet>
 

--- a/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v5.1.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v5.1.xml
@@ -1,0 +1,14 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+
+    <changeSet author="R3.Corda" id="ledger-utxo-creation-v5.1">
+       <createIndex
+           indexName="idx_consumed"
+           tableName="utxo_visible_transaction_state">
+           <column name="consumed"/>
+       </createIndex>
+    </changeSet>
+
+</databaseChangeLog>

--- a/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v5.1.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v5.1.xml
@@ -8,6 +8,7 @@
            indexName="idx_consumed"
            tableName="utxo_visible_transaction_state">
            <column name="consumed"/>
+           <where>consumed IS NULL</where>
        </createIndex>
     </changeSet>
 

--- a/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v5.1.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v5.1.xml
@@ -5,7 +5,7 @@
 
     <changeSet author="R3.Corda" id="ledger-utxo-creation-v5.1">
        <createIndex
-           indexName="idx_consumed"
+           indexName="utxo_visible_transaction_state_idx_consumed"
            tableName="utxo_visible_transaction_state">
            <column name="consumed"/>
        </createIndex>

--- a/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v5.1.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v5.1.xml
@@ -7,9 +7,10 @@
        <createIndex
            indexName="idx_consumed"
            tableName="utxo_visible_transaction_state">
-           <column name="consumed">
+           <column name="consumed"/>
+           <constraints>
                <where>consumed IS NULL</where>
-           </column>
+           </constraints>
        </createIndex>
     </changeSet>
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ cordaProductVersion = 5.1.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 20
+cordaApiRevision = 19
 
 # Main
 kotlinVersion = 1.8.21

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ cordaProductVersion = 5.1.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 19
+cordaApiRevision = 20
 
 # Main
 kotlinVersion = 1.8.21


### PR DESCRIPTION
This PR indexes `consumed` field of `utxo_visible_transaction_state`. 
This is to improve performance of `UtxoPersistenceService.findUnconsumedVisibleStatesByType` query so that other tables are pre-sorted by `consumed` timestamp and query performance improvement.

**Index created:**
<img width="582" alt="image" src="https://github.com/corda/corda-api/assets/135036209/03f7ab45-7f1b-4e36-8d1c-0e66636b4585">

**the query**
![image](https://github.com/corda/corda-api/assets/135036209/16325597-c6f5-440f-a616-21ae686b6352)

**execution plan before indexing**
<img width="434" alt="before" src="https://github.com/corda/corda-api/assets/135036209/1f9db1cb-9797-49a6-90d3-be6750137b78">

**database optimizer has chosen to use an index to retrieve rows from the table**
<img width="432" alt="after" src="https://github.com/corda/corda-api/assets/135036209/bc2c1f09-0fcb-44a8-b178-f2bbda38e2c1">
