### PR TITLE
CORE-17360: Add topics for mapper scheduled cleanup and update cleanup Avro records

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/flow/event/mapper/ExecuteCleanup.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/flow/event/mapper/ExecuteCleanup.avsc
@@ -4,5 +4,13 @@
   "docs": "When this event is processed the flow mapper state should be set to null",
   "namespace": "net.corda.data.flow.event.mapper",
   "fields": [
+    {
+      "name": "ids",
+      "docs": "A list of IDs of mapper states that should be deleted",
+      "type": {
+        "type": "array",
+        "items": "string"
+      }
+    }
   ]
 }

--- a/data/topic-schema/src/main/java/net/corda/schema/Schemas.java
+++ b/data/topic-schema/src/main/java/net/corda/schema/Schemas.java
@@ -103,6 +103,7 @@ public final class Schemas {
         public static final String FLOW_MAPPER_EVENT_TOPIC = "flow.mapper.event";
         public static final String FLOW_MAPPER_EVENT_STATE_TOPIC = getStateAndEventStateTopic(FLOW_MAPPER_EVENT_TOPIC);
         public static final String FLOW_MAPPER_EVENT_DLQ_TOPIC = getDLQTopic(FLOW_MAPPER_EVENT_TOPIC);
+        public static final String FLOW_MAPPER_CLEANUP_TOPIC = "flow.mapper.cleanup";
     }
 
     /**
@@ -267,5 +268,6 @@ public final class Schemas {
         private ScheduledTask() {}
 
         public static final String SCHEDULED_TASK_DB_PROCESSOR = "scheduled.task.db.processor";
+        public static final String SCHEDULED_TASK_MAPPER_PROCESSOR = "scheduled.task.mapper.processor";
     }
 }

--- a/data/topic-schema/src/main/resources/net/corda/schema/Flow.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/Flow.yaml
@@ -80,3 +80,10 @@ topics:
       min.compaction.lag.ms: 60000
       max.compaction.lag.ms: 604800000
       min.cleanable.dirty.ratio: 0.5
+  FlowMapperCleanupTopic:
+    name: flow.mapper.cleanup
+    consumers:
+      - flowMapper
+    producers:
+      - flowMapper
+    config:

--- a/data/topic-schema/src/main/resources/net/corda/schema/ScheduledTask.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/ScheduledTask.yaml
@@ -5,3 +5,9 @@ topics:
       - db
     producers:
       - db
+  ScheduledTaskFlowMapperProcessorTopic:
+    name: scheduled.task.mapper.processor
+    consumers:
+      - flowMapper
+    producers:
+      - db

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ cordaProductVersion = 5.1.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 24
+cordaApiRevision = 25
 
 # Main
 kotlinVersion = 1.8.21


### PR DESCRIPTION
**Problem statement**

As part of ongoing performance work, there is a requirement to move the storage of flow mapper states to a shared state store. This will break the current implementation of mapper state cleanup. Flow mapper states are currently cleaned up using a scheduler implemented in each flow mapper, which relies on states being partitioned across the set of mapper instances. This will no longer be happening.

This problem can be addressed using the new task scheduler implemented in the DB worker, but doing so will require a few new topics for the mapper to listen to.

**Solution**

Add two new topics. The first is the topic that scheduled tasks for the flow mapper will be written to. The second is a dedicated cleanup event topic that will be written to as part of processing the scheduled event.

In addition, the `ExecuteCleanup` event has been modified to take a list of IDs as a field. This will allow the processor of the scheduled task to batch up the cleanup requests being sent to the mapper workers.
