### PR TITLE
CORE-18229 Set code owners on feature branch

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
-* @driessamyn @jasonbyrner3 @dimosr @ronanbrowne @rick-r3 @simon-johnson-r3 @blsemo @Omar-awad @aditisdesai @vinir3 @vkolomeyko @thiagoviana @Sakpal
+* @corda/corda-platform-network-team
+


### PR DESCRIPTION
Set the code owners on the platform network branch to just the platform network team. Not to be merged to the 5.2 branch once it is created.