### PR TITLE
CORE-16921 Add configurable maximum payload size

### DIFF
--- a/application/src/main/java/net/corda/v5/application/messaging/FlowMessaging.java
+++ b/application/src/main/java/net/corda/v5/application/messaging/FlowMessaging.java
@@ -309,7 +309,8 @@ public interface FlowMessaging {
      * stops receiving heartbeat messages from the counterparty within the configurable timeout.
      * <p>
      * The {@code payload} object should be of a type that is annotated with @CordaSerializable or a primitive type. This
-     * function cannot handle types that do not meet these criteria. The maximum payload size that can be sent at once is dictated by Flow Config, and defaults to 100MB.
+     * function cannot handle types that do not meet these criteria. The maximum payload size that can be sent at once is
+     * dictated by `session.maxPayloadSize`, and defaults to 100MB.
      *
      * @param payload the payload to send, which should be either a primitive type or a type annotated with @CordaSerializable.
      *                Payload size should not exceed the configurable maximum size in bytes (default of 100MB).
@@ -328,7 +329,8 @@ public interface FlowMessaging {
      * stops receiving heartbeat messages from the counterparty within the configurable timeout.
      * <p>
      * The objects in {@code payloadsPerSession} should be of types that are annotated with @CordaSerializable or be primitive types. This
-     * function cannot handle types that do not meet these criteria. The maximum payload size that can be sent at once is dictated by Flow Config, and defaults to 100MB.
+     * function cannot handle types that do not meet these criteria. The maximum payload size that can be sent at once is
+     * dictated by `session.maxPayloadSize`, and defaults to 100MB.
      *
      * @param payloadsPerSession a mapping that contains the payload to be sent to each session.
      *                           The payloads should be either of primitive types or types annotated with @CordaSerializable.

--- a/application/src/main/java/net/corda/v5/application/messaging/FlowMessaging.java
+++ b/application/src/main/java/net/corda/v5/application/messaging/FlowMessaging.java
@@ -309,12 +309,13 @@ public interface FlowMessaging {
      * stops receiving heartbeat messages from the counterparty within the configurable timeout.
      * <p>
      * The {@code payload} object should be of a type that is annotated with @CordaSerializable or a primitive type. This
-     * function cannot handle types that do not meet these criteria.
+     * function cannot handle types that do not meet these criteria. The maximum payload size that can be sent at once is dictated by Flow Config, and defaults to 100MB.
      *
      * @param payload the payload to send, which should be either a primitive type or a type annotated with @CordaSerializable.
+     *                Payload size should not exceed the configurable maximum size in bytes (default of 100MB).
      * @param sessions the sessions to send the provided payload to.
      *
-     * @throws CordaRuntimeException if any session is closed or in a failed state.
+     * @throws CordaRuntimeException if any session is closed or in a failed state, or if the payload size exceeds the configured maximum size in bytes.
      */
     @Suspendable
     void sendAll(@NotNull Object payload, @NotNull Set<FlowSession> sessions);
@@ -327,12 +328,13 @@ public interface FlowMessaging {
      * stops receiving heartbeat messages from the counterparty within the configurable timeout.
      * <p>
      * The objects in {@code payloadsPerSession} should be of types that are annotated with @CordaSerializable or be primitive types. This
-     * function cannot handle types that do not meet these criteria.
+     * function cannot handle types that do not meet these criteria. The maximum payload size that can be sent at once is dictated by Flow Config, and defaults to 100MB.
      *
      * @param payloadsPerSession a mapping that contains the payload to be sent to each session.
      *                           The payloads should be either of primitive types or types annotated with @CordaSerializable.
+     *                           Payload size should not exceed the configurable maximum size in bytes (default of 100MB).
      *
-     * @throws CordaRuntimeException if any session is closed or in a failed state.
+     * @throws CordaRuntimeException if any session is closed or in a failed state, or if the payload size exceeds the configured maximum size in bytes.
      */
     @Suspendable
     void sendAllMap(@NotNull Map<FlowSession, Object> payloadsPerSession);

--- a/application/src/main/java/net/corda/v5/application/messaging/FlowSession.java
+++ b/application/src/main/java/net/corda/v5/application/messaging/FlowSession.java
@@ -74,15 +74,17 @@ public interface FlowSession {
      * <p>
      * Both the {@code payload} object and the {@code receiveType} should be of a type that is annotated
      * with @CordaSerializable or a primitive type. This function cannot handle types that do not meet these criteria.
+     * The maximum payload size that can be sent at once is dictated by Flow Config, and defaults to 100MB.
      *
      * @param <R> The data type received from the counterparty.
      * @param receiveType The data type received from the counterparty.
      * @param payload The data sent to the counterparty, which should be either a primitive type
-     *                or a type annotated with @CordaSerializable.
+     *                or a type annotated with @CordaSerializable. Payload size should not exceed the configurable maximum size in bytes
+     *                (default of 100MB).
      *
      * @return The received data <R>
      *
-     * @throws CordaRuntimeException if the session is closed or in a failed state.
+     * @throws CordaRuntimeException if the session is closed or in a failed state, or if the payload size exceeds the configured maximum size in bytes.
      */
     @Suspendable
     @NotNull
@@ -116,12 +118,14 @@ public interface FlowSession {
      * network's event horizon time.
      * <p>
      * The {@code payload} object should be of a type that is annotated with @CordaSerializable or a primitive type. This
-     * function cannot handle types that do not meet these criteria.
+     * function cannot handle types that do not meet these criteria. The maximum payload size that can be
+     * sent at once is dictated by Flow Config, and defaults to 100MB.
      *
      * @param payload The data sent to the counterparty, which should be either a primitive type
-     *                or a type annotated with @CordaSerializable.
+     *                or a type annotated with @CordaSerializable. Payload size should not exceed the configurable maximum size in bytes
+     *                (default of 100MB).
      *
-     * @throws CordaRuntimeException if the session is closed or in a failed state.
+     * @throws CordaRuntimeException if the session is closed or in a failed state, or if the payload size exceeds the configured maximum size in bytes.
      */
     @Suspendable
     void send(@NotNull Object payload);

--- a/application/src/main/java/net/corda/v5/application/messaging/FlowSession.java
+++ b/application/src/main/java/net/corda/v5/application/messaging/FlowSession.java
@@ -74,7 +74,7 @@ public interface FlowSession {
      * <p>
      * Both the {@code payload} object and the {@code receiveType} should be of a type that is annotated
      * with @CordaSerializable or a primitive type. This function cannot handle types that do not meet these criteria.
-     * The maximum payload size that can be sent at once is dictated by Flow Config, and defaults to 100MB.
+     * The maximum payload size that can be sent at once is dictated by `session.maxPayloadSize`, and defaults to 100MB.
      *
      * @param <R> The data type received from the counterparty.
      * @param receiveType The data type received from the counterparty.
@@ -119,7 +119,7 @@ public interface FlowSession {
      * <p>
      * The {@code payload} object should be of a type that is annotated with @CordaSerializable or a primitive type. This
      * function cannot handle types that do not meet these criteria. The maximum payload size that can be
-     * sent at once is dictated by Flow Config, and defaults to 100MB.
+     * sent at once is dictated by `session.maxPayloadSize`, and defaults to 100MB.
      *
      * @param payload The data sent to the counterparty, which should be either a primitive type
      *                or a type annotated with @CordaSerializable. Payload size should not exceed the configurable maximum size in bytes

--- a/data/config-schema/src/main/java/net/corda/schema/configuration/FlowConfig.java
+++ b/data/config-schema/src/main/java/net/corda/schema/configuration/FlowConfig.java
@@ -9,6 +9,7 @@ public final class FlowConfig {
     public static final String SESSION_TIMEOUT_WINDOW = "session.timeout";
     public static final String SESSION_P2P_TTL = "session.p2pTTL";
     public static final String SESSION_FLOW_CLEANUP_TIME = "session.cleanupTime";
+    public static final String SESSION_FLOW_MAX_PAYLOAD = "session.maxPayloadSize";
     public static final String PROCESSING_MAX_RETRY_ATTEMPTS = "processing.maxRetryAttempts";
     public static final String PROCESSING_MAX_RETRY_WINDOW_DURATION = "processing.maxRetryWindowDuration";
     public static final String PROCESSING_MAX_RETRY_DELAY = "processing.maxRetryDelay";

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/flow/1.0/corda.flow.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/flow/1.0/corda.flow.json
@@ -109,6 +109,13 @@
           "minimum": 10000,
           "maximum": 2147483647,
           "default": 600000
+        },
+        "maxPayloadSize": {
+          "description": "The maximum size of a payload in bytes that is allowed to be sent to a counterparty at once.",
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 2147483647,
+          "default": 104857600
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
In some cases, sending large messages to counterparties might flood the kafka topics with too many chunks, making it too slow. Allowing a configurable max message size resolves this issue.
