### PR TITLE
CORE-16183 Ledger data model simplifications (part 1)

### DIFF
--- a/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v5.1.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v5.1.xml
@@ -3,11 +3,6 @@
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
 
-    <property name="json.column.type" value="JSONB" dbms="postgresql"/>
-
-    <!-- Please note that HSQLDB schema is supported for integration test purposes only. -->
-    <property name="json.column.type" value="CLOB" dbms="hsqldb"/>
-
     <changeSet author="R3.Corda" id="ledger-utxo-creation-v5.1">
         <createIndex indexName="utxo_visible_transaction_state_idx_consumed"
                      tableName="utxo_visible_transaction_state">

--- a/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v5.1.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v5.1.xml
@@ -9,11 +9,6 @@
     <property name="json.column.type" value="CLOB" dbms="hsqldb"/>
 
     <changeSet author="R3.Corda" id="ledger-utxo-creation-v5.1">
-        <createIndex
-                indexName="utxo_visible_transaction_state_idx_consumed"
-                tableName="utxo_visible_transaction_state">
-            <column name="consumed"/>
-        </createIndex>
 
         <createIndex
                 indexName="utxo_transaction_output_idx_type"
@@ -89,6 +84,13 @@
 
         <!-- Rename utxo_transaction_output to utxo_visible_transaction_output -->
         <renameTable newTableName="utxo_visible_transaction_output" oldTableName="utxo_transaction_output"/>
+
+        <!-- Re-create the index on the consumed column in the new table -->
+        <createIndex
+                indexName="utxo_visible_transaction_output_idx_consumed"
+                tableName="utxo_visible_transaction_output">
+            <column name="consumed"/>
+        </createIndex>
 
         <!-- Drop the created column from the utxo_transaction_component table -->
         <dropColumn columnName="created" tableName="utxo_transaction_component"/>

--- a/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v5.1.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v5.1.xml
@@ -15,6 +15,94 @@
                 tableName="utxo_transaction_output">
             <column name="type"/>
         </createIndex>
+
+    <property name="json.column.type" value="JSONB" dbms="postgresql"/>
+
+    <!-- Please note that HSQLDB schema is supported for integration test purposes only. -->
+    <property name="json.column.type" value="CLOB" dbms="hsqldb"/>
+
+    <changeSet author="R3.Corda" id="ledger-utxo-creation-v5.2">
+
+        <!-- Add new status column to utxo_transaction -->
+        <addColumn tableName="utxo_transaction">
+            <column name="status" type="VARCHAR(255)">
+                <constraints nullable="true"/>
+            </column>
+            <column name="updated" type="TIMESTAMP">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+
+        <!-- Migrate data from the old status table -->
+        <update tableName="utxo_transaction">
+            <column name="status"
+                    valueComputed="(select status from utxo_transaction_status uts where uts.transaction_id=id)"/>
+            <column name="updated"
+                    valueComputed="(select updated from utxo_transaction_status uts where uts.transaction_id=id)"/>
+        </update>
+
+        <!-- Drop the old status table -->
+        <dropTable tableName="utxo_transaction_status"/>
+
+        <!-- After status data migration we can make the status/updated column non-nullable -->
+        <addNotNullConstraint tableName="utxo_transaction" columnName="status" columnDataType="VARCHAR(255)"/>
+        <addNotNullConstraint tableName="utxo_transaction" columnName="updated" columnDataType="TIMESTAMP"/>
+
+        <!-- Add new custom_representation and consumed columns to utxo_transaction_output -->
+        <addColumn tableName="utxo_transaction_output">
+            <column name="custom_representation" type="${json.column.type}">
+                <constraints nullable="true"/>
+            </column>
+            <column name="consumed" type="TIMESTAMP">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+
+        <!--
+        Migrate data from the old visible states table
+        NOTE: We can't use <update> here because both tables have the same column naming
+        (transaction_id, group_idx etc.) and the SQL statement generated will not work in
+        Postgres, and we have no way to alias the base table.
+        -->
+        <sql>
+            UPDATE utxo_transaction_output txo
+            SET
+            custom_representation = (
+            SELECT custom_representation from utxo_visible_transaction_state vts
+            WHERE vts.transaction_id=txo.transaction_id
+            AND vts.group_idx=txo.group_idx
+            AND vts.leaf_idx=txo.leaf_idx
+            ),
+            consumed = (
+            SELECT consumed from utxo_visible_transaction_state vts
+            WHERE vts.transaction_id=txo.transaction_id
+            AND vts.group_idx=txo.group_idx
+            AND vts.leaf_idx=txo.leaf_idx
+            );
+        </sql>
+
+        <!-- After visible states data migration we can make the custom_representation column non-nullable -->
+        <addNotNullConstraint tableName="utxo_transaction_output"
+                              columnName="custom_representation"
+                              columnDataType="${json.column.type}"/>
+
+        <!-- Drop the utxo_visible_transaction_state table after data migration -->
+        <dropTable tableName="utxo_visible_transaction_state"/>
+
+        <!-- Rename utxo_transaction_output to utxo_visible_transaction_output -->
+        <renameTable newTableName="utxo_visible_transaction_output" oldTableName="utxo_transaction_output"/>
+
+        <!-- Drop the created column from the utxo_transaction_component table -->
+        <dropColumn columnName="created" tableName="utxo_transaction_component"/>
+
+        <!-- Drop the utxo_transaction_sources table -->
+        <dropTable tableName="utxo_transaction_sources"/>
+
+        <!-- Drop the utxo_transaction_cpk table -->
+        <dropTable tableName="utxo_transaction_cpk"/>
+
+        <!-- Drop the utxo_cpk table -->
+        <dropTable tableName="utxo_cpk"/>
     </changeSet>
 
 </databaseChangeLog>

