### PR TITLE
CORE-19416 Update documentation for "flow.timeout" configuration

### DIFF
--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/flow/1.0/corda.flow.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/flow/1.0/corda.flow.json
@@ -90,7 +90,7 @@
           "default": 300000
         },
         "timeout": {
-          "description": "The length of time in milliseconds that Corda waits when no message has been received from a counterparty before causing the session to error.",
+          "description": "The length of time in milliseconds that Corda waits when no message has been received from a counterparty before causing the session to error. This value may be overridden by a flow specific timeout set via FlowMessaging API. ",
           "type": "integer",
           "minimum": 1000,
           "maximum": 2147483647,

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/flow/1.0/corda.flow.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/flow/1.0/corda.flow.json
@@ -90,7 +90,7 @@
           "default": 300000
         },
         "timeout": {
-          "description": "The length of time in milliseconds that Corda waits when no message has been received from a counterparty before causing the session to error. This value may be overridden by a flow specific timeout set via FlowMessaging API. ",
+          "description": "The length of time in milliseconds that Corda waits when no message has been received from a counterparty before causing the session to error. This value may be overridden by a flow specific timeout set via the FlowMessaging API. ",
           "type": "integer",
           "minimum": 1000,
           "maximum": 2147483647,


### PR DESCRIPTION
Updated documentation for "flow.timeout" configuration to note that it can be overridden by FlowMessaging API.