### PR TITLE
CORE-19289 - Updated the table `utxo_visible_transaction_output`

### DIFF
--- a/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/db.changelog-master.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/db.changelog-master.xml
@@ -7,5 +7,6 @@
     <include file="net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v1.0.xml"/>
     <include file="net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v5.1.xml"/>
     <include file="net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v5.2.xml"/>
+    <include file="net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v5.3.xml"/>
     <include file="net/corda/db/schema/vnode-vault/migration/vnode-vault-creation-v5.1.xml"/>
 </databaseChangeLog>

--- a/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v5.3.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v5.3.xml
@@ -1,0 +1,16 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+
+    <changeSet author="R3.Corda" id="ledger-utxo-creation-v5.3">
+
+        <addColumn tableName="utxo_visible_transaction_output">
+            <column name="token_priority" type="BIGINT">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+
+    </changeSet>
+
+</databaseChangeLog>

--- a/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v5.3.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v5.3.xml
@@ -11,6 +11,12 @@
             </column>
         </addColumn>
 
+        <createIndex indexName="utxo_visible_transaction_output_token_priority_tx_id_idx"
+                     tableName="utxo_visible_transaction_output">
+            <column name="token_priority"/>
+            <column name="transaction_id"/>
+        </createIndex>
+
     </changeSet>
 
 </databaseChangeLog>

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ cordaProductVersion = 5.3.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 9
+cordaApiRevision = 10
 
 # Main
 kotlin.stdlib.default.dependency = false

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ cordaProductVersion = 5.3.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 10
+cordaApiRevision = 9
 
 # Main
 kotlin.stdlib.default.dependency = false


### PR DESCRIPTION
Added the column `token_priority` to the database table `utxo_visible_transaction_output`.
Created an index that uses the `token_priority` and `transaction_id` columns.

Note: 
1) Liquibase does not support the creation of an index where NULL values are last unless we write the SQL code ourselves. (See reference: https://docs.liquibase.com/change-types/create-index.html)
2) Postgres reference for creating an index with the `NULLS LAST` option: https://www.postgresql.org/docs/current/indexes-ordering.html