### PR TITLE
CORE-16323: Improve State Manager Index

### DIFF
--- a/data/db-schema/src/main/resources/net/corda/db/schema/statemanager/migration/state-manager-migration-v5.1.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/statemanager/migration/state-manager-migration-v5.1.xml
@@ -30,7 +30,8 @@
                 <constraints nullable="false"/>
             </column>
         </createTable>
-        <createIndex tableName="state" indexName="state_version_idx">
+        <createIndex tableName="state" indexName="state_key_version_idx">
+            <column name="key"/>
             <column name="version"/>
         </createIndex>
         <addPrimaryKey columnNames="key" constraintName="state_key" tableName="state"/>


### PR DESCRIPTION
Update recently introduced index so it uses both the "key" and
"version" columns as both are used by the State Manager during update
and delete queries.
