### PR TITLE
ES-1747: remove unnecessary Gradle plugin reference

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -25,7 +25,6 @@ publicArtifactURL = https://download.corda.net/maven
 # dokka need more metaspace - https://github.com/Kotlin/dokka/issues/1405
 org.gradle.jvmargs=-Dfile.encoding=UTF-8 -XX:MaxMetaspaceSize=2g
 internalPluginVersion = 1.+
-artifactoryPluginVersion = 4.28.2
 
 gradleEnterpriseVersion = 3.14.1
 gradleDataPlugin = 1.8.2

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,7 +23,6 @@ mockitoVersion = "5.3.0"
 mockitoKotlinVersion = "5.2.1"
 
 # Plugins
-artifactoryVersion = "4.28.2"
 avroGradleVersion = "1.3.0"
 cyclonedxVersion = "1.7.4"
 dokkaVersion = "1.8.20"
@@ -78,7 +77,6 @@ test-runtime = ["junit-engine", "junit-platform"]
 
 [plugins]
 avro-gradle = { id = "com.github.davidmc24.gradle.plugin.avro-base", version.ref = "avroGradleVersion" }
-artifactory = { id = "com.jfrog.artifactory", version.ref = "artifactoryVersion" }
 cyclonedx-bom = { id = "org.cyclonedx.bom", version.ref = "cyclonedxVersion" }
 dependency-check-versions = { id = "com.github.ben-manes.versions", version.ref = "dependencyCheckVersion" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detektVersion" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -24,11 +24,9 @@ pluginManagement {
         }
 
     }
-
     plugins {
         id 'com.gradle.enterprise' version gradleEnterpriseVersion
         id 'com.gradle.common-custom-user-data-gradle-plugin' version gradleDataPlugin
-        id "com.jfrog.artifactory" version artifactoryPluginVersion
     }
 }
 plugins {


### PR DESCRIPTION
Remove direct reference to the `Artifactory` plugin, this is dead code and not required - The plugin is dynamically applied via the internal publishing plugin we maintain - we are declaring it in the project a second time for no reason. 

As such, the references in the `toml` file and `gradle.properties` are also being removed.  

I have verified publishing is unaffected by this, as can be observed in the logs of the PR gate shown below:

  ```
  00:16:39.378  :artifactoryDeploy (Thread[included builds Thread 2,5,main]) started.
  00:16:39.379  [pool-17-thread-3] Deploying artifact: https://software.r3.com/artifactory/corda-os-maven-unstable/net/corda/corda-api/5.2.0.17-alpha-1702663869186/corda-api-5.2.0.17-alpha-1702663869186.module
  00:16:39.379  [pool-17-thread-2] Deploying artifact: https://software.r3.com/artifactory/corda-os-maven-unstable/net/corda/corda-base/5.2.0.17-alpha-1702663869186/corda-base-5.2.0.17-alpha-1702663869186-javadoc.jar
  00:16:39.379  [pool-17-thread-1] Deploying artifact: https://software.r3.com/artifactory/corda-os-maven-unstable/net/corda/corda-application/5.2.0.17-alpha-1702663869186/corda-application-5.2.0.17-alpha-1702663869186-javadoc.jar
  00:16:39.637  [pool-17-thread-3] Deploying artifact: https://software.r3.com/artifactory/corda-os-maven-unstable/net/corda/corda-api/5.2.0.17-alpha-1702663869186/corda-api-5.2.0.17-alpha-1702663869186.pom
  and so on ....
```