### PR TITLE
CORE-18617: Add new parent key alias and created timestamp into the key rotation status

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/ops/key.status/UnmanagedKeyStatus.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/ops/key.status/UnmanagedKeyStatus.avsc
@@ -5,9 +5,14 @@
   "doc": "Defines the key status and key rotation status data.",
   "fields": [
     {
-      "name": "rootKeyAlias",
+      "name": "oldParentKeyAlias",
       "type": "string",
       "doc": "Alias of an unmanaged key that we are rotating away from."
+    },
+    {
+      "name": "newParentKeyAlias",
+      "type": ["null", "string"],
+      "doc": "The wrapping key alias that should be used for material currently wrapped with old key."
     },
     {
       "name": "total",
@@ -18,6 +23,14 @@
       "name": "rotatedKeys",
       "type": ["null", "int"],
       "doc": "Number of keys for tenantId that has been rotated. Null in case of key status."
+    },
+    {
+      "name": "createdTimestamp",
+      "type": {
+        "type": "long",
+        "logicalType": "timestamp-millis"
+      },
+      "doc": "The date and time the key rotation request was created."
     }
   ]
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ cordaProductVersion = 5.2.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 31
+cordaApiRevision = 32
 
 # Main
 kotlin.stdlib.default.dependency = false


### PR DESCRIPTION
**Changes**:
* update unmanaged key rotation status schema to also contain new parent key alias and created timestamp so we can print it out on key rotation status request
* renaming `rootKeyAlias` -> `oldParentKeyAlias` is not a breaking change as `UnmanagedKeyStatus` was only introduced in 5.2

Runtime-os PR: [5500](https://github.com/corda/corda-runtime-os/pull/5500)