### PR TITLE
CORE-17958 Limit the length of client request ids to 242 characters.

### DIFF
--- a/data/rbac-schema/src/main/java/net/corda/rbac/schema/RbacKeys.java
+++ b/data/rbac-schema/src/main/java/net/corda/rbac/schema/RbacKeys.java
@@ -50,7 +50,7 @@ public final class RbacKeys {
     /**
      * Flow start client request ID.
      */
-    public static final String CLIENT_REQ_REGEX = "[-._A-Za-z0-9]{1,250}";
+    public static final String CLIENT_REQ_REGEX = "[-._A-Za-z0-9]{1,242}";
 
     /**
      * FQN for a flow to be started.


### PR DESCRIPTION
This string is combined with the vnode shorthash to make a key for flow mapper states records for start flow events. The flow mapper state is stored in the state storage which has a limit of 255 characters. vnode shorthash is 12 characters with an additional separator character added this adds to the max 255.

runtime pr: https://github.com/corda/corda-runtime-os/pull/4977

