### PR TITLE
CORE-19494 Reducing flowStatusCleanupTime from 10 minutes to 1 minute for QA testing

### DIFF
--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/rest/1.0/corda.rest.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/rest/1.0/corda.rest.json
@@ -66,7 +66,7 @@
     "flowStatusCleanupTimeMs": {
       "description": "The duration, in milliseconds, for which the flow status lookup service retains flow statuses in terminal states (COMPLETED, FAILED, KILLED) without updates. After this period, they are deleted. This must be greater than flow.session.cleanupTime and flow.processing.cleanupTime otherwise flows with re-used requestIds may be silently de-duplicated by the FlowMapper.",
       "type": "integer",
-      "minimum": 600000,
+      "minimum": 60000,
       "maximum:": 2147483647,
       "default": 604800000
     }


### PR DESCRIPTION
The flowStatusCleanupTime parameter specifies the duration that a FlowStatus record can remain in state storage after its last update. Once this time elapses, the `FlowStatusCleanupProcessor` identifies and deletes the stale record.

Reducing the minimum value from `600_000ms` (10 minutes) to `60_000ms` (1 minute) to allow QA to test the scheduled cleanup in a reasonable timeframe.