### PR TITLE
CORE-20317 Performance tune persistance of filtered transactions

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/ledger/persistence/PersistFilteredTransactionsAndSignatures.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/ledger/persistence/PersistFilteredTransactionsAndSignatures.avsc
@@ -8,6 +8,22 @@
       "name": "filteredTransactionsAndSignatures",
       "type": "bytes",
       "doc": "the serialized map of filtered transactions and signatures"
+    },
+    {
+      "name": "inputStateRefs",
+      "type": {
+        "type" : "array",
+        "items" : "net.corda.data.ledger.utxo.StateRef"
+      },
+      "doc": "The input states being stored"
+    },
+    {
+      "name": "referenceStateRefs",
+      "type": {
+        "type" : "array",
+        "items" : "net.corda.data.ledger.utxo.StateRef"
+      },
+      "doc": "The reference states being stored"
     }
   ]
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ cordaProductVersion = 5.3.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 10
+cordaApiRevision = 11
 
 # Main
 kotlin.stdlib.default.dependency = false


### PR DESCRIPTION
The persistence of filtered transactions was identified as a slow point
in the happy path when using a contract verifying notary.

The changes to the avro schema support the runtime changes.
