### PR TITLE
CORE-6717 Add schemas for hosted identity reconciliation

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/request/MembershipPersistenceRequest.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/request/MembershipPersistenceRequest.avsc
@@ -40,7 +40,8 @@
         "net.corda.data.membership.db.request.query.MutualTlsListAllowedCertificates",
         "net.corda.data.membership.db.request.query.QueryApprovalRules",
         "net.corda.data.membership.db.request.query.QueryPreAuthToken",
-        "net.corda.data.membership.db.request.query.QueryStaticNetworkInfo"
+        "net.corda.data.membership.db.request.query.QueryStaticNetworkInfo",
+        "net.corda.data.membership.db.request.command.PersistHostedIdentity"
       ],
       "doc": "Request's payload, depends on the requested operation."
     }

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/request/command/PersistHostedIdentity.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/request/command/PersistHostedIdentity.avsc
@@ -1,0 +1,26 @@
+{
+  "type": "record",
+  "name": "PersistHostedIdentity",
+  "namespace": "net.corda.data.membership.db.request.command",
+  "doc": "Persist a locally-hosted identity.",
+  "fields": [
+    {
+      "name": "tlsCertificateAlias",
+      "doc": "Alias of the TLS certificate chain.",
+      "type": "string"
+    },
+    {
+      "name": "useClusterLevelTls",
+      "doc": "Specifies whether the cluster-level P2P TLS certificate type and key should be used, or the virtual node certificate and key.",
+      "type": "boolean"
+    },
+    {
+      "name": "sessionKeysAndCertificates",
+      "doc": "List of session keys and certificates.",
+      "type": {
+        "type": "array",
+        "items": "net.corda.data.membership.db.request.command.SessionKeyAndCertificate"
+      }
+    }
+  ]
+}

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/request/command/SessionKeyAndCertificate.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/request/command/SessionKeyAndCertificate.avsc
@@ -1,0 +1,23 @@
+{
+  "type": "record",
+  "name": "SessionKeyAndCertificate",
+  "namespace": "net.corda.data.membership.db.request.command",
+  "doc": "Session key and certificate for a locally-hosted identity.",
+  "fields": [
+    {
+      "name": "sessionKeyId",
+      "doc": "Session key identifier.",
+      "type": "string"
+    },
+    {
+      "name": "certificateAlias",
+      "doc": "The certificate chain alias of the session key. Null if no PKI is used for sessions.",
+      "type": ["null", "string"]
+    },
+    {
+      "name": "isPreferred",
+      "doc": "True if this key is the preferred key.",
+      "type": "boolean"
+    }
+  ]
+}

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/response/MembershipPersistenceResponse.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/response/MembershipPersistenceResponse.avsc
@@ -29,7 +29,8 @@
         "net.corda.data.membership.db.response.query.GroupPolicyQueryResponse",
         "net.corda.data.membership.db.response.query.ApprovalRulesQueryResponse",
         "net.corda.data.membership.db.response.query.PreAuthTokenQueryResponse",
-        "net.corda.data.membership.db.response.query.StaticNetworkInfoQueryResponse"
+        "net.corda.data.membership.db.response.query.StaticNetworkInfoQueryResponse",
+        "net.corda.data.membership.db.response.command.PersistHostedIdentityResponse"
       ],
       "doc": "Response payload which depends on the requested operation."
     }

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/response/command/PersistHostedIdentityResponse.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/membership/db/response/command/PersistHostedIdentityResponse.avsc
@@ -1,0 +1,13 @@
+{
+  "type": "record",
+  "name": "PersistHostedIdentityResponse",
+  "namespace": "net.corda.data.membership.db.response.command",
+  "doc": "Response to a persist hosted identity request.",
+  "fields": [
+    {
+      "name": "version",
+      "doc": "Version of the newly persisted hosted identity.",
+      "type": "int"
+    }
+  ]
+}

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/HostedIdentityEntry.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/HostedIdentityEntry.avsc
@@ -33,6 +33,10 @@
          "type": "array",
          "items": "HostedIdentitySessionKeyAndCert"
        }
