### PR TITLE
CORE-17012 dlq topic to be used by multi source mediator for producer  serialization errors

### DIFF
--- a/data/topic-schema/src/main/resources/net/corda/schema/Common.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/Common.yaml
@@ -1,0 +1,17 @@
+topics:
+  MediatorSerializationDLQ:
+    name: mediator.client.serialization.dlq
+    producers:
+      - crypto
+      - db
+      - flow
+      - flowMapper
+      - verification
+      - membership
+      - gateway
+      - link-manager
+      - persistence
+      - rest
+      - uniqueness
+      - tokenSelection
+    config:

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ cordaProductVersion = 5.1.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 37
+cordaApiRevision = 38
 
 # Main
 kotlinVersion = 1.8.21


### PR DESCRIPTION
It is not possible for a multi source mediator to determine which topic a record came from which triggered an output record that failed to serialize and therefore should be DLQ'd.

Adding a common topic for all mediators to send a DLQ record for to record serialization failures. 

Open to debate whether we should even bother DLQing this records. However as we DLQ these in the S+E this seems the only way to preserve that logic