### PR TITLE
CORE-18161: Put RBAC config values inside properties object

### DIFF
--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/rbac/1.0/corda.rbac.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/rbac/1.0/corda.rbac.json
@@ -10,22 +10,24 @@
       "description": "Settings for passwords.",
       "type": "object",
       "default": {},
-      "userPasswordChangeExpiry": {
-        "description": "The amount of time (days) before the password must be updated again after user password change.",
-        "type": "integer",
-        "minimum": 30,
-        "default": 90
-      },
-      "adminPasswordChangeExpiry": {
-        "description": "The amount of time (days) before the password must be updated again after admin password change",
-        "type": "integer",
-        "minimum": 1,
-        "default": 7
-      },
-      "passwordExpiryWarningWindow": {
-        "description": "The time (days) before a password expires in which we begin to offer warnings about upcoming expiry.",
-        "type": "integer",
-        "default": 30
+      "properties": {
+        "userPasswordChangeExpiry": {
+          "description": "The amount of time (days) before the password must be updated again after user password change.",
+          "type": "integer",
+          "minimum": 30,
+          "default": 90
+        },
+        "adminPasswordChangeExpiry": {
+          "description": "The amount of time (days) before the password must be updated again after admin password change",
+          "type": "integer",
+          "minimum": 1,
+          "default": 7
+        },
+        "passwordExpiryWarningWindow": {
+          "description": "The time (days) before a password expires in which we begin to offer warnings about upcoming expiry.",
+          "type": "integer",
+          "default": 30
+        }
       }
     }
   }


### PR DESCRIPTION
Puts RBAC config values in correct structure. This config was only added in 5.2 a couple of days ago, so this is only modifying the new config that will be used in the future in runtime-os. 

Needed for password endpoint changes here: https://github.com/corda/corda-runtime-os/pull/5189