-     }
+     },
+    {
+      "name": "version",
+      "type": "int"
+    }
   ]
 }

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/HostedIdentityEntry.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/HostedIdentityEntry.avsc
@@ -35,6 +35,7 @@
        }
      },
     {
+      "doc": "Version of the hosted identity",
       "name": "version",
       "type": ["null", "int"],
       "default": null

--- a/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/HostedIdentityEntry.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/p2p/HostedIdentityEntry.avsc
@@ -36,7 +36,8 @@
      },
     {
       "name": "version",
-      "type": "int"
+      "type": ["null", "int"],
+      "default": null
     }
   ]
 }

--- a/data/avro-schema/src/test/kotlin/net/corda/data/p2p/HostedIdentityEntryCompatibilityTest.kt
+++ b/data/avro-schema/src/test/kotlin/net/corda/data/p2p/HostedIdentityEntryCompatibilityTest.kt
@@ -1,0 +1,64 @@
+package net.corda.data.p2p
+
+import net.corda.data.identity.HoldingIdentity
+import org.apache.avro.Schema
+import org.apache.avro.SchemaCompatibility
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class HostedIdentityEntryCompatibilityTest {
+    @Test
+    fun `check HostedIdentityEntry schema changes between Corda 5_2 and 5_2_1 are compatible`() {
+        val schemaV52Json = """
+            {
+              "type": "record",
+              "name": "HostedIdentityEntry",
+              "namespace": "net.corda.data.p2p",
+              "fields": [
+                {
+                  "doc": "The Holding identity hosted in this node",
+                  "name": "holdingIdentity",
+                  "type": "net.corda.data.identity.HoldingIdentity"
+                },
+                {
+                  "doc": "The tenant ID under which the TLS key is stored",
+                  "name": "tlsTenantId",
+                  "type": "string"
+                },
+                {
+                  "doc": "The TLS certificates (in PEM format)",
+                  "name": "tlsCertificates",
+                  "type": {
+                    "type": "array",
+                    "items": "string"
+                  }
+                },
+                {
+                  "doc": "The preferred session initiation key and certificate",
+                  "name": "preferredSessionKeyAndCert",
+                  "type": "HostedIdentitySessionKeyAndCert"
+                },
+                {
+                  "doc": "Alternative session initiation keys and certificates",
+                  "name": "alternativeSessionKeysAndCerts",
+                   "type": {
+                     "type": "array",
+                     "items": "HostedIdentitySessionKeyAndCert"
+                   }
+                 }
+              ]
+            }
+        """.trimIndent()
+
+        val schemaV52 = Schema.Parser().addTypes(
+            mapOf(
+                HoldingIdentity::class.java.name to HoldingIdentity.`SCHEMA$`,
+                HostedIdentitySessionKeyAndCert::class.java.name to HostedIdentitySessionKeyAndCert.`SCHEMA$`
+            )
+        ).parse(schemaV52Json)
+        val schemaV521 = HostedIdentityEntry.`SCHEMA$`
+
+        val compatibility = SchemaCompatibility.checkReaderWriterCompatibility(schemaV521, schemaV52)
+        assertEquals(compatibility.type, SchemaCompatibility.SchemaCompatibilityType.COMPATIBLE)
+    }
+}

--- a/data/config-schema/src/main/java/net/corda/schema/configuration/ReconciliationConfig.java
+++ b/data/config-schema/src/main/java/net/corda/schema/configuration/ReconciliationConfig.java
@@ -12,6 +12,7 @@ public final class ReconciliationConfig {
     public static final String RECONCILIATION_VNODE_INFO_INTERVAL_MS ="vnodeInfoIntervalMs";
     public static final String RECONCILIATION_GROUP_PARAMS_INTERVAL_MS = "groupParamsIntervalMs";
     public static final String RECONCILIATION_MTLS_MGM_ALLOWED_LIST_INTERVAL_MS = "mtlsMgmAllowedCertificateSubjectsIntervalMs";
+    public static final String RECONCILIATION_HOSTED_IDENTITY_INTERVAL_MS = "hostedIdentityIntervalMs";
 
     public static final String RECONCILIATION_MEMBER_INFO_INTERVAL_MS = "memberInfoIntervalMs";
 }

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/reconciliation/1.0/corda.reconciliation.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/reconciliation/1.0/corda.reconciliation.json
@@ -61,6 +61,13 @@
       "minimum": 5000,
       "maximum": 2147483647,
       "default": 120000
