### PR TITLE
CORE-19029 - restricted state types

### DIFF
--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/stateManager/1.0/corda.stateManager.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/stateManager/1.0/corda.stateManager.json
@@ -4,6 +4,9 @@
   "title": "Corda State Manager Configuration Schema",
   "description": "Configuration schema for the State Manager section. This configures the interactions of the workers with the underlying persistent storage used by the out of process State Manager.",
   "type": "object",
+  "propertyNames": {
+    "$ref": "#/$defs/validStateTypes"
+  },
   "additionalProperties": {
     "type": "object",
     "$ref": "#/$defs/stateTypeConfig"
@@ -44,6 +47,16 @@
             ]
           }
         }
+      ]
+    },
+    "validStateTypes": {
+      "enum": [
+        "flowCheckpoint",
+        "flowMapping",
+        "flowStatus",
+        "keyRotation",
+        "p2pSession",
+        "tokenPoolCache"
       ]
     }
   }


### PR DESCRIPTION
Restrict the state types for state manager config schema. (Note this config schema only exists on local worker cache, not on message bus or config database table).

The following json is invalid due to "sss" not existing in the valid state type set:

```
{
  "sss": {
    "database": {
      "jdbc": {
        "driver": "org.postgresql.Driver",
        "url": "jdbc:postgresql://localhost:5432/cordacluster?currentSchema=STATE_MANAGER"
      },
      "pass": "password",
      "pool": {
        "idleTimeoutSeconds": 120,
        "keepAliveTimeSeconds": 0,
        "maxLifetimeSeconds": 1800,
        "maxSize": 5,
        "minSize": 0,
        "validationTimeoutSeconds": 5
      },
      "user": "user"
    },
    "type": "DATABASE"
  }
}
```