### PR TITLE
CORE-19738 Hash merkle proof id

### DIFF
--- a/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v5.2.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v5.2.xml
@@ -4,10 +4,10 @@
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
 
     <!-- TEXT type cannot be used for HSQL because it will be converted to CLOB when fetched -->
-    <property name="merkle.proof.hashes.column.type" value="VARCHAR(2048)" dbms="hsqldb"/>
+    <property name="merkle.proof.hashes.column.type" value="VARCHAR(8192)" dbms="hsqldb"/>
     <property name="merkle.proof.hashes.column.type" value="TEXT" dbms="postgresql"/>
 
-    <property name="merkle.proof.leaf.indexes.column.type" value="VARCHAR(2048)" dbms="hsqldb"/>
+    <property name="merkle.proof.leaf.indexes.column.type" value="VARCHAR(8192)" dbms="hsqldb"/>
     <property name="merkle.proof.leaf.indexes.column.type" value="TEXT" dbms="postgresql"/>
 
     <changeSet author="R3.Corda" id="ledger-utxo-creation-v5.2">

--- a/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v5.2.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v5.2.xml
@@ -4,8 +4,11 @@
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
 
     <!-- TEXT type cannot be used for HSQL because it will be converted to CLOB when fetched -->
-    <property name="merkle.proof.hashes.column.type" value="VARCHAR(1024)" dbms="hsqldb"/>
+    <property name="merkle.proof.hashes.column.type" value="VARCHAR(2048)" dbms="hsqldb"/>
     <property name="merkle.proof.hashes.column.type" value="TEXT" dbms="postgresql"/>
+
+    <property name="merkle.proof.leaf.indexes.column.type" value="VARCHAR(2048)" dbms="hsqldb"/>
+    <property name="merkle.proof.leaf.indexes.column.type" value="TEXT" dbms="postgresql"/>
 
     <changeSet author="R3.Corda" id="ledger-utxo-creation-v5.2">
 
@@ -21,6 +24,9 @@
                 <constraints nullable="false"/>
             </column>
             <column name="tree_size" type="INT">
+                <constraints nullable="false"/>
+            </column>
+            <column name="leaf_indexes" type="${merkle.proof.hashes.column.type}">
                 <constraints nullable="false"/>
             </column>
             <column name="hashes" type="${merkle.proof.hashes.column.type}">

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ cordaProductVersion = 5.2.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 48
+cordaApiRevision = 49
 
 # Main
 kotlin.stdlib.default.dependency = false


### PR DESCRIPTION
Store the merkle proof id as a hash of
`<transactionId>;<groupIndex>;<leafIndexes>`. The same structure was
used before this change, but would easily go over the columns size limit
when storing filtered transactions.

Using the hash gives us predictable ids as it is based on computed data
rather than any randomisation and also keeps the ids shorter.

As the id contained the leaf indexes which were parsed when read
from the database, the content still needed to be preserved in a
readable format; a column has been added for `leaf_indexes` to preserve
this data.