### PR TITLE
CORE-19330: FlowTimeout Reason

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/flow/FlowTimeout.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/flow/FlowTimeout.avsc
@@ -9,6 +9,11 @@
         "type": "string",
         "doc": "Key for the state record that is storing the checkpoint."
       },
+    {
+      "name": "reason",
+      "type": "string",
+      "doc": "Optional message indicating the underlying reason about why the flow is being timed out; used as the 'errorMessage' when marking the flow as 'FAILED'."
+    },
       {
         "name": "timeoutDateTime",
         "type": {

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/flow/FlowTimeout.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/flow/FlowTimeout.avsc
@@ -12,6 +12,7 @@
     {
       "name": "reason",
       "type": "string",
+      "default": "",
       "doc": "Optional message indicating the underlying reason about why the flow is being timed out; used as the 'errorMessage' when marking the flow as 'FAILED'."
     },
       {

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ cordaProductVersion = 5.2.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = JR
+cordaApiRevision = 31
 
 # Main
 kotlin.stdlib.default.dependency = false

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ cordaProductVersion = 5.2.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 30
+cordaApiRevision = JR
 
 # Main
 kotlin.stdlib.default.dependency = false


### PR DESCRIPTION
Add new 'reason' property to the 'FlowTimeout' schema so that the
platform can fully report to usser why a particular flow was timed out.
