### PR TITLE
CORE-9031: Add forceUpgrade parameter to VirtualNodeUpgradeRequest

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/virtualnode/VirtualNodeUpgradeRequest.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/virtualnode/VirtualNodeUpgradeRequest.avsc
@@ -21,7 +21,8 @@
     {
       "name": "forceUpgrade",
       "type": "boolean",
-      "doc": "Whether this upgrade should be forced regardless of OperationInProgress."
+      "doc": "Whether this upgrade should be forced regardless of OperationInProgress.",
+      "default": false
     }
   ]
 }

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/virtualnode/VirtualNodeUpgradeRequest.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/virtualnode/VirtualNodeUpgradeRequest.avsc
@@ -17,6 +17,11 @@
       "name": "actor",
       "type": "string",
       "doc": "ID of RPC user that requested the virtual node creation."
+    },
+    {
+      "name": "forceUpgrade",
+      "type": "boolean",
+      "doc": "Whether this upgrade should be forced regardless of OperationInProgress."
     }
   ]
 }

--- a/data/avro-schema/src/test/kotlin/net/corda/data/virtualnode/VirtualNodeUpgradeRequestSchemaCompatibilityTest.kt
+++ b/data/avro-schema/src/test/kotlin/net/corda/data/virtualnode/VirtualNodeUpgradeRequestSchemaCompatibilityTest.kt
@@ -1,0 +1,47 @@
+package net.corda.data.virtualnode
+
+import org.apache.avro.Schema
+import org.apache.avro.SchemaCompatibility
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class VirtualNodeUpgradeRequestSchemaCompatibilityTest {
+
+    @Test
+    fun `VirtualNodeUPgradeRequest schema changes between Corda 5_0 and 5_1 are compatible`() {
+        val schemaV50Json = """
+        {
+          "type": "record",
+          "name": "VirtualNodeUpgradeRequest",
+          "namespace": "net.corda.data.virtualnode",
+          "fields": [
+            {
+              "name": "virtualNodeShortHash",
+              "type": "string",
+              "doc": "Short hash of the virtual node / holding identity."
+            },
+            {
+              "name": "cpiFileChecksum",
+              "type": "string",
+              "doc": "The checksum of the CPI file."
+            },
+            {
+              "name": "actor",
+              "type": "string",
+              "doc": "ID of RPC user that requested the virtual node creation."
+            }
+          ]
+        }
+        """.trimIndent()
+
+        val schemaV50 = Schema.Parser().parse(schemaV50Json)
+        val schemaV51 = VirtualNodeUpgradeRequest.`SCHEMA$`
+
+        val compatibility = SchemaCompatibility.checkReaderWriterCompatibility(schemaV51, schemaV50)
+        Assertions.assertEquals(
+            compatibility.type,
+            SchemaCompatibility.SchemaCompatibilityType.COMPATIBLE,
+            "Failed due to incompatible change. ${compatibility.description}"
+        )
+    }
+}

--- a/data/avro-schema/src/test/kotlin/net/corda/data/virtualnode/VirtualNodeUpgradeRequestSchemaCompatibilityTest.kt
+++ b/data/avro-schema/src/test/kotlin/net/corda/data/virtualnode/VirtualNodeUpgradeRequestSchemaCompatibilityTest.kt
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test
 class VirtualNodeUpgradeRequestSchemaCompatibilityTest {
 
     @Test
-    fun `VirtualNodeUPgradeRequest schema changes between Corda 5_0 and 5_1 are compatible`() {
+    fun `VirtualNodeUpgradeRequest schema changes between Corda 5_0 and 5_1 are compatible`() {
         val schemaV50Json = """
         {
           "type": "record",

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ cordaProductVersion = 5.1.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 26
+cordaApiRevision = 27
 
 # Main
 kotlinVersion = 1.8.21

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ cordaProductVersion = 5.1.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 27
+cordaApiRevision = 26
 
 # Main
 kotlinVersion = 1.8.21

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ cordaProductVersion = 5.1.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 27
+cordaApiRevision = 28
 
 # Main
 kotlinVersion = 1.8.21


### PR DESCRIPTION
This adds an optional forceUpgrade field to the VirtualNodeUpgradeRequest schema which defaults to false. This supports the work being done in https://github.com/corda/corda-runtime-os/pull/4734.