### PR TITLE
CORE-17344 - Update the db schema by following the instructions

### DIFF
--- a/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/config-creation-v1.0.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/config-creation-v1.0.xml
@@ -114,17 +114,6 @@
         </insert>
 
         <insert tableName="config">
-            <column name="section" value="corda.ledger.utxo"/>
-            <column name="config" value=""/>
-            <column name="schema_version_major" value="1"/>
-            <column name="schema_version_minor" value="0"/>
-            <column name="version" value="0"/>
-            <column name="is_deleted" value="false"/>
-            <column name="update_ts" valueDate="${now}"/>
-            <column name="update_actor" value="admin"/>
-        </insert>
-
-        <insert tableName="config">
             <column name="section" value="corda.flow"/>
             <column name="config" value=""/>
             <column name="schema_version_major" value="1"/>

--- a/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/config-creation-v5.1.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/config-creation-v5.1.xml
@@ -14,6 +14,18 @@
             <column name="update_ts" valueDate="${now}"/>
             <column name="update_actor" value="admin"/>
         </insert>
+
+        <insert tableName="config">
+            <column name="section" value="corda.ledger.utxo"/>
+            <column name="config" value=""/>
+            <column name="schema_version_major" value="1"/>
+            <column name="schema_version_minor" value="0"/>
+            <column name="version" value="0"/>
+            <column name="is_deleted" value="false"/>
+            <column name="update_ts" valueDate="${now}"/>
+            <column name="update_actor" value="admin"/>
+        </insert>
+
     </changeSet>
 
 </databaseChangeLog>


### PR DESCRIPTION
In CORE-15179 , the db table `config` was updated without following the best practices that have been suggested. This commit moves the code responsible for updating the `config` table to the correct file.

