### PR TITLE
DA5-5 persist/find draft transactions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ cordaProductVersion = 5.1.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 37
+cordaApiRevision = 38
 
 # Main
 kotlinVersion = 1.8.21

--- a/ledger/ledger-utxo/src/main/java/net/corda/v5/ledger/utxo/UtxoLedgerService.java
+++ b/ledger/ledger-utxo/src/main/java/net/corda/v5/ledger/utxo/UtxoLedgerService.java
@@ -6,6 +6,7 @@ import net.corda.v5.application.persistence.PagedQuery.ResultSet;
 import net.corda.v5.base.annotations.DoNotImplement;
 import net.corda.v5.base.annotations.Suspendable;
 import net.corda.v5.crypto.SecureHash;
+import net.corda.v5.ledger.common.transaction.TransactionSignatureException;
 import net.corda.v5.ledger.utxo.query.VaultNamedParameterizedQuery;
 import net.corda.v5.ledger.utxo.query.VaultNamedQueryFactory;
 import net.corda.v5.ledger.utxo.transaction.UtxoLedgerTransaction;
@@ -305,4 +306,30 @@ public interface UtxoLedgerService {
     @Suspendable
     @NotNull
     <R> VaultNamedParameterizedQuery<R> query(@NotNull String queryName, @NotNull Class<R> resultClass);
+
+    /**
+     * Persists a non-finalized (draft) transaction.
+     * It executes the same checks as the finalization does before its initial persist.
+     * So the transaction and all of its signatures need to be valid, but there may be missing signatures.
+     * <p>
+     * @param utxoSignedTransaction The {@link UtxoSignedTransaction} to persist.
+     * @throws ContractVerificationException if the transaction fails contract verification.
+     * @throws TransactionSignatureException if a signature of the transaction fails verification.
+     * @throws IllegalStateException if the transaction does not have any signatures.
+     */
+    @Suspendable
+    void persistDraftSignedTransaction(
+            @NotNull UtxoSignedTransaction utxoSignedTransaction
+    );
+
+    /**
+     * Finds a draft {@link UtxoSignedTransaction} in the vault by the specified transaction ID.
+     * Draft transactions have not been finalized, so they may have missing signatures.
+     *
+     * @param id The ID of the {@link UtxoSignedTransaction} to find.
+     * @return Returns the {@link UtxoSignedTransaction} if it has been recorded previously, or null if no transaction could be found.
+     */
+    @Nullable
+    @Suspendable
+    UtxoSignedTransaction findDraftSignedTransaction(@NotNull SecureHash id);
 }


### PR DESCRIPTION
Add UtxoLedgerService.persistDraftSignedTransaction and UtxoLedgerService.findDraftSignedTransaction

runtime-os: https://github.com/corda/corda-runtime-os/pull/4964