### PR TITLE
CORE-17359: Rename topic for flow mapper scheduled task and add a scheduled task name

### DIFF
--- a/data/topic-schema/src/main/java/net/corda/schema/Schemas.java
+++ b/data/topic-schema/src/main/java/net/corda/schema/Schemas.java
@@ -267,13 +267,12 @@ public final class Schemas {
     public static final class ScheduledTask {
         private ScheduledTask() {}
 
-        // TODO - duplicated to ease migration from first to second. First can be removed once integrated with runtime-os
-        public static final String SCHEDULED_TASK_DB_PROCESSOR = "scheduled.task.db.processor";
         public static final String SCHEDULED_TASK_TOPIC_DB_PROCESSOR = "scheduled.task.db.processor";
         public static final String SCHEDULED_TASK_NAME_DB_PROCESSOR = "deduplication-table-clean-up-task";
-        public static final String SCHEDULED_TASK_MAPPER_PROCESSOR = "scheduled.task.mapper.processor";
+        public static final String SCHEDULED_TASK_TOPIC_MAPPER_PROCESSOR = "scheduled.task.mapper.processor";
+        public static final String SCHEDULED_TASK_NAME_MAPPER_CLEANUP = "flow-mapper-state-cleanup";
         public static final String SCHEDULED_TASK_TOPIC_FLOW_PROCESSOR = "scheduled.task.flow.processor";
-        public static final String SCHEDULED_TASK_NAME_SESSION_TIMEOUT = "flow-session-timout";
+        public static final String SCHEDULED_TASK_NAME_SESSION_TIMEOUT = "flow-session-timeout";
 
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ cordaProductVersion = 5.1.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 26
+cordaApiRevision = 27
 
 # Main
 kotlinVersion = 1.8.21


### PR DESCRIPTION
### Problem statement

The flow mapper requires a topic and a scheduled task name to perform cleanup of the mapper states once the cleanup time window expires. The previous name of the topic constant was not clear, and the task name did not previously exist.

### Solution

Clean up the topic name and add a scheduled task name.
