### PR TITLE
CORE-19490 Adding topics, task names and config values for schedule FlowStatus cleanup processor

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/rest/ExecuteFlowStatusCleanup.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/rest/ExecuteFlowStatusCleanup.avsc
@@ -1,0 +1,16 @@
+{
+  "type": "record",
+  "name": "ExecuteFlowStatusCleanup",
+  "docs": "When this event is processed the listed FlowKeys should be deleted from the flow status lookup service store",
+  "namespace": "net.corda.data.rest",
+  "fields": [
+    {
+      "name": "keys",
+      "docs": "A list of FlowKeys for flow states that should be deleted",
+      "type": {
+        "type": "array",
+        "items": "string"
+      }
+    }
+  ]
+}

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/rest/ExecuteFlowStatusCleanup.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/rest/ExecuteFlowStatusCleanup.avsc
@@ -1,15 +1,33 @@
 {
   "type": "record",
-  "name": "ExecuteFlowStatusCleanup",
-  "docs": "When this event is processed the listed FlowKeys should be deleted from the flow status lookup service store",
+  "name": "FlowStatusRecord",
+  "docs": "This record represents the fingerprint of a specific FlowStatus in state storage, holding its key and its version",
   "namespace": "net.corda.data.rest",
   "fields": [
     {
-      "name": "keys",
+      "name": "key",
+      "type": "string"
+    },
+    {
+      "name": "version",
+      "type": "string"
+    }
+  ]
+}
+
+
+{
+  "type": "record",
+  "name": "ExecuteFlowStatusCleanup",
+  "docs": "When this event is processed the listed FlowStatus records should be deleted from the flow status lookup service store",
+  "namespace": "net.corda.data.rest",
+  "fields": [
+    {
+      "name": "records",
       "docs": "A list of FlowKeys for flow states that should be deleted",
       "type": {
         "type": "array",
-        "items": "string"
+        "items": "net.corda.data.rest.FlowStatusRecord"
       }
     }
   ]

--- a/data/config-schema/src/main/java/net/corda/schema/configuration/ConfigKeys.java
+++ b/data/config-schema/src/main/java/net/corda/schema/configuration/ConfigKeys.java
@@ -38,7 +38,7 @@ public final class ConfigKeys {
     public static final String REST_AZUREAD_CLIENT_SECRET = "sso.azureAd.clientSecret";
     public static final String REST_AZUREAD_TENANT_ID = "sso.azureAd.tenantId";
     public static final String REST_WEBSOCKET_CONNECTION_IDLE_TIMEOUT_MS = "websocket.idleTimeoutMs";
-    public static final String REST_FLOW_STATUS_CLEANUP_TIME_MS = "flowStatusCleanupTime";
+    public static final String REST_FLOW_STATUS_CLEANUP_TIME_MS = "flowStatusCleanupTimeMs";
 
     // RBAC
     public static final String RBAC_USER_PASSWORD_CHANGE_EXPIRY = "password.userPasswordChangeExpiry";

--- a/data/config-schema/src/main/java/net/corda/schema/configuration/ConfigKeys.java
+++ b/data/config-schema/src/main/java/net/corda/schema/configuration/ConfigKeys.java
@@ -38,6 +38,7 @@ public final class ConfigKeys {
     public static final String REST_AZUREAD_CLIENT_SECRET = "sso.azureAd.clientSecret";
     public static final String REST_AZUREAD_TENANT_ID = "sso.azureAd.tenantId";
     public static final String REST_WEBSOCKET_CONNECTION_IDLE_TIMEOUT_MS = "websocket.idleTimeoutMs";
+    public static final String REST_FLOW_STATUS_CLEANUP_TIME_MS = "flowStatusCleanupTime";
 
     // RBAC
     public static final String RBAC_USER_PASSWORD_CHANGE_EXPIRY = "password.userPasswordChangeExpiry";

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/rest/1.0/corda.rest.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/rest/1.0/corda.rest.json
@@ -62,6 +62,13 @@
           "default": 30000
         }
       }
+    },
+    "flowStatusCleanupTime": {
+      "description": "The duration, in milliseconds, for which the flow status lookup service retains flow statuses in terminal states (COMPLETED, FAILED, KILLED) without updates. After this period, they are deleted. This must be greater than flow.session.cleanupTime and flow.processing.cleanupTime otherwise flows with re-used requestIds may be swallowed by the FlowMapper.",
+      "type": "integer",
+      "minimum": 600000,
+      "maximum:": 2147483647,
+      "default": 604800000
     }
   }
 }

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/rest/1.0/corda.rest.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/rest/1.0/corda.rest.json
@@ -64,7 +64,7 @@
       }
     },
     "flowStatusCleanupTime": {
-      "description": "The duration, in milliseconds, for which the flow status lookup service retains flow statuses in terminal states (COMPLETED, FAILED, KILLED) without updates. After this period, they are deleted. This must be greater than flow.session.cleanupTime and flow.processing.cleanupTime otherwise flows with re-used requestIds may be swallowed by the FlowMapper.",
+      "description": "The duration, in milliseconds, for which the flow status lookup service retains flow statuses in terminal states (COMPLETED, FAILED, KILLED) without updates. After this period, they are deleted. This must be greater than flow.session.cleanupTime and flow.processing.cleanupTime otherwise flows with re-used requestIds may be silently de-duplicated by the FlowMapper.",
       "type": "integer",
       "minimum": 600000,
       "maximum:": 2147483647,

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/rest/1.0/corda.rest.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/rest/1.0/corda.rest.json
@@ -63,7 +63,7 @@
         }
       }
     },
