### PR TITLE
CORE-9975: Add support for key category parameter to signing API

### DIFF
--- a/application/src/main/java/net/corda/v5/application/crypto/SigningService.java
+++ b/application/src/main/java/net/corda/v5/application/crypto/SigningService.java
@@ -41,6 +41,10 @@ public interface SigningService {
     @NotNull
     DigitalSignature.WithKeyId sign(@NotNull byte[] bytes, @NotNull PublicKey publicKey, @NotNull SignatureSpec signatureSpec);
 
+    @Suspendable
+    @NotNull
+    DigitalSignature.WithKeyId sign(@NotNull byte[] bytes, @NotNull PublicKey publicKey, @NotNull SignatureSpec signatureSpec, @NotNull Map<String, String> context);
+
     /**
      * Looks into a set of signing keys to find keys owned by the caller. In case of {@link CompositeKey} it looks into
      * the composite key leaves and returns the firstly found owned composite key leaf.

--- a/application/src/main/java/net/corda/v5/application/crypto/SigningService.java
+++ b/application/src/main/java/net/corda/v5/application/crypto/SigningService.java
@@ -49,10 +49,7 @@ public interface SigningService {
      * primary identity, or previously generated via the freshKey method. If the {@link PublicKey} is actually
      * a {@link CompositeKey}, the first leaf signing key hosted by the node is used.
      * @param signatureSpec The {@link SignatureSpec} to use when producing this signature.
-     * @param context The execution context of the signing operation as a map of strings. Currently accepts the following parameters
-     * <ul>
-     *   <li>category: the type of signing key requested for additional verification</li>
-     * </ul>
+     * @param context The execution context of the signing operation.
      *
      * @return A {@link DigitalSignature.WithKeyId} representing the signed data and the {@link PublicKey} that belongs to the
      * same {@link KeyPair} as the {@link PrivateKey} that signed the data.
@@ -61,7 +58,7 @@ public interface SigningService {
      */
     @Suspendable
     @NotNull
-    DigitalSignature.WithKeyId sign(@NotNull byte[] bytes, @NotNull PublicKey publicKey, @NotNull SignatureSpec signatureSpec, @NotNull Map<String, String> context);
+    DigitalSignature.WithKeyId sign(@NotNull byte[] bytes, @NotNull PublicKey publicKey, @NotNull SignatureSpec signatureSpec, @NotNull SigningServiceSignContext context);
 
     /**
      * Looks into a set of signing keys to find keys owned by the caller. In case of {@link CompositeKey} it looks into

--- a/application/src/main/java/net/corda/v5/application/crypto/SigningService.java
+++ b/application/src/main/java/net/corda/v5/application/crypto/SigningService.java
@@ -41,6 +41,21 @@ public interface SigningService {
     @NotNull
     DigitalSignature.WithKeyId sign(@NotNull byte[] bytes, @NotNull PublicKey publicKey, @NotNull SignatureSpec signatureSpec);
 
+    /**
+     * Using the provided signing {@link PublicKey}, internally looks up the matching {@link PrivateKey} and signs the data.
+     *
+     * @param bytes The data to sign over using the chosen key.
+     * @param publicKey The {@link PublicKey} partner to an internally held {@link PrivateKey}, either derived from the node's
+     * primary identity, or previously generated via the freshKey method. If the {@link PublicKey} is actually
+     * a {@link CompositeKey}, the first leaf signing key hosted by the node is used.
+     * @param signatureSpec The {@link SignatureSpec} to use when producing this signature.
+     * @param context The execution context of the signing operation.
+     *
+     * @return A {@link DigitalSignature.WithKeyId} representing the signed data and the {@link PublicKey} that belongs to the
+     * same {@link KeyPair} as the {@link PrivateKey} that signed the data.
+     *
+     * @throws CordaRuntimeException If the input key is not a member of {@code keys}.
+     */
     @Suspendable
     @NotNull
     DigitalSignature.WithKeyId sign(@NotNull byte[] bytes, @NotNull PublicKey publicKey, @NotNull SignatureSpec signatureSpec, @NotNull Map<String, String> context);

--- a/application/src/main/java/net/corda/v5/application/crypto/SigningService.java
+++ b/application/src/main/java/net/corda/v5/application/crypto/SigningService.java
@@ -49,7 +49,10 @@ public interface SigningService {
      * primary identity, or previously generated via the freshKey method. If the {@link PublicKey} is actually
      * a {@link CompositeKey}, the first leaf signing key hosted by the node is used.
      * @param signatureSpec The {@link SignatureSpec} to use when producing this signature.
-     * @param context The execution context of the signing operation.
+     * @param context The execution context of the signing operation as a map of strings. Currently accepts the following parameters
+     * <ul>
+     *   <li>category: the type of signing key requested for additional verification</li>
+     * </ul>
      *
      * @return A {@link DigitalSignature.WithKeyId} representing the signed data and the {@link PublicKey} that belongs to the
      * same {@link KeyPair} as the {@link PrivateKey} that signed the data.

--- a/application/src/main/java/net/corda/v5/application/crypto/SigningServiceSignContext.java
+++ b/application/src/main/java/net/corda/v5/application/crypto/SigningServiceSignContext.java
@@ -15,4 +15,8 @@ public final class SigningServiceSignContext {
     public SigningServiceSignContext(String keyCategory) {
         this.keyCategory = keyCategory;
     }
+
+    public String getKeyCategory() {
+        return keyCategory;
+    }
 }

--- a/application/src/main/java/net/corda/v5/application/crypto/SigningServiceSignContext.java
+++ b/application/src/main/java/net/corda/v5/application/crypto/SigningServiceSignContext.java
@@ -1,0 +1,18 @@
+package net.corda.v5.application.crypto;
+
+import net.corda.v5.base.annotations.CordaSerializable;
+
+/*
+ * Context attached to the sign operation of SigningService
+ */
+@CordaSerializable
+public final class SigningServiceSignContext {
+    private final String keyCategory;
+
+    /**
+     * @param keyCategory the category of the key to be signed with
+     */
+    public SigningServiceSignContext(String keyCategory) {
+        this.keyCategory = keyCategory;
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ cordaProductVersion = 5.1.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 24
+cordaApiRevision = 25
 
 # Main
 kotlinVersion = 1.8.21


### PR DESCRIPTION
Added support for context parameter as an object to signing API.