### PR TITLE
CORE-17818: Api change to remove uniqueness checker duplication

### DIFF
--- a/data/topic-schema/src/main/java/net/corda/schema/Schemas.java
+++ b/data/topic-schema/src/main/java/net/corda/schema/Schemas.java
@@ -225,16 +225,6 @@ public final class Schemas {
     }
 
     /**
-     * Uniqueness checker schema.
-     */
-    public static final class UniquenessChecker {
-        private UniquenessChecker() {
-        }
-
-        public static final String UNIQUENESS_CHECK_TOPIC = "uniqueness.check";
-    }
-
-    /**
      * Virtual node schema.
      */
     public static final class VirtualNode {

--- a/data/topic-schema/src/main/resources/net/corda/schema/Flow.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/Flow.yaml
@@ -5,11 +5,8 @@ topics:
       - flow
     producers:
       - db
-      - crypto
       - flow
       - flowMapper
-      - persistence
-      - uniqueness
       - tokenSelection
     config:
   FlowEventDLQTopic:

--- a/data/topic-schema/src/main/resources/net/corda/schema/UniquenessChecker.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/UniquenessChecker.yaml
@@ -1,8 +1,0 @@
-topics:
-  UniquenessCheckTopic:
-    name: uniqueness.check
-    consumers:
-      - "uniqueness"
-    producers:
-      - "flow"
-    config:

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ cordaProductVersion = 5.2.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 10
+cordaApiRevision = 11
 
 # Main
 kotlinVersion = 1.8.21


### PR DESCRIPTION
This change is required as part of this PR https://github.com/corda/corda-runtime-os/pull/5184 to remove uniqueness checker duplication. This change will remove an unused uniqueness checker topic from the api.