### PR TITLE
CORE-17431 utxo_transaction_metadata table and related migrations

### DIFF
--- a/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v5.1.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v5.1.xml
@@ -129,9 +129,6 @@
             <column name="canonical_data" type="VARBINARY(1048576)">
                 <constraints nullable="false"/>
             </column>
-            <column name="json_data" type="${json.column.type}">
-                <constraints nullable="false"/>
-            </column>
             <column name="group_parameters_hash" type="VARCHAR(160)">
                 <constraints nullable="false"/>
             </column>
@@ -154,7 +151,6 @@
             SELECT
                 hash,
                 data as canonical_data,
-                convert_from(data, 'UTF-8')::jsonb AS json_data,
                 convert_from(data, 'UTF-8')::jsonb->'membershipGroupParametersHash' AS group_parameters_hash,
                 convert_from(data, 'UTF-8')::jsonb->'cpiMetadata'->'fileChecksum' AS cpi_file_checksum
             FROM

--- a/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v5.1.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v5.1.xml
@@ -121,6 +121,59 @@
 
         <!-- Drop the utxo_cpk table -->
         <dropTable tableName="utxo_cpk"/>
+
+        <createTable tableName="utxo_transaction_metadata">
+            <column name="hash" type="VARCHAR(160)">
+                <constraints nullable="false" primaryKey="true"/>
+            </column>
+            <column name="data" type="${json.column.type}">
+                <constraints nullable="false"/>
+            </column>
+            <column name="group_parameters_hash" type="VARCHAR(160)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="cpi_file_checksum" type="VARCHAR(160)">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <!-- Add utxo_transaction.metadata_hash nullable to let migrate data later -->
+        <addColumn tableName="utxo_transaction">
+            <column name="metadata_hash" type="VARCHAR(160)">
+                <constraints nullable="true" foreignKeyName="fk_utxo_transaction_metadata" references="utxo_transaction_metadata(hash)"/>
+            </column>
+        </addColumn>
+
+        <!-- Populate utxo_transaction_metadata. Postgresql only since, no other dbs were supported before 5.1. So only Postgres can have data which needs to be migrated. -->
+        <!-- ^^ is this correct?? -->
+        <sql dbms="postgresql">
+            INSERT INTO utxo_transaction_metadata
+            SELECT
+                hash,
+                convert_from(data, 'UTF-8')::jsonb AS data,
+                convert_from(data, 'UTF-8')::jsonb->'membershipGroupParametersHash' AS group_parameters_hash,
+                convert_from(data, 'UTF-8')::jsonb->'cpiMetadata'->'fileChecksum' AS cpi_file_checksum
+            FROM
+                utxo_transaction_component
+            WHERE
+                group_idx=0 AND
+                leaf_idx=0;
+        </sql>
+
+        <!-- Migrate utxo_transaction.metadata_hash -->
+        <update tableName="utxo_transaction">
+            <column name="metadata_hash"
+                    valueComputed="(select hash from utxo_transaction_component c where c.transaction_id=id and group_idx=0 and leaf_idx=0)"/>
+        </update>
+
+        <!-- Change utxo_transaction.metadata_hash to not nullable -->
+        <addNotNullConstraint tableName="utxo_transaction" columnName="metadata_hash" columnDataType="VARCHAR(160)"/>
+
+        <!-- Old metadata records are not needed anymore. -->
+        <delete tableName="utxo_transaction_component">
+            <where>group_idx=0 AND leaf_idx=0</where>
+        </delete>
+
     </changeSet>
 
 </databaseChangeLog>

--- a/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v5.1.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v5.1.xml
@@ -148,7 +148,7 @@
         <!-- ^^ is this correct?? -->
         <sql dbms="postgresql">
             INSERT INTO utxo_transaction_metadata
-            SELECT
+            SELECT DISTINCT
                 hash,
                 data as canonical_data,
                 convert_from(data, 'UTF-8')::jsonb->'membershipGroupParametersHash' AS group_parameters_hash,

--- a/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v5.1.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v5.1.xml
@@ -126,7 +126,10 @@
             <column name="hash" type="VARCHAR(160)">
                 <constraints nullable="false" primaryKey="true"/>
             </column>
-            <column name="data" type="${json.column.type}">
+            <column name="canonical_data" type="VARBINARY(1048576)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="json_data" type="${json.column.type}">
                 <constraints nullable="false"/>
             </column>
             <column name="group_parameters_hash" type="VARCHAR(160)">
@@ -150,7 +153,8 @@
             INSERT INTO utxo_transaction_metadata
             SELECT
                 hash,
-                convert_from(data, 'UTF-8')::jsonb AS data,
+                data as canonical_data,
+                convert_from(data, 'UTF-8')::jsonb AS json_data,
                 convert_from(data, 'UTF-8')::jsonb->'membershipGroupParametersHash' AS group_parameters_hash,
                 convert_from(data, 'UTF-8')::jsonb->'cpiMetadata'->'fileChecksum' AS cpi_file_checksum
             FROM

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ cordaProductVersion = 5.1.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 32
+cordaApiRevision = 33
 
 # Main
 kotlinVersion = 1.8.21


### PR DESCRIPTION
CORE-17431 Create utxo_transaction_metadata for storing metadata since it is relatively large but does not change frequently. Also, two new fields for accessing signed group parameters and CPI file checksum easier.

Tests:
* Running the 5.1 migration script on top of a 5.0 combined worker with some vnodes and transactions. After running the migration, the new table and fields appeared with the expected content and the metadata components were deleted from the components table.
* Running utxo smoke tests on the 5.1 combined worker executed the migrations on a clean database.

Runtime-os: https://github.com/corda/corda-runtime-os/pull/4845