+    },
+    "hostedIdentityIntervalMs": {
+      "description": "The interval in milliseconds between aligning the Kafka Hosted Identity with the DB Hosted Identity.",
+      "type": "integer",
+      "minimum": 5000,
+      "maximum": 2147483647,
+      "default": 120000
     }
   }
 }

--- a/data/db-schema/src/main/java/net/corda/db/schema/DbSchema.java
+++ b/data/db-schema/src/main/java/net/corda/db/schema/DbSchema.java
@@ -39,6 +39,8 @@ public final class DbSchema {
     public static final String VNODE_GROUP_APPROVAL_RULES = "vnode_group_approval_rules";
     public static final String VNODE_PRE_AUTH_TOKENS = "vnode_pre_auth_tokens";
     public static final String VNODE_PERSISTENCE_REQUEST_ID_TABLE = "vnode_persistence_request_id";
+    public static final String HOSTED_IDENTITY = "hosted_identity";
+    public static final String HOSTED_IDENTITY_SESSION_KEY_INFO = "hosted_identity_session_key_info";
 
     public static final String LEDGER_CONSENSUAL_TRANSACTION_TABLE = "consensual_transaction";
     public static final String LEDGER_CONSENSUAL_TRANSACTION_STATUS_TABLE = "consensual_transaction_status";

--- a/data/db-schema/src/main/resources/net/corda/db/schema/config/db.changelog-master.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/config/db.changelog-master.xml
@@ -12,5 +12,5 @@
 
     <include file="net/corda/db/schema/config/migration/config-creation-v5.2.xml"/>
 
-    <include file="net/corda/db/schema/config/migration/config-creation-v5.2.1.xml"/>
+    <include file="net/corda/db/schema/config/migration/hosted-identity-creation-v5.2.1.xml"/>
 </databaseChangeLog>

--- a/data/db-schema/src/main/resources/net/corda/db/schema/config/db.changelog-master.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/config/db.changelog-master.xml
@@ -11,4 +11,6 @@
     <include file="net/corda/db/schema/config/migration/scheduler-creation-v5.1.xml"/>
 
     <include file="net/corda/db/schema/config/migration/config-creation-v5.2.xml"/>
+
+    <include file="net/corda/db/schema/config/migration/config-creation-v5.2.1.xml"/>
 </databaseChangeLog>

--- a/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/config-creation-v5.2.1.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/config-creation-v5.2.1.xml
@@ -1,0 +1,48 @@
+<?xml version="1.1" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
+
+    <changeSet author="R3.Corda" id="config-creation-v5.2.1">
+        <createTable tableName="hosted_identity_session_key_info">
+            <column name="holding_identity_id" type="VARCHAR(12)">
+                <constraints nullable="false"/>
+            </column>
+            <!-- short hash (first 12 hex chars of SHA256) of the public key -->
+            <column name="session_key_id" type="CHAR(12)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="session_certificate_alias" type="VARCHAR(255)">
+                <constraints nullable="true"/>
+            </column>
+        </createTable>
+        <addPrimaryKey tableName="vnode_session_key_info" columnNames="holding_identity_id,session_key_id"
+                       constraintName="vnode_session_key_info_pk"/>
+
+        <createTable tableName="hosted_identity">
+            <column name="holding_identity_id" type="VARCHAR(12)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="preferred_session_key_id" type="CHAR(12)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="tls_certificate_alias" type="VARCHAR(64)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="use_cluster_level_tls" type="BOOLEAN">
+                <constraints nullable="false"/>
+            </column>
+            <column name="version" type="INT">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+        <addPrimaryKey tableName="hosted_identity" columnNames="holding_identity_id"
+                       constraintName="hosted_identity_pk"/>
+        <addForeignKeyConstraint baseColumnNames="holding_identity_id,preferred_session_key_id"
+                                 baseTableName="hosted_identity"
+                                 constraintName="FK_hosted_identity_preferred_session_key"
+                                 referencedColumnNames="holding_identity_id,session_key_id"
+                                 referencedTableName="hosted_identity_session_key_info"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/config-creation-v5.2.1.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/config-creation-v5.2.1.xml
@@ -16,8 +16,8 @@
                 <constraints nullable="true"/>
             </column>
         </createTable>
-        <addPrimaryKey tableName="vnode_session_key_info" columnNames="holding_identity_id,session_key_id"
-                       constraintName="vnode_session_key_info_pk"/>
+        <addPrimaryKey tableName="hosted_identity_session_key_info" columnNames="holding_identity_id,session_key_id"
+                       constraintName="hosted_identity_session_key_info_pk"/>
 
         <createTable tableName="hosted_identity">
             <column name="holding_identity_id" type="VARCHAR(12)">

--- a/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/hosted-identity-creation-v5.2.1.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/hosted-identity-creation-v5.2.1.xml
@@ -3,7 +3,7 @@
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
 
-    <changeSet author="R3.Corda" id="config-creation-v5.2.1">
+    <changeSet author="R3.Corda" id="hosted-identity-creation-v5.2.1">
         <createTable tableName="hosted_identity_session_key_info">
             <column name="holding_identity_id" type="VARCHAR(12)">
                 <constraints nullable="false"/>

--- a/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/hosted-identity-creation-v5.2.1.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/config/migration/hosted-identity-creation-v5.2.1.xml
@@ -38,11 +38,6 @@
         </createTable>
         <addPrimaryKey tableName="hosted_identity" columnNames="holding_identity_id"
                        constraintName="hosted_identity_pk"/>
-        <addForeignKeyConstraint baseColumnNames="holding_identity_id,preferred_session_key_id"
-                                 baseTableName="hosted_identity"
-                                 constraintName="FK_hosted_identity_preferred_session_key"
-                                 referencedColumnNames="holding_identity_id,session_key_id"
-                                 referencedTableName="hosted_identity_session_key_info"/>
     </changeSet>
 
 </databaseChangeLog>

--- a/data/topic-schema/src/main/resources/net/corda/schema/Crypto.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/Crypto.yaml
@@ -34,6 +34,7 @@ topics:
       - link-manager
       - membership
       - rest
+      - db
     producers:
       - crypto
     config:

--- a/data/topic-schema/src/main/resources/net/corda/schema/Crypto.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/Crypto.yaml
@@ -25,6 +25,7 @@ topics:
       - link-manager
       - membership
       - rest
+      - db
     config:
   CryptoOpsRpcResponseTopic:
     name: crypto.ops.rpc.resp

--- a/data/topic-schema/src/main/resources/net/corda/schema/P2P.yaml
+++ b/data/topic-schema/src/main/resources/net/corda/schema/P2P.yaml
@@ -55,9 +55,11 @@ topics:
       - link-manager
       - membership
       - flowMapper
+      - db
     producers:
       - rest # Dynamic Network registration
       - membership # Static Network registration
+      - db
     config:
       cleanup.policy: compact
       segment.ms: 600000

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ cordaProductVersion = 5.2.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 52
+cordaApiRevision = 53
 
 # Main
 kotlin.stdlib.default.dependency = false


### PR DESCRIPTION
Introduces database and Avro schemas to enable persistence and reconciliation of locally-hosted identities.

- Adds cluster-level tables `hosted_identity` and `hosted_identity_session_key_info`
- Extends `HostedIdentityEntry.avsc` to include `version` (compatibility test added)
- Adds config for hosted identity reconciliation