-    "flowStatusCleanupTime": {
+    "flowStatusCleanupTimeMs": {
       "description": "The duration, in milliseconds, for which the flow status lookup service retains flow statuses in terminal states (COMPLETED, FAILED, KILLED) without updates. After this period, they are deleted. This must be greater than flow.session.cleanupTime and flow.processing.cleanupTime otherwise flows with re-used requestIds may be silently de-duplicated by the FlowMapper.",
       "type": "integer",
       "minimum": 600000,

--- a/data/topic-schema/src/main/java/net/corda/schema/Schemas.java
+++ b/data/topic-schema/src/main/java/net/corda/schema/Schemas.java
@@ -252,6 +252,8 @@ public final class Schemas {
         public static final String SCHEDULED_TASK_NAME_MAPPER_CLEANUP = "flow-mapper-state-cleanup";
         public static final String SCHEDULED_TASK_TOPIC_FLOW_PROCESSOR = "scheduled.task.flow.processor";
         public static final String SCHEDULED_TASK_NAME_SESSION_TIMEOUT = "flow-session-timeout";
+        public static final String SCHEDULED_TASK_TOPIC_FLOW_STATUS_PROCESSOR = "scheduled.task.flow.status.processor";
+        public static final String SCHEDULE_TASK_NAME_FLOW_STATUS_CLEANUP = "flow-status-cleanup";
 
     }
 }

--- a/data/topic-schema/src/main/java/net/corda/schema/Schemas.java
+++ b/data/topic-schema/src/main/java/net/corda/schema/Schemas.java
@@ -223,6 +223,7 @@ public final class Schemas {
         public static final String REST_PERM_GROUP_TOPIC = "rest.permissions.group";
         public static final String REST_PERM_ROLE_TOPIC = "rest.permissions.role";
         public static final String REST_PERM_ENTITY_TOPIC = "rest.permissions.permission";
+        public static final String REST_FLOW_STATUS_CLEANUP_TOPIC = "rest.flow.status.cleanup";
     }
 
     /**

--- a/data/topic-schema/src/main/resources/net/corda/schema/Rest.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/Rest.yaml
@@ -70,7 +70,7 @@ topics:
       max.compaction.lag.ms: 604800000
       min.cleanable.dirty.ratio: 0.5
   RestFlowStatusCleanupTopic:
-    name: rest.permissions.role
+    name: rest.flow.status.cleanup
     consumers:
       - rest
     producers:

--- a/data/topic-schema/src/main/resources/net/corda/schema/Rest.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/Rest.yaml
@@ -69,3 +69,10 @@ topics:
       min.compaction.lag.ms: 60000
       max.compaction.lag.ms: 604800000
       min.cleanable.dirty.ratio: 0.5
+  RestFlowStatusCleanupTopic:
+    name: rest.permissions.role
+    consumers:
+      - rest
+    producers:
+      - rest
+    config:

--- a/data/topic-schema/src/main/resources/net/corda/schema/ScheduledTask.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/ScheduledTask.yaml
@@ -17,3 +17,9 @@ topics:
       - flow
     producers:
       - db
+  ScheduledTaskFlowStatusProcessorTopic:
+    name: scheduled.task.flow.status.processor
+    consumers:
+      - rest
+    producers:
+      - rest


### PR DESCRIPTION
This PR is part of the **CORE-19435** epic, and supports us in adding a scheduled job to clean-up stale flow statuses from the StateManager which backs the `getStatus()` REST endpoint.

Added:
1. The Kafka topic `scheduled.task.flow.status.processor` to which we will post scheduled FlowStatusCleanup jobs.
2. The Kafka topic `rest.flow.status.cleanup` where batches of stale FlowKeys to be cleaned up will be posted, as determined during the FlowStatusCleanup job.
3. An avro object, `FlowStatusRecord`, which contains the 'fingerprint' (key, version) of a FlowStatus in state storage.
4. An avro object, `ExecuteFlowStatusCleanup`, which will be posted to the `rest.flow.status.cleanup` topic and will contain the **FlowStatusRecords** to be deleted.
5. A new REST config, `flowStatusCleanupTime`, which determines how long a FlowStatus in a terminated state can remain idle (no updates) before it's deleted. Default: 7 days.
6. The task name for the FlowStatusCleanup job, `flow-status-cleanup`.
7. Permission config for the newly created Kafka topics.
