### PR TITLE
CORE-19290 - Set the `tokenCacheExpiryPeriodMilliseconds` to be an integer instead of a long

### DIFF
--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/ledger.utxo/1.0/corda.ledger.utxo.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/ledger.utxo/1.0/corda.ledger.utxo.json
@@ -61,7 +61,7 @@
         },
         "tokenCacheExpiryPeriodMilliseconds": {
           "description": "Expiry period in milliseconds for token in the cache (default 200 milliseconds). A zero value means the cached tokens expire instantly",
-          "type": "long",
+          "type": "integer",
           "minimum": 0,
           "default": 200
         }


### PR DESCRIPTION
The type `long` prevents the `combined worker` from starting up. This change changes the type of `tokenCacheExpiryPeriodMilliseconds ` from long to integer.