### PR TITLE
ES-2248: Adding 'merge-release' to stale-branch-remove exemption regex

### DIFF
--- a/.github/workflows/remove-stale-branches.yml
+++ b/.github/workflows/remove-stale-branches.yml
@@ -15,5 +15,5 @@ jobs:
           days-before-branch-delete: 14
           stale-branch-message: "@{author} The branch [{branchName}]({branchUrl}) hasn't been updated in the last 30 days and is marked as stale. It will be removed in 14 days.\r\nIf you want to keep this branch around, delete this comment or add new commits to this branch."
           exempt-protected-branches: true
-          exempt-branches-regex: "^(release\\/|feature\\/|poc\\/).*"
+          exempt-branches-regex: "^(release\\/|feature\\/|poc\\/|merge-release\\/).*"
           operations-per-run: 30


### PR DESCRIPTION
**Problem Description**
When a remove-stale github action is triggered, it causes an error on merge branches as there is no associated author.

**Solution**
Adding 'merge-release' to the exemptions regex to prevent remove-stale from flagging a merge branch for removal.

https://github.com/corda/corda-e2e-tests/actions/runs/8750709270/job/24014775525 
`branch merge-release/5.2-release/5.3-2024-02-28-14                                                                       
  -> branch was last updated by (unknown user) on 2024-02-28T14:10:05Z                                                   
  branch merge-release/5.2-release/5.3-2024-02-28-14 is exempted`