### PR TITLE
CORE-20093: Add default master wrapping key alias to individual key rotation request message

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/ops/key/rotation/IndividualKeyRotationRequest.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/crypto/wire/ops/key/rotation/IndividualKeyRotationRequest.avsc
@@ -15,6 +15,11 @@
       "doc": "Specifies the specific tenant that owns the old key."
     },
     {
+      "name": "masterWrappingKeyAlias",
+      "type": ["null", "string"],
+      "doc": "Mandatory for unmanaged key rotation only, always null for managed key rotation. Specifies the default master wrapping key to rotate to."
+    },
+    {
       "name": "targetKeyAlias",
       "type": ["null", "string"],
       "doc": "Mandatory for unmanaged key rotation only, always null for managed key rotation. Specifies the wrapped key to rotate."

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ cordaProductVersion = 5.3.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 11
+cordaApiRevision = 12
 
 # Main
 kotlin.stdlib.default.dependency = false


### PR DESCRIPTION
To improve the sync issues between crypto workers when updating the configuration before key rotation, we use only one place to retrieve the default master wrapping key alias. To pass it to other workers, we use kafka message.

Runtime-os PR: [#6029](https://github.com/corda/corda-runtime-os/pull/6029)