### PR TITLE
CORE-18539: Increase "maxIdleTime" Flow Property

### DIFF
--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/flow/1.0/corda.flow.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/flow/1.0/corda.flow.json
@@ -44,7 +44,7 @@
           "type": "integer",
           "minimum": 60000,
           "maximum": 31557600000,
-          "default": 300000
+          "default": 1800000
         },
         "cleanupTime": {
           "description": "The length of time in milliseconds that the flow mapper holds onto the state for a flow that has finished. When the start flow state is removed, clientRequestIds will be available for reuse within the flow mapper. This value should be set lower than the rest config field 'flowStatusCleanupTimeMs'.",


### PR DESCRIPTION
Increase the default maximum time a flow can be in 'RUNNING' state
without receiving any updates before Corda marks the flow as 'FAILED'
and deletes associated state from 5 to 30 minutes (same default
timeout set for flow sessions).
