### PR TITLE
CORE-17623 - Change ACL mappings to add tokenSelection worker.

### DIFF
--- a/data/topic-schema/src/main/resources/net/corda/schema/AvroSchema.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/AvroSchema.yaml
@@ -13,6 +13,7 @@ topics:
       - persistence
       - rest
       - uniqueness
+      - tokenSelection
     producers:
       - crypto
       - db
@@ -25,6 +26,7 @@ topics:
       - persistence
       - rest
       - uniqueness
+      - tokenSelection
     config:
       cleanup.policy: compact
       segment.ms: 600000

--- a/data/topic-schema/src/main/resources/net/corda/schema/Config.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/Config.yaml
@@ -27,6 +27,7 @@ topics:
       - rest
       - persistence
       - uniqueness
+      - tokenSelection
     producers:
       - db
     config:

--- a/data/topic-schema/src/main/resources/net/corda/schema/Flow.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/Flow.yaml
@@ -11,6 +11,7 @@ topics:
       - verification
       - persistence
       - uniqueness
+      - tokenSelection
     config:
   FlowEventStateTopic:
     name: flow.event.state

--- a/data/topic-schema/src/main/resources/net/corda/schema/Services.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/Services.yaml
@@ -1,19 +1,24 @@
+# TODO: remove db access once the tokenSelection worker has been integrated.
 topics:
   ServicesTokenEventTopic:
     name: services.token.event
     consumers:
       - db
+      - tokenSelection
     producers:
       - flow
       - db
       - persistence
+      - tokenSelection
     config:
   ServicesTokenEventStateTopic:
     name: services.token.event.state
     consumers:
       - db
+      - tokenSelection
     producers:
       - db
+      - tokenSelection
     config:
       cleanup.policy: compact
       segment.ms: 600000
@@ -25,22 +30,28 @@ topics:
     name: services.token.event.dlq
     consumers:
       - db
+      - tokenSelection
     producers:
       - db
+      - tokenSelection
     config:
   ServicesTokenSyncEventTopic:
     name: services.token.sync.event
     consumers:
       - db
+      - tokenSelection
     producers:
       - db
+      - tokenSelection
     config:
   ServicesTokenSyncEventStateTopic:
     name: services.token.sync.event.state
     consumers:
       - db
+      - tokenSelection
     producers:
       - db
+      - tokenSelection
     config:
       cleanup.policy: compact
       segment.ms: 600000
@@ -52,6 +63,8 @@ topics:
     name: services.token.sync.event.dlq
     consumers:
       - db
+      - tokenSelection
     producers:
       - db
+      - tokenSelection
     config:

--- a/data/topic-schema/src/main/resources/net/corda/schema/VirtualNode.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/VirtualNode.yaml
@@ -74,6 +74,7 @@ topics:
       - link-manager
       - persistence
       - rest
+      - tokenSelection
     producers:
       - db
     config:


### PR DESCRIPTION
Add `tokenSelection` to the topic ACL mappings. 

NOTE: the `db` user should be removed from these, but to avoid API version bumps, this will be done once they are not used anymore.

runtime changes: https://github.com/corda/corda-runtime-os/pull/4835