### PR TITLE
ES-1485 PR and Branch housekeeping automation (still dry-run)

### DIFF
--- a/.github/workflows/remove-stale-branches.yml
+++ b/.github/workflows/remove-stale-branches.yml
@@ -1,12 +1,7 @@
-on: 
-  workflow_dispatch: # this will eventually be a cron job - for now it is used in manual testing
-    inputs:
-      days_before_stale:
-        type: number
-        default: 30
-      days_before_delete:
-        type: number
-        default: 14
+name: 'Remove stale branches'
+on:
+  schedule:
+    - cron: '0 0 * * 1-5'
 
 jobs:
   remove-stale-branches:
@@ -16,8 +11,9 @@ jobs:
       - uses: fpicalausa/remove-stale-branches@v1.5.8
         with:
           dry-run: true
-          days-before-branch-stale: ${{ inputs.days_before_stale }}
-          days-before-branch-delete: ${{ inputs.days_before_delete }}
+          days-before-branch-stale: 30
+          days-before-branch-delete: 14
           stale-branch-message: "@{author} The branch [{branchName}]({branchUrl}) hasn't been updated in the last 30 days and is marked as stale. It will be removed in 14 days.\r\nIf you want to keep this branch around, delete this comment or add new commits to this branch."
           exempt-protected-branches: true
           exempt-branches-regex: "^(release\\/|feature\\/|poc\\/).*"
+          operations-per-run: 30


### PR DESCRIPTION
- Adds a cron-job that will trigger this workflow at midnight, every Monday - Friday
- Still in dry-run mode
- Increased the limit of affected branches per execution from 10 -> 30
