### PR TITLE
CORE-19016 avro object to store a list of bus bound output records from a mediator processor.

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/messaging/mediator/OutputRecord.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/messaging/mediator/OutputRecord.avsc
@@ -1,0 +1,23 @@
+{
+  "type": "record",
+  "name": "OutputRecord",
+  "namespace": "net.corda.data.messaging.mediator",
+  "doc": "Holds the contents of a bus bound output record from the mediator processor",
+  "fields": [
+	{
+		"name": "topic",
+		"type": "string",
+		"doc": "The topic to send the record"
+	},
+    {
+      "name": "key",
+      "type": "bytes",
+      "doc": "The avro serialized bytes of the key of the record"
+    },
+    {
+      "name": "value",
+      "type": "bytes",
+      "doc": "The avro serialized bytes of the value of the record"
+    }
+  ]
+}

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/messaging/mediator/OutputRecords.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/messaging/mediator/OutputRecords.avsc
@@ -1,0 +1,16 @@
+{
+  "type": "record",
+  "name": "OutputRecords",
+  "namespace": "net.corda.data.messaging.mediator",
+  "doc": "Holds all output records from the mediator processor as a single object that are to be sent to the bus",
+  "fields": [
+	{
+		"name": "outputRecords",
+        "type": {
+          "type": "array",
+          "items": "net.corda.data.messaging.mediator.OutputRecord"
+        },
+		"doc": "The bus bound output records from a mediator processor"
+	}
+  ]
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ cordaProductVersion = 5.2.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 26
+cordaApiRevision = 999
 
 # Main
 kotlin.stdlib.default.dependency = false


### PR DESCRIPTION
This allows the outputs to be avro serialized as bytes and then be stored in the state storage