### PR TITLE
CORE-15396 This change allows the external event context to be nullable

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/ledger/utxo/token/selection/data/TokenClaimRelease.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/ledger/utxo/token/selection/data/TokenClaimRelease.avsc
@@ -6,7 +6,7 @@
   "fields": [
       {
         "name": "requestContext",
-        "type": "net.corda.data.flow.event.external.ExternalEventContext",
+        "type": ["null", "net.corda.data.flow.event.external.ExternalEventContext"],
         "doc": "Flow request context data for the original claim query"
       },
       {


### PR DESCRIPTION
This change allows the external event context to be nullable on the token claim release event. This is to allow release events to be generated outside the flow external event framework, which is required when generating release events as part of cleanup for flows that are completing/failing.


