### PR TITLE
CORE-15396 Add support for an expiry timeout on a token claim

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/ledger/utxo/token/selection/data/TokenClaim.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/ledger/utxo/token/selection/data/TokenClaim.avsc
@@ -10,6 +10,12 @@
         "doc": "Unique identifier for the claim"
       },
       {
+        "name": "claimTimestamp",
+        "type": ["null", "long"],
+        "default": null,
+        "doc": "Timestamp of when the claim was made in epoc milliseconds"
+      },
+      {
         "name": "claimedTokenStateRefs",
         "type": {
           "type": "array",

--- a/data/avro-schema/src/test/kotlin/net/corda/data/ledger/utxo/token/selection/data/TokenClaimSchemaCompatibilityTest.kt
+++ b/data/avro-schema/src/test/kotlin/net/corda/data/ledger/utxo/token/selection/data/TokenClaimSchemaCompatibilityTest.kt
@@ -1,0 +1,64 @@
+package net.corda.data.ledger.utxo.token.selection.data
+
+import org.apache.avro.Schema
+import org.apache.avro.SchemaCompatibility
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class TokenClaimSchemaCompatibilityTest {
+
+    @Test
+    fun `Token Claim schema changes between Corda 5_0 and 5_1 are compatible`() {
+        val oldSchemaJson = """
+        {
+  "type": "record",
+  "name": "TokenClaim",
+  "namespace": "net.corda.data.ledger.utxo.token.selection.data",
+  "doc": "The set of tokens claimed by a query",
+  "fields": [
+      {
+        "name": "claimId",
+        "type": "string",
+        "doc": "Unique identifier for the claim"
+      },
+      {
+        "name": "claimedTokenStateRefs",
+        "type": {
+          "type": "array",
+          "items": "string"
+        },
+        "default": [],
+        "doc": "Deprecated. The List of state refs for the claimed tokens"
+      },
+      {
+        "name": "claimedTokens",
+        "type": {
+          "type": "array",
+          "items": "net.corda.data.ledger.utxo.token.selection.data.Token"
+        },
+        "default": [],
+        "doc": "List of claimed tokens"
+      }
+  ]
+}
+""".trimIndent()
+
+        val oldSchema = Schema.Parser()
+            .addTypes(
+                mapOf(
+                    Token::class.java.name to Token.`SCHEMA$`,
+                )
+            )
+            .parse(oldSchemaJson)
+
+        val newSchema = TokenClaim.`SCHEMA$`
+
+        val compatibility = SchemaCompatibility.checkReaderWriterCompatibility(newSchema, oldSchema)
+
+        Assertions.assertEquals(
+            compatibility.type,
+            SchemaCompatibility.SchemaCompatibilityType.COMPATIBLE,
+            "Failed due to incompatible change. ${compatibility.description}"
+        )
+    }
+}

--- a/data/config-schema/src/main/java/net/corda/schema/configuration/LedgerConfig.java
+++ b/data/config-schema/src/main/java/net/corda/schema/configuration/LedgerConfig.java
@@ -10,6 +10,7 @@ public final class LedgerConfig {
     public static final String UTXO_TOKEN_PERIODIC_CHECK_BLOCK_SIZE = "tokens.periodCheckBlockSize";
     public static final String UTXO_TOKEN_SEND_WAKEUP_MAX_RETRY_ATTEMPTS = "tokens.sendWakeUpMaxRetryAttempts";
     public static final String UTXO_TOKEN_SEND_WAKEUP_MAX_RETRY_DELAY = "tokens.sendWakeUpMaxRetryDelay";
-    public static final String UTXO_TOKEN_CACHED_TOKEN_PAGE_SIZE= "tokens.cachedTokenPageSize";
+    public static final String UTXO_TOKEN_CACHED_TOKEN_PAGE_SIZE = "tokens.cachedTokenPageSize";
+    public static final String UTXO_TOKEN_CLAIM_TIMEOUT_SECONDS = "tokens.claimTimeoutSeconds";
     public static final String UTXO_BACKCHAIN_BATCH_SIZE = "backchain.batchSize";
 }

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/ledger.utxo/1.0/corda.ledger.utxo.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/ledger.utxo/1.0/corda.ledger.utxo.json
@@ -52,6 +52,12 @@
           "type": "integer",
           "minimum": 0,
           "default": 1500
+        },
+        "claimTimeoutSeconds": {
+          "description": "Time in seconds before the claim will be automatically released (default 10 minutes)",
+          "type": "integer",
+          "minimum": 1,
+          "default": 600
         }
       }
     },


### PR DESCRIPTION
Add support for an expiry timeout on a token claim, this is to support automatic cleanup of orphaned claims.
