### PR TITLE
CORE-19562: Remove unused fields from KeyRotationRequest avro messages

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/ops/key/rotation/IndividualKeyRotationRequest.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/ops/key/rotation/IndividualKeyRotationRequest.avsc
@@ -15,16 +15,6 @@
       "doc": "Specifies the specific tenant that owns the old key."
     },
     {
-      "name": "oldParentKeyAlias",
-      "type": ["null", "string"],
-      "doc": "Mandatory for unmanaged key rotation only, always null for managed key rotation. The key alias whose protected content will be re-wrapped with a new key."
-    },
-    {
-      "name": "newParentKeyAlias",
-      "type": ["null", "string"],
-      "doc": "Mandatory for unmanaged key rotation only, always null for managed key rotation. The new wrapping key which oldParentKeyAlias' content will be re-wrapped with."
-    },
-    {
       "name": "targetKeyAlias",
       "type": ["null", "string"],
       "doc": "Mandatory for unmanaged key rotation only, always null for managed key rotation. Specifies the wrapped key to rotate."

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/ops/key/rotation/KeyRotationRequest.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/ops/key/rotation/KeyRotationRequest.avsc
@@ -19,16 +19,6 @@
       "doc": "Type of the key to be rotated."
     },
     {
-      "name": "oldParentKeyAlias",
-      "type": ["null", "string"],
-      "doc": "Mandatory for unmanaged key rotation only, always null for managed key rotation. The key alias that should no longer be used, and all its protected content re-wrapped with a new key."
-    },
-    {
-      "name": "newParentKeyAlias",
-      "type": ["null", "string"],
-      "doc": "Mandatory for unmanaged key rotation only, always null for managed key rotation. The unmanaged key alias that should be used for material currently wrapped with old key."
-    },
-    {
       "name": "tenantId",
       "type": ["null", "string"],
       "doc": "Mandatory for managed key rotation only, always null for unmanaged key rotation. Specifies the specific tenant for which managed wrapping keys will be rotated."

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ cordaProductVersion = 5.2.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 42
+cordaApiRevision = 43
 
 # Main
 kotlin.stdlib.default.dependency = false


### PR DESCRIPTION
Our Avro schemas for KeyRotationRequest and IndividualKeyRotationRequest both have fields which are no longer used. This PR removes those fields from the schemas.

https://github.com/corda/corda-runtime-os/pull/5672