### PR TITLE
CORE-18539: New "maxIdleTime" Flow Property

### DIFF
--- a/data/config-schema/src/main/java/net/corda/schema/configuration/FlowConfig.java
+++ b/data/config-schema/src/main/java/net/corda/schema/configuration/FlowConfig.java
@@ -14,4 +14,5 @@ public final class FlowConfig {
     public static final String PROCESSING_MAX_RETRY_DELAY = "processing.maxRetryDelay";
     public static final String PROCESSING_MAX_FLOW_SLEEP_DURATION = "processing.maxFlowSleepDuration";
     public static final String PROCESSING_FLOW_CLEANUP_TIME = "processing.cleanupTime";
+    public static final String PROCESSING_MAX_IDLE_TIME = "processing.maxIdleTime";
 }

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/flow/1.0/corda.flow.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/flow/1.0/corda.flow.json
@@ -39,6 +39,13 @@
           "maximum": 2147483647,
           "default": 900000
         },
+        "maxIdleTime": {
+          "description": "The maximum time, in milliseconds, a Flow can be in 'RUNNING' state without receiving any updates. Once this time has elapsed, Corda will automatically mark the flow as 'FAILED' and clean up any associated state.",
+          "type": "integer",
+          "minimum": 60000,
+          "maximum": 31557600000,
+          "default": 300000
+        },
         "cleanupTime": {
           "description": "The length of time in milliseconds that the flow mapper holds onto its state for a flow that has finished. This value should be at least 2 times larger than the session.p2pTTL.",
           "type": "integer",


### PR DESCRIPTION
Add new property, "maxIdleTime", to the flow configuration so that
users can tune how long a flow can be in 'RUNNING' state without
receiving any updates before Corda marks the flow as 'FAILED' and
deletes any associated state.
