### PR TITLE
CORE-17471 - Apply indexing to frequently used columns of the db table `utxo_transaction_output`

### DIFF
--- a/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v5.1.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v5.1.xml
@@ -4,39 +4,33 @@
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
 
     <changeSet author="R3.Corda" id="ledger-utxo-creation-v5.1">
-        <createIndex
-                indexName="utxo_visible_transaction_state_idx_consumed"
-                tableName="utxo_visible_transaction_state">
+        <createIndex indexName="utxo_visible_transaction_state_idx_consumed"
+                     tableName="utxo_visible_transaction_state">
             <column name="consumed"/>
         </createIndex>
 
-        <createIndex
-                indexName="utxo_transaction_output_idx_type"
-                tableName="utxo_transaction_output">
+        <createIndex indexName="utxo_transaction_output_idx_type"
+                     tableName="utxo_transaction_output">
             <column name="type"/>
         </createIndex>
 
-        <createIndex
-                indexName="utxo_transaction_output_idx_token_type"
-                tableName="utxo_transaction_output">
+        <createIndex indexName="utxo_transaction_output_idx_token_type"
+                     tableName="utxo_transaction_output">
             <column name="token_type"/>
         </createIndex>
 
-        <createIndex
-                indexName="utxo_transaction_output_idx_token_issuer_hash"
-                tableName="utxo_transaction_output">
+        <createIndex indexName="utxo_transaction_output_idx_token_issuer_hash"
+                     tableName="utxo_transaction_output">
             <column name="token_issuer_hash"/>
         </createIndex>
 
-        <createIndex
-                indexName="utxo_transaction_output_idx_token_symbol"
-                tableName="utxo_transaction_output">
+        <createIndex indexName="utxo_transaction_output_idx_token_symbol"
+                     tableName="utxo_transaction_output">
             <column name="token_symbol"/>
         </createIndex>
 
-        <createIndex
-                indexName="utxo_transaction_output_idx_token_notary_x500_name"
-                tableName="utxo_transaction_output">
+        <createIndex indexName="utxo_transaction_output_idx_token_notary_x500_name"
+                     tableName="utxo_transaction_output">
             <column name="token_notary_x500_name"/>
         </createIndex>
     </changeSet>

--- a/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v5.1.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v5.1.xml
@@ -4,16 +4,40 @@
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
 
     <changeSet author="R3.Corda" id="ledger-utxo-creation-v5.1">
-       <createIndex
-           indexName="utxo_visible_transaction_state_idx_consumed"
-           tableName="utxo_visible_transaction_state">
-           <column name="consumed"/>
-       </createIndex>
+        <createIndex
+                indexName="utxo_visible_transaction_state_idx_consumed"
+                tableName="utxo_visible_transaction_state">
+            <column name="consumed"/>
+        </createIndex>
 
         <createIndex
                 indexName="utxo_transaction_output_idx_type"
                 tableName="utxo_transaction_output">
             <column name="type"/>
+        </createIndex>
+
+        <createIndex
+                indexName="utxo_transaction_output_idx_token_type"
+                tableName="utxo_transaction_output">
+            <column name="token_type"/>
+        </createIndex>
+
+        <createIndex
+                indexName="utxo_transaction_output_idx_token_issuer_hash"
+                tableName="utxo_transaction_output">
+            <column name="token_issuer_hash"/>
+        </createIndex>
+
+        <createIndex
+                indexName="utxo_transaction_output_idx_token_symbol"
+                tableName="utxo_transaction_output">
+            <column name="token_symbol"/>
+        </createIndex>
+
+        <createIndex
+                indexName="utxo_transaction_output_idx_token_notary_x500_name"
+                tableName="utxo_transaction_output">
+            <column name="token_notary_x500_name"/>
         </createIndex>
     </changeSet>
 


### PR DESCRIPTION
The token selection feature uses db queries frequently. Indexing the columns that are used by those queries will improve performance. This commit indexes the columns `token_type`, `token_issuer_hash`, `token_symbol`, and `token_notary_x500_name` from table `utxo_transaction_output`.

DB query details for the token balance execution:
![image](https://github.com/corda/corda-api/assets/6329837/99314d6b-0444-45b4-8a0d-6b9d1e2266e3)

DB query details for the token selection execution:
![image](https://github.com/corda/corda-api/assets/6329837/d84c6e46-0812-4a22-8c7f-762b59913940)