--- a/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v5.1.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v5.1.xml
@@ -56,7 +56,7 @@
         <dropTable tableName="utxo_transaction_status"/>
 
         <!-- After status data migration we can make the status/updated column non-nullable -->
-        <addNotNullConstraint tableName="utxo_transaction" columnName="status" columnDataType="VARCHAR(255)"/>
+        <addNotNullConstraint tableName="utxo_transaction" columnName="status" columnDataType="VARCHAR(16)"/>
         <addNotNullConstraint tableName="utxo_transaction" columnName="updated" columnDataType="TIMESTAMP"/>
 
         <!-- Add new custom_representation and consumed columns to utxo_transaction_output -->

--- a/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v5.1.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v5.1.xml
@@ -41,7 +41,7 @@
 
         <!-- Add new status column to utxo_transaction -->
         <addColumn tableName="utxo_transaction">
-            <column name="status" type="VARCHAR(255)">
+            <column name="status" type="VARCHAR(16)">
                 <constraints nullable="true"/>
             </column>
             <column name="updated" type="TIMESTAMP">

--- a/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v5.1.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v5.1.xml
@@ -84,16 +84,16 @@
             UPDATE utxo_transaction_output txo
             SET
             custom_representation = (
-            SELECT custom_representation from utxo_visible_transaction_state vts
-            WHERE vts.transaction_id=txo.transaction_id
-            AND vts.group_idx=txo.group_idx
-            AND vts.leaf_idx=txo.leaf_idx
+                SELECT custom_representation from utxo_visible_transaction_state vts
+                WHERE vts.transaction_id=txo.transaction_id
+                AND vts.group_idx=txo.group_idx
+                AND vts.leaf_idx=txo.leaf_idx
             ),
             consumed = (
-            SELECT consumed from utxo_visible_transaction_state vts
-            WHERE vts.transaction_id=txo.transaction_id
-            AND vts.group_idx=txo.group_idx
-            AND vts.leaf_idx=txo.leaf_idx
+                SELECT consumed from utxo_visible_transaction_state vts
+                WHERE vts.transaction_id=txo.transaction_id
+                AND vts.group_idx=txo.group_idx
+                AND vts.leaf_idx=txo.leaf_idx
             );
         </sql>
 

--- a/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v5.1.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v5.1.xml
@@ -3,25 +3,23 @@
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
 
+    <property name="json.column.type" value="JSONB" dbms="postgresql"/>
+
+    <!-- Please note that HSQLDB schema is supported for integration test purposes only. -->
+    <property name="json.column.type" value="CLOB" dbms="hsqldb"/>
+
     <changeSet author="R3.Corda" id="ledger-utxo-creation-v5.1">
-       <createIndex
-           indexName="utxo_visible_transaction_state_idx_consumed"
-           tableName="utxo_visible_transaction_state">
-           <column name="consumed"/>
-       </createIndex>
+        <createIndex
+                indexName="utxo_visible_transaction_state_idx_consumed"
+                tableName="utxo_visible_transaction_state">
+            <column name="consumed"/>
+        </createIndex>
 
         <createIndex
                 indexName="utxo_transaction_output_idx_type"
                 tableName="utxo_transaction_output">
             <column name="type"/>
         </createIndex>
-
-    <property name="json.column.type" value="JSONB" dbms="postgresql"/>
-
-    <!-- Please note that HSQLDB schema is supported for integration test purposes only. -->
-    <property name="json.column.type" value="CLOB" dbms="hsqldb"/>
-
-    <changeSet author="R3.Corda" id="ledger-utxo-creation-v5.2">
 
         <!-- Add new status column to utxo_transaction -->
         <addColumn tableName="utxo_transaction">

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ cordaProductVersion = 5.1.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 28
+cordaApiRevision = 29
 
 # Main
 kotlinVersion = 1.8.21

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ cordaProductVersion = 5.1.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 25
+cordaApiRevision = 26
 
 # Main
 kotlinVersion = 1.8.21

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ cordaProductVersion = 5.1.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 29
+cordaApiRevision = 30
 
 # Main
 kotlinVersion = 1.8.21

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ cordaProductVersion = 5.1.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 26
+cordaApiRevision = 27
 
 # Main
 kotlinVersion = 1.8.21


### PR DESCRIPTION
### Overview

This PR contains the `AGREED` suggestions from this page: https://r3-cev.atlassian.net/wiki/spaces/CB/pages/4578214028/UTXO+Ledger+Data+Model+Simplifications#Remove-created-field-from-utxo_transaction_component-table-Agreed.

These are:
- Merge utxo_transaction_status table into utxo_transaction (then delete the `utxo_transaction_status` table) and rename utxo_transaction_output table to utxo_visible_transaction_output
- Merge utxo_visible_transaction_state table into utxo_transaction_output (then delete the `utxo_visible_transaction_state` table)
- Removal of utxo_transaction_sources table 
- Removal of utxo_transaction_cpk and utxo_cpk tables 
- Remove created field from utxo_transaction_component table 

### Test plan

1. 5.0 -> 5.1 
The upgrade SQL file was generated using the Corda CLI tool with the latest plugin. The SQL generated then was executed in a live Postgres database. The existing transactions were moved according to the 5.1 schema accordingly.

2. 5.1 Postgres
Started up a 5.1 instance with a fresh Postgres instance and schema creation ran successfully.
