### PR TITLE
CORE-19485: Introduce `password.lengthLimit` config option for RBAC

### DIFF
--- a/data/config-schema/src/main/java/net/corda/schema/configuration/ConfigKeys.java
+++ b/data/config-schema/src/main/java/net/corda/schema/configuration/ConfigKeys.java
@@ -1,6 +1,7 @@
 package net.corda.schema.configuration;
 
 /** The keys for various configurations for a worker. */
+@SuppressWarnings("unused")
 public final class ConfigKeys {
     private ConfigKeys() {
     }
@@ -42,6 +43,7 @@ public final class ConfigKeys {
     public static final String RBAC_USER_PASSWORD_CHANGE_EXPIRY = "password.userPasswordChangeExpiry";
     public static final String RBAC_ADMIN_PASSWORD_CHANGE_EXPIRY = "password.adminPasswordChangeExpiry";
     public static final String RBAC_PASSWORD_EXPIRY_WARNING_WINDOW = "password.passwordExpiryWarningWindow";
+    public static final String RBAC_PASSWORD_LENGTH_LIMIT = "password.lengthLimit";
     // Secrets Service
     // 
     // SECRETS_TYPE control which secrets service implementation will be selected.

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/rbac/1.0/corda.rbac.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/rbac/1.0/corda.rbac.json
@@ -27,6 +27,13 @@
           "description": "The time (days) before a password expires in which we begin to offer warnings about upcoming expiry.",
           "type": "integer",
           "default": 30
+        },
+        "lengthLimit" : {
+          "description": "The maximum number of characters to be used when assigning a password to a user.",
+          "type": "integer",
+          "minimum": 10,
+          "maximum": 1000,
+          "default": 255
         }
       }
     }


### PR DESCRIPTION
This is a non-breaking change and it is being used by `corda-runtime-os` PR: https://github.com/corda/corda-runtime-os/pull/5564