### PR TITLE
CORE-19628 Increased the default sandbox cache max size

### DIFF
--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/sandbox/1.0/corda.sandbox.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/sandbox/1.0/corda.sandbox.json
@@ -22,7 +22,7 @@
               "description": "The maximum number of cached flow sandboxes.",
               "type": "integer",
               "minimum": 0,
-              "default": 10
+              "default": 500
             }
           }
         }
@@ -44,7 +44,7 @@
               "description": "The maximum number of cached database sandboxes.",
               "type": "integer",
               "minimum": 0,
-              "default": 10
+              "default": 500
             }
           }
         }
@@ -66,7 +66,7 @@
               "description": "The maximum number of cached verification sandboxes.",
               "type": "integer",
               "minimum": 0,
-              "default": 10
+              "default": 500
             }
           }
         }


### PR DESCRIPTION
Size increase is based on scalability tests which were run in order to validate large caches are not massive consumers of memory. This size better reflects the 5.2 commitment to larger numbers of virtual nodes.