### PR TITLE
CORE-15396 Adding a new token selection event type

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/ledger/utxo/token/selection/data/TokenForceClaimRelease.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/ledger/utxo/token/selection/data/TokenForceClaimRelease.avsc
@@ -1,0 +1,18 @@
+{
+  "type": "record",
+  "name": "TokenForceClaimRelease",
+  "namespace": "net.corda.data.ledger.utxo.token.selection.data",
+  "doc": "Forcibly removes the entire claim. No response is expected for this event type.",
+  "fields": [
+    {
+      "name": "poolKey",
+      "type": "net.corda.data.ledger.utxo.token.selection.key.TokenPoolCacheKey",
+      "doc": "The key of the cache pool for the existing claim"
+    },
+    {
+      "name": "claimId",
+      "type": "string",
+      "doc": "Unique identifier for the claim"
+    }
+  ]
+}

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/ledger/utxo/token/selection/event/TokenPoolCacheEvent.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/ledger/utxo/token/selection/event/TokenPoolCacheEvent.avsc
@@ -16,7 +16,8 @@
         "net.corda.data.ledger.utxo.token.selection.data.TokenClaimRelease",
         "net.corda.data.ledger.utxo.token.selection.data.TokenLedgerChange",
         "net.corda.data.ledger.utxo.token.selection.data.TokenCachedSyncCheck",
-        "net.corda.data.ledger.utxo.token.selection.data.TokenBalanceQuery"
+        "net.corda.data.ledger.utxo.token.selection.data.TokenBalanceQuery",
+        "net.corda.data.ledger.utxo.token.selection.data.TokenForceClaimRelease"
       ],
       "doc": "Represents the specific type and data of inbound event"
     }


### PR DESCRIPTION
Adding a new token selection event type. This event type is used to forcibly remove an existing claim and releasing any claimed tokens back to the cache. This event is generated by the postprocessing stage of the flow event pipeline when a flow completes or fails.

