### PR TITLE
CORE-18553: Add response type from link manager to the gateway

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/gateway/LinkManagerResponse.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/gateway/LinkManagerResponse.avsc
@@ -1,0 +1,16 @@
+{
+  "type": "record",
+  "name": "LinkManagerResponse",
+  "namespace": "net.corda.data.p2p.gateway",
+  "doc": "A response from the p2p link manager to the p2p gateway component",
+  "fields": [
+    {
+      "name": "payload",
+      "type": [
+        "null",
+        "net.corda.data.p2p.crypto.AuthenticatedEncryptedDataMessage",
+        "net.corda.data.p2p.crypto.AuthenticatedDataMessage"
+      ]
+    }
+  ]
+}

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/linkmanager/LinkManagerResponse.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/linkmanager/LinkManagerResponse.avsc
@@ -1,8 +1,8 @@
 {
   "type": "record",
   "name": "LinkManagerResponse",
-  "namespace": "net.corda.data.p2p.gateway",
-  "doc": "A response from the p2p link manager to the p2p gateway component",
+  "namespace": "net.corda.data.p2p.linkmanager",
+  "doc": "A response from the p2p link manager when being sent a LinkInMessage via the HTTP endpoint",
   "fields": [
     {
       "name": "payload",

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ cordaProductVersion = 5.2.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 23
+cordaApiRevision = 26
 
 # Main
 kotlin.stdlib.default.dependency = false

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ cordaProductVersion = 5.2.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 26
+cordaApiRevision = 24
 
 # Main
 kotlin.stdlib.default.dependency = false


### PR DESCRIPTION
Introduce a type to wrap the responses from the link manager to the gateway.

Runtime pull request is in https://github.com/corda/corda-runtime-os/pull/5322