### PR TITLE
CORE-18390: Allow old version of SetOwnRegistrationStatus in the command

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/command/registration/member/PersistMemberRegistrationState.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/command/registration/member/PersistMemberRegistrationState.avsc
@@ -12,7 +12,10 @@
     {
       "name": "setStatusRequest",
       "doc" : "The request to set the status.",
-      "type": "net.corda.data.membership.p2p.v2.SetOwnRegistrationStatus"
+      "type": [
+        "net.corda.data.membership.p2p.v2.SetOwnRegistrationStatus",
+        "net.corda.data.membership.p2p.SetOwnRegistrationStatus"
+      ]
     }
   ]
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ cordaProductVersion = 5.1.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 37
+cordaApiRevision = 38
 
 # Main
 kotlinVersion = 1.8.21


### PR DESCRIPTION
This should allow a command from 5.0 to work on a 5.1 cluster.

The runtime pull request is in https://github.com/corda/corda-runtime-os/pull/5114