### PR TITLE
CORE-17782 Add deprecation warning to `findUnconsumedStatesByType`

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ cordaProductVersion = 5.1.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 36
+cordaApiRevision = 37
 
 # Main
 kotlinVersion = 1.8.21

--- a/ledger/ledger-utxo/src/main/java/net/corda/v5/ledger/utxo/UtxoLedgerService.java
+++ b/ledger/ledger-utxo/src/main/java/net/corda/v5/ledger/utxo/UtxoLedgerService.java
@@ -90,18 +90,19 @@ public interface UtxoLedgerService {
 
     /**
      * Finds unconsumed states that are concrete implementations or subclasses of {@code type}.
-     * <p>
-     * Only use this method if subclasses of {@code type} must be returned.
-     * <p>
-     * Use {@link #findUnconsumedStatesByExactType(Class<T>)} to return exact instances of the input {@code type}.
-     * This method is more performant than {@link #findUnconsumedStatesByExactType(Class, Integer, Instant)}.
-     * <p>
-     * Use {@link #query(String, Class)} for a more performant method of retrieving subclasses of a specified type.
+     *
+     * @deprecated This method should no longer be used due to its lack of paging support, which can result in
+     *             serious performance issues and / or out of memory errors if the query returns many states.
+     *             {@link #findUnconsumedStatesByExactType(Class, Integer, Instant)} should be used instead. Note
+     *             that this will not return subclasses of the specified class. If this functionality is required,
+     *             it is recommended to write a custom query and invoke this via the {@link #query(String, Class)}
+     *             API instead.
      *
      * @param <T>  The underlying {@link ContractState} type.
      * @param type The {@link ContractState} type to find in the vault.
      * @return Returns a {@link List} of {@link StateAndRef} of unconsumed states of the specified type, or an empty list if no states could be found.
      */
+    @Deprecated(since = "5.1", forRemoval = true)
     @NotNull
     @Suspendable
     <T extends ContractState> List<StateAndRef<T>> findUnconsumedStatesByType(@NotNull Class<T> type);


### PR DESCRIPTION
Mark `findUnconsumedStatesByType` as deprecated, ahead of its removal in a subsequent release.

An API version bump is required due to a flow in `corda-runtime-os` using this API, which needs to be updated to suppress deprecation warnings following this change. Similarly, changes to the E2E tests are required. See https://github.com/corda/corda-runtime-os/pull/4884 and https://github.com/corda/corda-e2e-tests/pull/284.