### PR TITLE
CORE-19425 - server side pool url

### DIFF
--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/db/1.0/corda.db.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/db/1.0/corda.db.json
@@ -37,6 +37,11 @@
               "description": "The JDBC URL.",
               "type": "string",
               "default": "jdbc:postgresql://cluster-db:5432/cordacluster"
+            },
+            "serversidePoolerUrl": {
+              "description": "The JDBC URL for the connection pooler if used (optional). When not set or empty, connections will always fall back to `url`",
+              "type": "string",
+              "default": ""
             }
           },
           "additionalProperties": false


### PR DESCRIPTION
Expose optional `serversidePoolerUrl` configuration attribute to accommodate application changes where we explicitly want to avoid the pooler.
