### PR TITLE
DOC-5944 Allow server definitions in Gateway config with same host/port but different path

### DIFF
--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/p2p.gateway/1.0/corda.p2p.gateway.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/p2p.gateway/1.0/corda.p2p.gateway.json
@@ -8,7 +8,7 @@
     "serversConfiguration": {
       "type": "array",
       "minItems": 1,
-      "description": "A list of HTTP servers that Corda listens to. The list is specified as an array of hostAddress, hostPort, and urlPath values. The hostAddress and hostPort pair must be unique for each server.",
+      "description": "A list of HTTP servers that Corda listens to. The list is specified as an array of hostAddress, hostPort, and urlPath values.",
       "default": [{
         "hostAddress": "0.0.0.0",
         "hostPort": 8080,


### PR DESCRIPTION
Update to `serversConfiguration` description. This text is displayed in the documentation: https://docs.r3.com/en/platform/corda/5.0/deploying-operating/config/fields/p2p-gateway.html