### PR TITLE
CORE-17821 Removing unused crypto topics

### DIFF
--- a/data/topic-schema/src/main/java/net/corda/schema/Schemas.java
+++ b/data/topic-schema/src/main/java/net/corda/schema/Schemas.java
@@ -84,7 +84,6 @@ public final class Schemas {
 
         public static final String RPC_HSM_REGISTRATION_MESSAGE_TOPIC = "crypto.hsm.rpc.registration";
         public static final String RPC_HSM_REGISTRATION_MESSAGE_RESPONSE_TOPIC = getRPCResponseTopic(RPC_HSM_REGISTRATION_MESSAGE_TOPIC);
-        public static final String FLOW_OPS_MESSAGE_TOPIC = "crypto.ops.flow";
         public static final String RPC_OPS_MESSAGE_TOPIC = "crypto.ops.rpc";
         public static final String RPC_OPS_MESSAGE_RESPONSE_TOPIC = getRPCResponseTopic(RPC_OPS_MESSAGE_TOPIC);
         public static final String REKEY_MESSAGE_TOPIC = "crypto.key.rotation.ops";

--- a/data/topic-schema/src/main/resources/net/corda/schema/Crypto.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/Crypto.yaml
@@ -15,13 +15,6 @@ topics:
     producers:
       - crypto
     config:
-  CryptoOpsFlowTopic:
-    name: crypto.ops.flow
-    consumers:
-      - crypto
-    producers:
-      - flow
-    config:
   CryptoOpsRpcTopic:
     name: crypto.ops.rpc
     consumers:

--- a/data/topic-schema/src/test/java/net/corda/schema/SchemasTests.java
+++ b/data/topic-schema/src/test/java/net/corda/schema/SchemasTests.java
@@ -9,6 +9,5 @@ public class SchemasTests {
     void cryptoTopicsShouldLookNiceInJavaApi() {
         assertNotNull(Schemas.Crypto.RPC_HSM_REGISTRATION_MESSAGE_TOPIC);
         assertNotNull(Schemas.Crypto.RPC_OPS_MESSAGE_TOPIC);
-        assertNotNull(Schemas.Crypto.FLOW_OPS_MESSAGE_TOPIC);
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ cordaProductVersion = 5.2.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 5
+cordaApiRevision = 6
 
 # Main
 kotlinVersion = 1.8.21


### PR DESCRIPTION
Now that communication with the `CryptoWorker` is done via RPC rather than over Kafka, we no longer need to define the relevant topics in our API. This PR removes those which are no longer used.

Associated `corda-runtime-os` changes: https://github.com/corda/corda-runtime-os/pull/5150/