### PR TITLE
CORE-18456: Api change to remove ledger persistence duplication

### DIFF
--- a/data/topic-schema/src/main/java/net/corda/schema/Schemas.java
+++ b/data/topic-schema/src/main/java/net/corda/schema/Schemas.java
@@ -220,7 +220,6 @@ public final class Schemas {
         }
 
         public static final String PERSISTENCE_ENTITY_PROCESSOR_TOPIC = "persistence.entity.processor";
-        public static final String PERSISTENCE_LEDGER_PROCESSOR_TOPIC = "persistence.ledger.processor";
     }
 
     /**

--- a/data/topic-schema/src/main/resources/net/corda/schema/Persistence.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/Persistence.yaml
@@ -6,10 +6,3 @@ topics:
     producers:
       - flow
     config:
-  PersistenceLedgerProcessorTopic:
-    name: persistence.ledger.processor
-    consumers:
-      - persistence
-    producers:
-      - flow
-    config:

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ cordaProductVersion = 5.2.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 6
+cordaApiRevision = 7
 
 # Main
 kotlinVersion = 1.8.21


### PR DESCRIPTION
This change is required as part of this PR https://github.com/corda/corda-runtime-os/pull/5147 to remove ledger persistence duplication. This change will remove an unused ledger persistence topic from the api. 