### PR TITLE
CORE-18960 Managed key status

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/ops/key.status/ManagedKeyStatus.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/ops/key.status/ManagedKeyStatus.avsc
@@ -1,0 +1,31 @@
+{
+  "type": "record",
+  "name": "ManagedKeyStatus",
+  "namespace": "net.corda.data.crypto.wire.ops.key.status",
+  "doc": "Defines the key status and key rotation status data for managed keys.",
+  "fields": [
+    {
+      "name": "wrappingKeyAlias",
+      "type": "string",
+      "doc": "Alias of a managed wrapping key that we are rotating."
+    },
+    {
+      "name": "total",
+      "type": "int",
+      "doc": "Total number of keys that need rotating away from the original wrapping key."
+    },
+    {
+      "name": "rotatedKeys",
+      "type": ["null", "int"],
+      "doc": "Number of keys that have been rotated away from the original wrapping key. Null in case of key status."
+    },
+    {
+      "name": "createdTimestamp",
+      "type": {
+        "type": "long",
+        "logicalType": "timestamp-millis"
+      },
+      "doc": "The date and time the key rotation request was created."
+    }
+  ]
+}

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/ops/key.status/UnmanagedKeyStatus.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/ops/key.status/UnmanagedKeyStatus.avsc
@@ -2,7 +2,7 @@
   "type": "record",
   "name": "UnmanagedKeyStatus",
   "namespace": "net.corda.data.crypto.wire.ops.key.status",
-  "doc": "Defines the key status and key rotation status data.",
+  "doc": "Defines the key status and key rotation status data for unmanaged keys.",
   "fields": [
     {
       "name": "oldParentKeyAlias",


### PR DESCRIPTION
Added managed key status avro type. This is the type which is stored in state manager for key status and rotation status. It is the equivalent of the existing unmanaged key status but for managed keys.