### PR TITLE
CORE-2840: Remove no longer needed package exports

### DIFF
--- a/data/topic-schema/src/main/java/net/corda/p2p/schema/package-info.java
+++ b/data/topic-schema/src/main/java/net/corda/p2p/schema/package-info.java
@@ -1,4 +1,0 @@
-@Export
-package net.corda.p2p.schema;
-
-import org.osgi.annotation.bundle.Export;

--- a/data/topic-schema/src/main/java/net/corda/rpc/schema/package-info.java
+++ b/data/topic-schema/src/main/java/net/corda/rpc/schema/package-info.java
@@ -1,4 +1,0 @@
-@Export
-package net.corda.rpc.schema;
-
-import org.osgi.annotation.bundle.Export;


### PR DESCRIPTION
The packages are no longer necessary and should not be exported.
This is a non-breaking change.