### PR TITLE
CORE-19618: Remove unneeded old and new alias from key rotation status

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/ops/key.status/UnmanagedKeyStatus.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/ops/key.status/UnmanagedKeyStatus.avsc
@@ -2,18 +2,8 @@
   "type": "record",
   "name": "UnmanagedKeyStatus",
   "namespace": "net.corda.data.crypto.wire.ops.key.status",
-  "doc": "Defines the key status and key rotation status data for unmanaged keys.",
+  "doc": "Defines the key status and key rotation status data for master wrapping key.",
   "fields": [
-    {
-      "name": "oldParentKeyAlias",
-      "type": "string",
-      "doc": "Alias of an unmanaged key that we are rotating away from."
-    },
-    {
-      "name": "newParentKeyAlias",
-      "type": ["null", "string"],
-      "doc": "The wrapping key alias that should be used for material currently wrapped with old key."
-    },
     {
       "name": "tenantId",
       "type": "string",
@@ -22,7 +12,7 @@
     {
       "name": "total",
       "type": "int",
-      "doc": "Total number of keys that needs rotating away from rootKeyAlias in tenantId."
+      "doc": "Total number of keys that needs rotating in tenantId."
     },
     {
       "name": "rotatedKeys",

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ cordaProductVersion = 5.2.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 40
+cordaApiRevision = 41
 
 # Main
 kotlin.stdlib.default.dependency = false


### PR DESCRIPTION
Key rotation now checks the default master wrapping key tag and rotates wrapping keys to this parent key. 
Old and new alias are not longer used, therefore we are removing them from the avro schema used for storing key rotation status. 

Runtime-os PR: [#5666](https://github.com/corda/corda-runtime-os/pull/5666)
