### PR TITLE
CORE-18495 Made topic field in ExternalEvent.avsc optional; defaults to null

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/flow/event/external/ExternalEvent.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/flow/event/external/ExternalEvent.avsc
@@ -6,8 +6,9 @@
   "fields": [
     {
       "name": "topic",
-      "type": "string",
-      "doc": "The topic that the external event is sent to."
+      "type": ["null", "string"],
+      "doc": "The topic that the external event is sent to.",
+      "default": null
     },
     {
       "name": "key",


### PR DESCRIPTION
Now that some external events are send over HTTP RPC rather than the Kafka message bus, we should make the topic field in the ExternalEvent AVRO object optional so it need not be set for HTTP-based communications.

Runtime OS PR with these changes building successfully: https://github.com/corda/corda-runtime-os/pull/5152 🟢 