### PR TITLE
CORE-15267 Add `@CordaSerializable` to MemberContext and MGMContext

### DIFF
--- a/base/src/main/java/net/corda/v5/base/types/LayeredPropertyMap.java
+++ b/base/src/main/java/net/corda/v5/base/types/LayeredPropertyMap.java
@@ -1,5 +1,6 @@
 package net.corda.v5.base.types;
 
+import net.corda.v5.base.annotations.CordaSerializable;
 import net.corda.v5.base.exceptions.ValueNotFoundException;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -51,6 +52,7 @@ import java.util.Set;
  * converters using OSGi. Out of box it supports conversion to simple types like {@code int}, {@code boolean},
  * as well as {@link MemberX500Name}.
  */
+@CordaSerializable
 public interface LayeredPropertyMap {
     /**
      * @return {@link Set} of all entries in the underlying map.

--- a/base/src/main/java/net/corda/v5/base/types/LayeredPropertyMap.java
+++ b/base/src/main/java/net/corda/v5/base/types/LayeredPropertyMap.java
@@ -1,6 +1,5 @@
 package net.corda.v5.base.types;
 
-import net.corda.v5.base.annotations.CordaSerializable;
 import net.corda.v5.base.exceptions.ValueNotFoundException;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -52,7 +51,6 @@ import java.util.Set;
  * converters using OSGi. Out of box it supports conversion to simple types like {@code int}, {@code boolean},
  * as well as {@link MemberX500Name}.
  */
-@CordaSerializable
 public interface LayeredPropertyMap {
     /**
      * @return {@link Set} of all entries in the underlying map.

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ cordaProductVersion = 5.1.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 37
+cordaApiRevision = 38
 
 # Main
 kotlinVersion = 1.8.21

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ cordaProductVersion = 5.1.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 38
+cordaApiRevision = 39
 
 # Main
 kotlinVersion = 1.8.21

--- a/membership/src/main/java/net/corda/v5/membership/MGMContext.java
+++ b/membership/src/main/java/net/corda/v5/membership/MGMContext.java
@@ -1,5 +1,6 @@
 package net.corda.v5.membership;
 
+import net.corda.v5.base.annotations.CordaSerializable;
 import net.corda.v5.base.types.LayeredPropertyMap;
 
 /**
@@ -32,4 +33,5 @@ import net.corda.v5.base.types.LayeredPropertyMap;
  *
  * @see LayeredPropertyMap for further information on the properties and functions.
  */
+@CordaSerializable
 public interface MGMContext extends LayeredPropertyMap {}

--- a/membership/src/main/java/net/corda/v5/membership/MemberContext.java
+++ b/membership/src/main/java/net/corda/v5/membership/MemberContext.java
@@ -1,5 +1,6 @@
 package net.corda.v5.membership;
 
+import net.corda.v5.base.annotations.CordaSerializable;
 import net.corda.v5.base.types.LayeredPropertyMap;
 
 /**
@@ -32,4 +33,5 @@ import net.corda.v5.base.types.LayeredPropertyMap;
  *
  * @see LayeredPropertyMap For further information on the properties and functions.
  */
+@CordaSerializable
 public interface MemberContext extends LayeredPropertyMap {}


### PR DESCRIPTION
Marks `MemberContext` and `MGMContext` interfaces as `@CordaSerializable` to make `MemberInfo` serializable. The corresponding runtime-os change registers custom serializers for its implementation types - https://github.com/corda/corda-runtime-os/pull/5127 