### PR TITLE
CORE-18730 Increase session timeout default value

### DIFF
--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/p2p.linkManager/1.0/corda.p2p.linkManager.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/p2p.linkManager/1.0/corda.p2p.linkManager.json
@@ -91,7 +91,7 @@
     "sessionTimeout": {
       "description": "The session timeout in milliseconds.",
       "type": "integer",
-      "default": 10000,
+      "default": 60000,
       "minimum": 500
     },
     "sessionsPerPeer": {


### PR DESCRIPTION
This change increases the P2P Link Manager session timeout, this is to avoid unnecessary session recycling for slow responders.  
