### PR TITLE
ES-1755: Allow use of TOML file in settings.gradle to leverage version catalog and thus dependabot updates

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -26,8 +26,6 @@ publicArtifactURL = https://download.corda.net/maven
 org.gradle.jvmargs=-Dfile.encoding=UTF-8 -XX:MaxMetaspaceSize=2g
 internalPluginVersion = 1.+
 
-gradleEnterpriseVersion = 3.14.1
-gradleDataPlugin = 1.8.2
 org.gradle.caching = true
 gradleEnterpriseUrl = https://gradle.dev.r3.com
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -22,11 +22,28 @@ pluginManagement {
             }
             gradlePluginPortal()
         }
-
     }
+
+    // Manually parse the Toml file to workaround issues with version catalog
+    // not supporting direct use in settings.gradle
+    def tomlFile = new File(rootDir, 'gradle/libs.versions.toml')
+    def tomlContent = tomlFile.text
+    def extractVersion = { String name ->
+        def pattern = java.util.regex.Pattern.compile("${name}\\s*=\\s*\"([^\"]+)\"")
+        def matcher = pattern.matcher(tomlContent)
+        if (matcher.find()) {
+            return matcher.group(1)
+        } else {
+            return null
+        }
+    }
+
+    def gradleEnterpriseVersion = extractVersion('gradleEnterpriseVersion')
+    def gradleDataPluginVersion = extractVersion('gradleDataVersion')
+
     plugins {
         id 'com.gradle.enterprise' version gradleEnterpriseVersion
-        id 'com.gradle.common-custom-user-data-gradle-plugin' version gradleDataPlugin
+        id 'com.gradle.common-custom-user-data-gradle-plugin' version gradleDataPluginVersion
     }
 }
 plugins {


### PR DESCRIPTION
This change provides a workaround for some limitations of the Gradle version catalog, namely that it is not natively readable from `settings.gradle` due to the order of resolution by Gradle's builds life cycle when evaluating settings.gradle and the TOML file in the gradle directory.

To get around this, We manually parse the `TOML` file, using standard Groovy means, to return the version in question, using a Regex pattern to parse the file, then return the version e.g. for an entry in the TOML file like `gradleEnterpriseVersion = "3.14.1" ` just `3.14.1` would be returned and then passed as the plugin parameter.

This allows us to continue to leverage the version catalogue for items which must be declared in settings.gradle.

Further reading is available [here ](https://discuss.gradle.org/t/how-to-use-version-catalog-in-the-root-settings-gradle-kts-file/44603/2) on Gradles forums, where a solution similar to this is suggested by one of their engineers regarding using the Gradle Enterprise plugins with a  version catalog.