### PR TITLE
CORE-17768 Topology changes - Use new topics

### DIFF
--- a/data/topic-schema/src/main/resources/net/corda/schema/Flow.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/Flow.yaml
@@ -114,6 +114,7 @@ topics:
     consumers:
       - flowMapper
     producers:
+      - flowMapper
       - link-manager
     config:
   FlowStart:

--- a/data/topic-schema/src/main/resources/net/corda/schema/Flow.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/Flow.yaml
@@ -130,5 +130,6 @@ topics:
       - flow
     producers:
       - flowMapper
+      - tokenSelection
     config:
 


### PR DESCRIPTION
Set permission for `FlowMapper` to send messages to Kafka topic `flow.mapper.session.in`.
Set permission for `TokenSelection` to send messages to Kafka topic `flow.session`.