### PR TITLE
CORE-19840 Make `pub_key_hash` part of PK for signature table

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/ledger/persistence/PersistTransactionSignatures.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/ledger/persistence/PersistTransactionSignatures.avsc
@@ -10,11 +10,6 @@
       "doc": "The transaction ID, derived from the root hash of its Merkle tree"
     },
     {
-      "name": "startingIndex",
-      "type": "int",
-      "doc": "The index to insert the new signatures from"
-    },
-    {
       "name": "signatures",
       "type": {
         "type" : "array",

--- a/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v5.3.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v5.3.xml
@@ -17,6 +17,18 @@
             <column name="transaction_id"/>
         </createIndex>
 
+        <dropPrimaryKey constraintName="utxo_transaction_signature_pkey"
+            dropIndex="true"
+            tableName="utxo_transaction_signature"
+        />
+
+        <addPrimaryKey columnNames="transaction_id, pub_key_hash"
+            constraintName="utxo_transaction_signature_pkey"
+            tableName="utxo_transaction_signature"
+        />
+
+        <dropColumn columnName="signature_idx" tableName="utxo_transaction_signature"/>
+
     </changeSet>
 
 </databaseChangeLog>

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ cordaProductVersion = 5.3.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 12
+cordaApiRevision = 13
 
 # Main
 kotlin.stdlib.default.dependency = false


### PR DESCRIPTION
Remove `signature_idx` column and use `pub_key_hash` in the primary key instead, which simplifies the insert and `ON CONFLICT` logic, while ensuring that we don't have issues when storing a filtered transaction followed by a signed transaction for the same transaction id.