### PR TITLE
CORE-17257 - Reason column length is too short in RegistrationRequest table

### DIFF
--- a/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/vnode-vault-creation-v5.1.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/vnode-vault-creation-v5.1.xml
@@ -12,5 +12,10 @@
                 <constraints nullable="false" primaryKey="true"/>
             </column>
         </createTable>
+
+        <modifyDataType
+                columnName="reason"
+                newDataType="varchar(1000)"
+                tableName="vnode_registration_request"/>
     </changeSet>
 </databaseChangeLog>

--- a/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/vnode-vault-creation-v5.1.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/vnode-vault-creation-v5.1.xml
@@ -15,7 +15,7 @@
 
         <modifyDataType
                 columnName="reason"
-                newDataType="varchar(1000)"
+                newDataType="TEXT"
                 tableName="vnode_registration_request"/>
     </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
Resiliency test run failed caused by exception messages found in db worker logs. The exception messages suggested that the previous length of 255 was too short for the reason column.