### PR TITLE
CORE-19368 Managed key rotation

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/ops/key/rotation/IndividualKeyRotationRequest.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/ops/key/rotation/IndividualKeyRotationRequest.avsc
@@ -17,22 +17,22 @@
     {
       "name": "oldParentKeyAlias",
       "type": ["null", "string"],
-      "doc": "For unmanaged key rotation. The key alias whose protected content will be re-wrapped with a new key."
+      "doc": "Mandatory for unmanaged key rotation only, always null for managed key rotation. The key alias whose protected content will be re-wrapped with a new key."
     },
     {
       "name": "newParentKeyAlias",
       "type": ["null", "string"],
-      "doc": "For unmanaged key rotation. The new wrapping key which oldParentKeyAlias' content will be re-wrapped with."
+      "doc": "Mandatory for unmanaged key rotation only, always null for managed key rotation. The new wrapping key which oldParentKeyAlias' content will be re-wrapped with."
     },
     {
       "name": "targetKeyAlias",
       "type": ["null", "string"],
-      "doc": "For unmanaged key rotation. Specifies the wrapped key to rotate."
+      "doc": "Mandatory for unmanaged key rotation only, always null for managed key rotation. Specifies the wrapped key to rotate."
     },
         {
       "name": "keyUuid",
       "type": ["null", "string"],
-      "doc": "For managed key rotation. Specifies the managed wrapping key id to rotate."
+      "doc": "Mandatory for managed key rotation only, always null for unmanaged key rotation. Specifies the managed wrapping key id to rotate."
     },
     {
       "name": "keyType",

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/ops/key/rotation/IndividualKeyRotationRequest.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/ops/key/rotation/IndividualKeyRotationRequest.avsc
@@ -16,18 +16,23 @@
     },
     {
       "name": "oldParentKeyAlias",
-      "type": "string",
-      "doc": "The key alias whose protected content will be re-wrapped with a new key."
+      "type": ["null", "string"],
+      "doc": "For unmanaged key rotation. The key alias whose protected content will be re-wrapped with a new key."
     },
     {
       "name": "newParentKeyAlias",
-      "type": "string",
-      "doc": "The new wrapping key which oldParentKeyAlias' content will be re-wrapped with."
+      "type": ["null", "string"],
+      "doc": "For unmanaged key rotation. The new wrapping key which oldParentKeyAlias' content will be re-wrapped with."
     },
     {
       "name": "targetKeyAlias",
-      "type": "string",
-      "doc": "Specifies the wrapped key to rotate."
+      "type": ["null", "string"],
+      "doc": "For unmanaged key rotation. Specifies the wrapped key to rotate."
+    },
+        {
+      "name": "keyUuid",
+      "type": ["null", "string"],
+      "doc": "For managed key rotation. Specifies the managed wrapping key id to rotate."
     },
     {
       "name": "keyType",

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/ops/key/rotation/KeyRotationRequest.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/ops/key/rotation/KeyRotationRequest.avsc
@@ -21,17 +21,17 @@
     {
       "name": "oldParentKeyAlias",
       "type": ["null", "string"],
-      "doc": "For unmanaged key rotation. The key alias that should no longer be used, and all its protected content re-wrapped with a new key."
+      "doc": "Mandatory for unmanaged key rotation only, always null for managed key rotation. The key alias that should no longer be used, and all its protected content re-wrapped with a new key."
     },
     {
       "name": "newParentKeyAlias",
       "type": ["null", "string"],
-      "doc": "For unmanaged key rotation. The unmanaged key alias that should be used for material currently wrapped with old key."
+      "doc": "Mandatory for unmanaged key rotation only, always null for managed key rotation. The unmanaged key alias that should be used for material currently wrapped with old key."
     },
     {
       "name": "tenantId",
       "type": ["null", "string"],
-      "doc": "For managed key rotation. Specifies the specific tenant for which managed wrapping keys will be rotated."
+      "doc": "Mandatory for managed key rotation only, always null for unmanaged key rotation. Specifies the specific tenant for which managed wrapping keys will be rotated."
     }
   ]
 }

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/ops/key/rotation/KeyRotationRequest.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/ops/key/rotation/KeyRotationRequest.avsc
@@ -21,22 +21,17 @@
     {
       "name": "oldParentKeyAlias",
       "type": ["null", "string"],
-      "doc": "The key alias that should no longer be used, and all its protected content re-wrapped with a new key."
+      "doc": "For unmanaged key rotation. The key alias that should no longer be used, and all its protected content re-wrapped with a new key."
     },
     {
       "name": "newParentKeyAlias",
       "type": ["null", "string"],
-      "doc": "The unmanaged key alias that should be used for material currently wrapped with old key. Only specified when rotating unmanaged keys."
-    },
-    {
-      "name": "oldGeneration",
-      "type": ["null", "int"],
-      "doc": "Specifies the old generation number we should move away from. If absent, rotate all matching keys."
+      "doc": "For unmanaged key rotation. The unmanaged key alias that should be used for material currently wrapped with old key."
     },
     {
       "name": "tenantId",
       "type": ["null", "string"],
-      "doc": "Only specified when targeting managed keys. Specifies the specific tenant that owns the old and new key."
+      "doc": "For managed key rotation. Specifies the specific tenant for which managed wrapping keys will be rotated."
     }
   ]
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ cordaProductVersion = 5.2.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 29
+cordaApiRevision = 30
 
 # Main
 kotlin.stdlib.default.dependency = false


### PR DESCRIPTION
Changes (breaking) to 5.2 introduced key rotation messages to accommodate managed key rotation. Changes are
- Made the unmanaged key rotation fields optional (nullable)
- Removed "old generation" because you always and only rotate from the latest generation
- Added keyUuid which is the input for managed key rotation

runtime-os changes to accommodate these changes here: https://github.com/corda/corda-runtime-os/pull/5489