### PR TITLE
CORE-17485 - Reinstate removed properties during flow session refactor

### DIFF
--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/flow/1.0/corda.flow.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/flow/1.0/corda.flow.json
@@ -54,6 +54,27 @@
       "type": "object",
       "default": {},
       "properties": {
+        "messageResendWindow": {
+          "description": "The length of time in milliseconds that Corda waits before resending unacknowledged flow session messages.",
+          "type": "integer",
+          "minimum": 1000,
+          "maximum": 2147483647,
+          "default": 120000
+        },
+        "heartbeatTimeout": {
+          "description": "The length of time in milliseconds that Corda waits when no message has been received from a counterparty before causing the session to error. This should be set at least 2 times larger than session.messageResendWindow.",
+          "type": "integer",
+          "minimum": 1000,
+          "maximum": 2147483647,
+          "default": 1800000
+        },
+        "missingCounterpartyTimeout": {
+          "description": "The length of time in milliseconds to wait when the counterparty can't be found in a member lookup before causing the session to error",
+          "type": "integer",
+          "minimum": 1000,
+          "maximum": 2147483647,
+          "default": 300000
+        },
         "timeout": {
           "description": "The length of time in milliseconds that Corda waits when no message has been received from a counterparty before causing the session to error.",
           "type": "integer",


### PR DESCRIPTION
Config properties can’t be removed because Corda 5.1 will treat ones it doesn't know about from existing config on a running Corda 5.0 cluster as extra properties, which we don't allow.

This PR will reinstate property that were removed as a result of the Flow Session Refactor work: CORE-15757 flow session refactor (https://github.com/corda/corda-api/pull/1208)