### PR TITLE
CORE-17506 Removing unused flow topics

### DIFF
--- a/data/topic-schema/src/main/java/net/corda/schema/Schemas.java
+++ b/data/topic-schema/src/main/java/net/corda/schema/Schemas.java
@@ -106,9 +106,6 @@ public final class Schemas {
         public static final String FLOW_EVENT_TOPIC = "flow.event";
         public static final String FLOW_EVENT_STATE_TOPIC = getStateAndEventStateTopic(FLOW_EVENT_TOPIC);
         public static final String FLOW_EVENT_DLQ_TOPIC = getDLQTopic(FLOW_EVENT_TOPIC);
-        public static final String FLOW_MAPPER_EVENT_TOPIC = "flow.mapper.event";
-        public static final String FLOW_MAPPER_EVENT_STATE_TOPIC = getStateAndEventStateTopic(FLOW_MAPPER_EVENT_TOPIC);
-        public static final String FLOW_MAPPER_EVENT_DLQ_TOPIC = getDLQTopic(FLOW_MAPPER_EVENT_TOPIC);
         public static final String FLOW_MAPPER_CLEANUP_TOPIC = "flow.mapper.cleanup";
         public static final String FLOW_TIMEOUT_TOPIC = "flow.timeout";
         public static final String FLOW_MAPPER_START = "flow.mapper.start";

--- a/data/topic-schema/src/main/resources/net/corda/schema/Flow.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/Flow.yaml
@@ -32,53 +32,6 @@ topics:
     producers:
       - flow
     config:
-  FlowMapperEventTopic:
-    name: flow.mapper.event
-    consumers:
-      - flow
-      - flowMapper
-    producers:
-      - flow
-      - flowMapper
-      - rest
-    config:
-  FlowMapperEventStateTopic:
-    name: flow.mapper.event.state
-    consumers:
-      - flow
-      - flowMapper
-    producers:
-      - flow
-      - flowMapper
-    config:
-      cleanup.policy: compact
-      segment.ms: 600000
-      delete.retention.ms: 300000
-      min.compaction.lag.ms: 60000
-      max.compaction.lag.ms: 604800000
-      min.cleanable.dirty.ratio: 0.5
-  FlowMapperEventDLQTopic:
-    name: flow.mapper.event.dlq
-    consumers:
-      - flow
-      - flowMapper
-    producers:
-      - flowMapper
-    config:
-  FlowStatusTopic:
-    name: flow.status
-    consumers:
-      - rest
-    producers:
-      - flow
-      - rest
-    config:
-      cleanup.policy: compact
-      segment.ms: 600000
-      delete.retention.ms: 300000
-      min.compaction.lag.ms: 60000
-      max.compaction.lag.ms: 604800000
-      min.cleanable.dirty.ratio: 0.5
   FlowMapperCleanupTopic:
     name: flow.mapper.cleanup
     consumers:

--- a/data/topic-schema/src/main/resources/net/corda/schema/Flow.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/Flow.yaml
@@ -19,6 +19,20 @@ topics:
     producers:
       - flow
     config:
+  FlowStatusTopic:
+    name: flow.status
+    consumers:
+      - rest
+    producers:
+      - flow
+      - rest
+    config:
+      cleanup.policy: compact
+      segment.ms: 600000
+      delete.retention.ms: 300000
+      min.compaction.lag.ms: 60000
+      max.compaction.lag.ms: 604800000
+      min.cleanable.dirty.ratio: 0.5
   FlowMapperCleanupTopic:
     name: flow.mapper.cleanup
     consumers:

--- a/data/topic-schema/src/main/resources/net/corda/schema/Flow.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/Flow.yaml
@@ -12,19 +12,6 @@ topics:
       - uniqueness
       - tokenSelection
     config:
-  FlowEventStateTopic:
-    name: flow.event.state
-    consumers:
-      - flow
-    producers:
-      - flow
-    config:
-      cleanup.policy: compact
-      segment.ms: 600000
-      delete.retention.ms: 300000
-      min.compaction.lag.ms: 60000
-      max.compaction.lag.ms: 604800000
-      min.cleanable.dirty.ratio: 0.5
   FlowEventDLQTopic:
     name: flow.event.dlq
     consumers:


### PR DESCRIPTION
This PR removes flow topics which are no longer used after the switch of some events from Kafka to synchronous HTTP/RPC. A PR build with these changes can be found here: https://github.com/corda/corda-runtime-os/pull/5171