### PR TITLE
CORE-20210 Flow worker must be added as a producer to flow mapper start due to ledger repair tool changes

### DIFF
--- a/data/topic-schema/src/main/resources/net/corda/schema/Flow.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/Flow.yaml
@@ -50,6 +50,7 @@ topics:
       - flowMapper
     producers:
       - rest
+      - flow
     config:
   FlowMapperSessionOut:
     name: flow.mapper.session.out


### PR DESCRIPTION
Without this change the ledger repair tool will not work on a kafka deployment