### PR TITLE
CORE-19519 persist transaction signatures request

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/ledger/persistence/LedgerPersistenceRequest.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/ledger/persistence/LedgerPersistenceRequest.avsc
@@ -42,7 +42,8 @@
         "net.corda.data.ledger.persistence.FindSignedLedgerTransaction",
         "net.corda.data.ledger.persistence.FindTransactionIdsAndStatuses",
         "net.corda.data.ledger.persistence.PersistMerkleProofIfDoesNotExist",
-        "net.corda.data.ledger.persistence.FindMerkleProofs"
+        "net.corda.data.ledger.persistence.FindMerkleProofs",
+        "net.corda.data.ledger.persistence.PersistTransactionSignatures"
       ]
     },
     {

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/ledger/persistence/PersistTransactionSignatures.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/ledger/persistence/PersistTransactionSignatures.avsc
@@ -1,0 +1,26 @@
+{
+  "type": "record",
+  "name": "PersistTransactionSignatures",
+  "doc": "Persist new transactions signatures. One of several types of ledger persistence request {@link LedgerPersistenceRequest}",
+  "namespace": "net.corda.data.ledger.persistence",
+  "fields": [
+    {
+      "name": "id",
+      "type": "string",
+      "doc": "The transaction ID, derived from the root hash of its Merkle tree"
+    },
+    {
+      "name": "startingIndex",
+      "type": "int",
+      "doc": "The index to insert the new signatures from"
+    },
+    {
+      "name": "signatures",
+      "type": {
+        "type" : "array",
+        "items" : "bytes"
+      },
+      "doc": "the new signatures to persist"
+    }
+  ]
+}


### PR DESCRIPTION
Introduce a dedicated PersistTransactionSignatures call to avoid persisting the whole transaction again when only signatures have been added.

Runtime: https://github.com/corda/corda-runtime-os/pull/5579