### PR TITLE
CORE-16615: create index for utxo_transaction_output.type

### DIFF
--- a/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v5.1.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v5.1.xml
@@ -9,6 +9,12 @@
            tableName="utxo_visible_transaction_state">
            <column name="consumed"/>
        </createIndex>
+
+        <createIndex
+                indexName="utxo_transaction_output_idx_type"
+                tableName="utxo_transaction_output">
+            <column name="type"/>
+        </createIndex>
     </changeSet>
 
 </databaseChangeLog>


### PR DESCRIPTION
This PR created index for `type` of `utxo_transaction_output` in order to improve performance of `findUnconsumedStatesByType` query

**query unconsumed states by type**
<img width="645" alt="image" src="https://github.com/corda/corda-api/assets/135036209/70a3f0da-a61d-486f-8618-9b3b8a17bd5e">

**the query used utxo_transaction_output_pkey index before**
<img width="429" alt="before" src="https://github.com/corda/corda-api/assets/135036209/6cec7a34-32b8-4d5a-b28f-74b739606ed4">

**the query is now using utxo_transaction_output_idx_type index**
<img width="429" alt="after" src="https://github.com/corda/corda-api/assets/135036209/856353ef-02c5-4849-bd03-f7ca17b827e5">
