### PR TITLE
ES-2248: ignore-unknown-authors in remove-stale-branches.yaml

### DIFF
--- a/.github/workflows/remove-stale-branches.yml
+++ b/.github/workflows/remove-stale-branches.yml
@@ -11,6 +11,8 @@ jobs:
       - uses: fpicalausa/remove-stale-branches@v1.5.8
         with:
           dry-run: false
+          ignore-unknown-authors: true
+          default-recipient: "corda-jenkins-ci02"
           days-before-branch-stale: 30
           days-before-branch-delete: 14
           stale-branch-message: "@{author} The branch [{branchName}]({branchUrl}) hasn't been updated in the last 30 days and is marked as stale. It will be removed in 14 days.\r\nIf you want to keep this branch around, delete this comment or add new commits to this branch."


### PR DESCRIPTION
**Description**
[ES-2248](https://r3-cev.atlassian.net/jira/software/c/projects/ES/boards/960?assignee=712020%3A9773507a-4110-49ab-ba86-13ba21d9730d&selectedIssue=ES-2248) seems to be persisting after an initial change to 'exempt-branches'

**Solution**
Implementing an ignore-unknown-authors tag along with a default-recipient.

**Tested Against**
https://github.com/corda/corda-e2e-tests/actions/runs/8875574080/job/24365289041

[ES-2248]: https://r3-cev.atlassian.net/browse/ES-2248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