### PR TITLE
CORE-19403 - Ensure one of the strings `ext` or `EXT` are part of the Kafka topic used by the external messaging service

### DIFF
--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/externalMessaging/1.0/corda.externalMessaging.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/externalMessaging/1.0/corda.externalMessaging.json
@@ -13,7 +13,7 @@
         "receiveTopicPattern": {
           "type": "string",
           "default": "ext.$HOLDING_ID.$CHANNEL_NAME.receive",
-          "pattern": "^([a-zA-Z0-9\\._\\-]|\\$HOLDING_ID|\\$CHANNEL_NAME){1,100}$",
+          "pattern": "^([a-zA-Z0-9\\._\\-]){0,100}(ext|EXT)([a-zA-Z0-9\\._\\-]|\\$HOLDING_ID|\\$CHANNEL_NAME){1,100}$",
           "description": "The pattern used to generate the external app receiving topic. When creating routes, Corda replaces any placeholders with the virtual node specific values. "
         },
         "active": {


### PR DESCRIPTION
This change change will prevent people from accidently sending messages to topics that should be used exclusively by the workers.