### PR TITLE
CORE-18961: Up flow sandbox cache size to 20

### DIFF
--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/sandbox/1.0/corda.sandbox.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/sandbox/1.0/corda.sandbox.json
@@ -22,7 +22,7 @@
               "description": "The maximum number of cached flow sandboxes.",
               "type": "integer",
               "minimum": 0,
-              "default": 10
+              "default": 20
             }
           }
         }


### PR DESCRIPTION
Having a current limit of 10 may too low to allow E2E tests to pass given that we have a number of vNodes running flows concurrently during E2E tests execution. With current limit of 10, sandbox context for the currently running flow may be closed, resulting bundle de-activation and `ClassNotFoundException` on the initiated flow execution.

Tried with: https://github.com/corda/corda-runtime-os/pull/5260

Proven to have a positive effect on E2E run: https://ci02.dev.r3.com/job/Corda5/job/corda5-e2e-tests/job/PR-369/13/