### PR TITLE
CORE-18382 Base Flow Engine fiber timeout on flow config value

### DIFF
--- a/data/config-schema/src/main/java/net/corda/schema/configuration/FlowConfig.java
+++ b/data/config-schema/src/main/java/net/corda/schema/configuration/FlowConfig.java
@@ -16,4 +16,5 @@ public final class FlowConfig {
     public static final String PROCESSING_MAX_FLOW_SLEEP_DURATION = "processing.maxFlowSleepDuration";
     public static final String PROCESSING_FLOW_MAPPER_CLEANUP_TIME = "processing.cleanupTime";
     public static final String PROCESSING_MAX_IDLE_TIME = "processing.maxIdleTime";
+    public static final String PROCESSING_FLOW_FIBER_TIMEOUT = "processing.fiberTimeout";
 }

--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/flow/1.0/corda.flow.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/flow/1.0/corda.flow.json
@@ -53,6 +53,13 @@
           "maximum": 2147483647,
           "default": 600000
         },
+        "fiberTimeout": {
+          "description": "The length of time in milliseconds before fiber times out. This value must be lower than subscription.processorTimeout.",
+          "type": "integer",
+          "minimum": 1000,
+          "maximum": 2147483647,
+          "default": 11250
+        },
         "poolSize": {
           "description": "The size of the flow event processing pool size.",
           "type": "integer",


### PR DESCRIPTION
### Problem
Currently, the Flow fiber timeout value is taken from `subscription.processorTimeout` messaging config which is now unrelated to the Flow Engine.

### Solution
Introduce a new value in the flow config: `processing.fiberTimeout` and replace the value in [FlowEventProcessorImpl.kt](https://github.com/corda/corda-runtime-os/pull/6106/files#diff-057116ae1069928d91003c46941b74f59b13d5cb94e112d21ff30a15663e60ea) with it.

https://github.com/corda/corda-runtime-os/pull/6106