### PR TITLE
CORE-18492 notary registration & add backchain required flag on Notar…

### DIFF
--- a/data/membership-schema/src/main/resources/net/corda/schema/membership/member/dynamic/registration/1.0/corda.member.dynamic.registration.json
+++ b/data/membership-schema/src/main/resources/net/corda/schema/membership/member/dynamic/registration/1.0/corda.member.dynamic.registration.json
@@ -65,6 +65,16 @@
         "O=NotaryService, L=London, C=GB"
       ]
     },
+    "corda.notary.service.backchain.required": {
+      "description": "Boolean flag whether backchain verification by members is required when using this notary service.",
+      "type": "string",
+      "enum": ["true", "false"],
+      "default": "true",
+      "examples": [
+        "true",
+        "false"
+      ]
+    },
     "corda.notary.service.flow.protocol.name": {
       "description": "Name of the flow protocol used by the notary service. Valid only when one of the roles is notary.",
       "type": "string",

--- a/data/membership-schema/src/main/resources/net/corda/schema/membership/member/dynamic/registration/1.0/corda.member.dynamic.registration.json
+++ b/data/membership-schema/src/main/resources/net/corda/schema/membership/member/dynamic/registration/1.0/corda.member.dynamic.registration.json
@@ -69,7 +69,6 @@
       "description": "Boolean flag whether backchain verification by members is required when using this notary service.",
       "type": "string",
       "enum": ["true", "false"],
-      "default": "true",
       "examples": [
         "true",
         "false"

--- a/data/membership-schema/src/main/resources/net/corda/schema/membership/member/static/registration/1.0/corda.member.static.registration.json
+++ b/data/membership-schema/src/main/resources/net/corda/schema/membership/member/static/registration/1.0/corda.member.static.registration.json
@@ -44,7 +44,6 @@
       "description": "Boolean flag whether backchain verification by members is required when using this notary service.",
       "type": "string",
       "enum": ["true", "false"],
-      "default": "true",
       "examples": [
         "true",
         "false"

--- a/data/membership-schema/src/main/resources/net/corda/schema/membership/member/static/registration/1.0/corda.member.static.registration.json
+++ b/data/membership-schema/src/main/resources/net/corda/schema/membership/member/static/registration/1.0/corda.member.static.registration.json
@@ -40,6 +40,16 @@
         "O=NotaryService, L=London, C=GB"
       ]
     },
+    "corda.notary.service.backchain.required": {
+      "description": "Boolean flag whether backchain verification by members is required when using this notary service.",
+      "type": "string",
+      "enum": ["true", "false"],
+      "default": "true",
+      "examples": [
+        "true",
+        "false"
+      ]
+    },
     "corda.notary.service.flow.protocol.name": {
       "description": "Name of the flow protocol used by the notary service. Valid only when one of the roles is notary.",
       "type": "string",

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ cordaProductVersion = 5.2.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 8
+cordaApiRevision = 9
 
 # Main
 kotlinVersion = 1.8.21

--- a/membership/scans/corda-membership-5.2.0.yaml
+++ b/membership/scans/corda-membership-5.2.0.yaml
@@ -123,6 +123,12 @@ net.corda.v5.membership.NotaryInfo:
   extends: []
   interface: true
   methods:
+    getBackchainRequired:
+      annotations:
+        - NotNull
+      default: false
+      type: public abstract
+      returnType: Boolean
     getName:
       annotations:
         - NotNull

--- a/membership/scans/corda-membership-5.2.0.yaml
+++ b/membership/scans/corda-membership-5.2.0.yaml
@@ -57,14 +57,16 @@ net.corda.v5.membership.GroupParametersLookup:
       type: public abstract
       returnType: net.corda.v5.membership.GroupParameters
 net.corda.v5.membership.MGMContext:
-  annotations: []
+  annotations:
+    - CordaSerializable
   type: public interface
   extends:
     - net.corda.v5.base.types.LayeredPropertyMap
   interface: true
   methods: {}
 net.corda.v5.membership.MemberContext:
-  annotations: []
+  annotations:
+    - CordaSerializable
   type: public interface
   extends:
     - net.corda.v5.base.types.LayeredPropertyMap
@@ -123,7 +125,7 @@ net.corda.v5.membership.NotaryInfo:
   extends: []
   interface: true
   methods:
-    getBackchainRequired:
+    getIsBackchainRequired:
       annotations:
         - NotNull
       default: false

--- a/membership/scans/corda-membership-5.2.0.yaml
+++ b/membership/scans/corda-membership-5.2.0.yaml
@@ -125,12 +125,6 @@ net.corda.v5.membership.NotaryInfo:
   extends: []
   interface: true
   methods:
-    getIsBackchainRequired:
-      annotations:
-        - NotNull
-      default: false
-      type: public abstract
-      returnType: Boolean
     getName:
       annotations:
         - NotNull
@@ -155,3 +149,9 @@ net.corda.v5.membership.NotaryInfo:
       default: false
       type: public abstract
       returnType: java.security.PublicKey
+    isBackchainRequired:
+      annotations:
+        - NotNull
+      default: false
+      type: public abstract
+      returnType: Boolean

--- a/membership/src/main/java/net/corda/v5/membership/NotaryInfo.java
+++ b/membership/src/main/java/net/corda/v5/membership/NotaryInfo.java
@@ -18,12 +18,14 @@ import java.util.Collection;
  * String protocol = notaryInfo.getProtocol();
  * Collection<Integer> protocolVersions = notaryInfo.getProtocolVersions();
  * PublicKey publicKey = notaryInfo.getPublicKey();
+ * Boolean backchainRequired = notaryInfo.getBackchainRequired();
  * }</pre></li>
  * <li>Kotlin:<pre>{@code
  * val name = notaryInfo.name
  * val protocol = notaryInfo.protocol
  * val protocolVersions = notaryInfo.protocolVersions
  * val publicKey = notaryInfo.publicKey
+ * val backchainRequired = notaryInfo.backchainRequired
  * }</pre></li>
  * </ul>
  */
@@ -48,4 +50,9 @@ public interface NotaryInfo {
      * @return The public key of the notary service, which will be a composite key of all notary virtual nodes keys.
      */
     @NotNull PublicKey getPublicKey();
+
+    /**
+     * @return boolean of whether it requires backchain verification.
+     */
+    @NotNull Boolean getBackchainRequired();
 }

--- a/membership/src/main/java/net/corda/v5/membership/NotaryInfo.java
+++ b/membership/src/main/java/net/corda/v5/membership/NotaryInfo.java
@@ -54,5 +54,5 @@ public interface NotaryInfo {
     /**
      * @return boolean of whether it requires backchain verification.
      */
-    @NotNull Boolean getBackchainRequired();
+    @NotNull Boolean getIsBackchainRequired();
 }

--- a/membership/src/main/java/net/corda/v5/membership/NotaryInfo.java
+++ b/membership/src/main/java/net/corda/v5/membership/NotaryInfo.java
@@ -54,5 +54,5 @@ public interface NotaryInfo {
     /**
      * @return boolean of whether it requires backchain verification.
      */
-    @NotNull Boolean getIsBackchainRequired();
+    @NotNull Boolean isBackchainRequired();
 }


### PR DESCRIPTION
This PR includes changes such as:
- new field schema for notary service registration that allows skip backchain or not.
- added a `backchainRequired` flag to `NotaryInfo` to be able to use in the implementation of a contract verifying notary which will be a follow-up ticket of this.
