### PR TITLE
ES-1485 PR and Branch housekeeping automation dry run

### DIFF
--- a/.github/workflows/remove-stale-branches.yml
+++ b/.github/workflows/remove-stale-branches.yml
@@ -1,0 +1,23 @@
+on: 
+  workflow_dispatch: # this will eventually be a cron job - for now it is used in manual testing
+    inputs:
+      days_before_stale:
+        type: number
+        default: 30
+      days_before_delete:
+        type: number
+        default: 14
+
+jobs:
+  remove-stale-branches:
+    name: Remove stale branches
+    runs-on: ubuntu-latest
+    steps:
+      - uses: fpicalausa/remove-stale-branches@v1.5.8
+        with:
+          dry-run: true
+          days-before-branch-stale: ${{ inputs.days_before_stale }}
+          days-before-branch-delete: ${{ inputs.days_before_delete }}
+          stale-branch-message: "@{author} The branch [{branchName}]({branchUrl}) hasn't been updated in the last 30 days and is marked as stale. It will be removed in 14 days.\r\nIf you want to keep this branch around, delete this comment or add new commits to this branch."
+          exempt-protected-branches: true
+          exempt-branches-regex: "^(release\\/|feature\\/|poc\\/).*"


### PR DESCRIPTION
Tested here: https://github.com/corda/Build_team_Test_repo/blob/release/os/5.0/.github/workflows/removeStaleBranches.yml
(runs can be seen here: https://github.com/corda/Build_team_Test_repo/actions/workflows/removeStaleBranches.yml)

This workflow is set to run only in `dry-run` mode - this means it cannot make any changes or comments on branches.