### PR TITLE
CORE-17476 Adding Corda worker RPC endpoints to API schema

### DIFF
--- a/data/config-schema/src/main/java/net/corda/schema/configuration/BootConfig.java
+++ b/data/config-schema/src/main/java/net/corda/schema/configuration/BootConfig.java
@@ -41,4 +41,6 @@ public final class BootConfig {
     public static final String BOOT_STATE_MANAGER_DB_USER = BOOT_STATE_MANAGER + ".database.user";
     public static final String BOOT_STATE_MANAGER_DB_PASS = BOOT_STATE_MANAGER + ".database.pass";
     public static final String BOOT_STATE_MANAGER_JDBC_URL = BOOT_STATE_MANAGER + ".database.jdbc.url";
+
+    public static final String BOOT_WORKER_SERVICE = "worker";
 }

--- a/data/config-schema/src/main/java/net/corda/schema/configuration/BootConfig.java
+++ b/data/config-schema/src/main/java/net/corda/schema/configuration/BootConfig.java
@@ -43,4 +43,8 @@ public final class BootConfig {
     public static final String BOOT_STATE_MANAGER_JDBC_URL = BOOT_STATE_MANAGER + ".database.jdbc.url";
 
     public static final String BOOT_WORKER_SERVICE = "worker";
+    public static final String CRYPTO_WORKER_REST_ENDPOINT = BOOT_WORKER_SERVICE + ".endpoints.crypto";
+    public static final String VERIFICATION_WORKER_REST_ENDPOINT = BOOT_WORKER_SERVICE + ".endpoints.verification";
+    public static final String UNIQUENESS_WORKER_REST_ENDPOINT = BOOT_WORKER_SERVICE + ".endpoints.uniqueness";
+    public static final String PERSISTENCE_WORKER_REST_ENDPOINT = BOOT_WORKER_SERVICE + ".endpoints.persistence";
 }

--- a/data/topic-schema/src/main/java/net/corda/schema/Schemas.java
+++ b/data/topic-schema/src/main/java/net/corda/schema/Schemas.java
@@ -287,9 +287,9 @@ public final class Schemas {
      */
     public static final class Endpoint {
         private Endpoint() {}
-        public static final String CRYPTO_WORKER_REST_ENDPOINT = "worker.rest.endpoint.crypto";
-        public static final String VERIFICATION_WORKER_REST_ENDPOINT = "worker.rest.endpoint.verification";
-        public static final String UNIQUENESS_WORKER_REST_ENDPOINT = "worker.rest.endpoint.uniqueness";
-        public static final String PERSISTENCE_WORKER_REST_ENDPOINT = "worker.rest.endpoint.persistence";
+        public static final String CRYPTO_WORKER_REST_ENDPOINT = "worker.endpoints.crypto";
+        public static final String VERIFICATION_WORKER_REST_ENDPOINT = "worker.endpoints.verification";
+        public static final String UNIQUENESS_WORKER_REST_ENDPOINT = "worker.endpoints.uniqueness";
+        public static final String PERSISTENCE_WORKER_REST_ENDPOINT = "worker.endpoints.persistence";
     }
 }

--- a/data/topic-schema/src/main/java/net/corda/schema/Schemas.java
+++ b/data/topic-schema/src/main/java/net/corda/schema/Schemas.java
@@ -281,4 +281,15 @@ public final class Schemas {
         public static final String SCHEDULED_TASK_NAME_SESSION_TIMEOUT = "flow-session-timeout";
 
     }
+
+    /**
+     * Corda worker RPC endpoints
+     */
+    public static final class Endpoint {
+        private Endpoint() {}
+        public static final String CRYPTO_WORKER_RPC_ENDPOINT = "worker.rpc.endpoint.crypto";
+        public static final String VERIFICATION_WORKER_RPC_ENDPOINT = "worker.rpc.endpoint.verification";
+        public static final String UNIQUENESS_WORKER_RPC_ENDPOINT = "worker.rpc.endpoint.uniqueness";
+        public static final String PERSISTENCE_WORKER_RPC_ENDPOINT = "worker.rpc.endpoint.persistence";
+    }
 }

--- a/data/topic-schema/src/main/java/net/corda/schema/Schemas.java
+++ b/data/topic-schema/src/main/java/net/corda/schema/Schemas.java
@@ -283,13 +283,13 @@ public final class Schemas {
     }
 
     /**
-     * Corda worker RPC endpoints
+     * Corda worker REST endpoints
      */
     public static final class Endpoint {
         private Endpoint() {}
-        public static final String CRYPTO_WORKER_RPC_ENDPOINT = "worker.rpc.endpoint.crypto";
-        public static final String VERIFICATION_WORKER_RPC_ENDPOINT = "worker.rpc.endpoint.verification";
-        public static final String UNIQUENESS_WORKER_RPC_ENDPOINT = "worker.rpc.endpoint.uniqueness";
-        public static final String PERSISTENCE_WORKER_RPC_ENDPOINT = "worker.rpc.endpoint.persistence";
+        public static final String CRYPTO_WORKER_REST_ENDPOINT = "worker.rest.endpoint.crypto";
+        public static final String VERIFICATION_WORKER_REST_ENDPOINT = "worker.rest.endpoint.verification";
+        public static final String UNIQUENESS_WORKER_REST_ENDPOINT = "worker.rest.endpoint.uniqueness";
+        public static final String PERSISTENCE_WORKER_REST_ENDPOINT = "worker.rest.endpoint.persistence";
     }
 }

--- a/data/topic-schema/src/main/java/net/corda/schema/Schemas.java
+++ b/data/topic-schema/src/main/java/net/corda/schema/Schemas.java
@@ -281,15 +281,4 @@ public final class Schemas {
         public static final String SCHEDULED_TASK_NAME_SESSION_TIMEOUT = "flow-session-timeout";
 
     }
-
-    /**
-     * Corda worker REST endpoints
-     */
-    public static final class Endpoint {
-        private Endpoint() {}
-        public static final String CRYPTO_WORKER_REST_ENDPOINT = "worker.endpoints.crypto";
-        public static final String VERIFICATION_WORKER_REST_ENDPOINT = "worker.endpoints.verification";
-        public static final String UNIQUENESS_WORKER_REST_ENDPOINT = "worker.endpoints.uniqueness";
-        public static final String PERSISTENCE_WORKER_REST_ENDPOINT = "worker.endpoints.persistence";
-    }
 }


### PR DESCRIPTION
In a related corda-runtime-os PR ([HERE](https://github.com/corda/corda-runtime-os/pull/4777)), we're adding a `ClusterIP` load balancer service to each Corda worker which will distribute HTTP calls to various instances of each worker type. The endpoints for these services are then passed into the `FlowWorker` startup args in key:value pairs. This PR adds these keys to the API so that we can query the endpoint map passed into the `FlowWorker`.

**PR Building with these changes:** https://ci02.dev.r3.com/job/Corda5/job/corda-runtime-os/job/PR-4823/8/