### PR TITLE
DA5-5 fix api version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,11 +5,11 @@
 org.gradle.java.installations.auto-download=false
 
 # Versioning
-cordaProductVersion = 5.1.0-DA
+cordaProductVersion = 5.1.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 1
+cordaApiRevision = 200-DA
 
 # Main
 kotlinVersion = 1.8.21


### PR DESCRIPTION
Mainly to avoid gradle mixing version numbers.
Required to run the e2e repository's tests.
Background: 
https://r3holdco.slack.com/archives/C039J1A3ZQB/p1698657116094349