### PR TITLE
CORE-18306: Merging network 5.2 feature branch into the release branch

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
-* @driessamyn @jasonbyrner3 @dimosr @ronanbrowne @rick-r3 @simon-johnson-r3 @blsemo @Omar-awad @aditisdesai @vinir3 @vkolomeyko @thiagoviana @Sakpal
+* @corda/corda-platform-network-team
+

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ cordaProductVersion = 5.1.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 37
+cordaApiRevision = 37-NETWORK-5-2
 
 # Main
 kotlinVersion = 1.8.21


### PR DESCRIPTION
There were conflicts in:
* `.github/CODEOWNERS` - reverted to the release branch version
* `gradle.properties` - API version was changed into 2.

Do not squash