### PR TITLE
CORE-15730 Interop persistence and reconciliation 

### DIFF
--- a/data/db-schema/src/main/java/net/corda/db/schema/DbSchema.java
+++ b/data/db-schema/src/main/java/net/corda/db/schema/DbSchema.java
@@ -63,4 +63,6 @@ public final class DbSchema {
     public static final String UNIQUENESS_REJECTED_TX_TABLE = "uniqueness_rejected_txs";
 
     public static final String STATE_MANAGER_TABLE = "state";
+
+    public static final String INTEROP_IDENTITY_DB_TABLE = "interop_identity";
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ cordaProductVersion = 5.1.0-INTEROP
 ## IMPORTANT:
 ## The interop feature branches track api revisions separately to the mainline branch.
 ## API version of last merge from corda mainline: 19
-cordaApiRevision = 20
+cordaApiRevision = 21
 
 # Main
 kotlinVersion = 1.8.21


### PR DESCRIPTION
# Changes
- Add interop identity table name to `DbSchema` class.

# Info
- Runtime OS PR: https://github.com/corda/corda-runtime-os/pull/4651