### PR TITLE
ES-1614: Create remove-stale-prs workflow

### DIFF
--- a/.github/workflows/remove-stale-prs.yml
+++ b/.github/workflows/remove-stale-prs.yml
@@ -1,0 +1,20 @@
+name: 'Close stale issues and PR'
+on:
+  schedule:
+    - cron: '0 0 * * 1-5'
+
+jobs:
+  remove-stale-prs:
+    name: Remove stale PRs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v8.0.0
+        with:
+          debug-only: true
+          exempt-pr-labels: 'DO_NOT_CLOSE'
+          stale-pr-message: 'This PR is stale because it has been open 7 days with no activity. Remove the `Stale` label or add a comment - otherwise this will be closed in 7 days.'
+          close-pr-message: 'This PR was closed because it has been stale for 7 days with no activity.'
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+          days-before-pr-stale: 7
+          days-before-pr-close: 7


### PR DESCRIPTION
Add a **dry run** of remove-stale-prs GitHub workflow, that will trigger every weekday at midnight.

This action will mark a PR as stale after 7 days, and then after 7 more it will be closed.

This action will not impact GitHub Issues.
