### PR TITLE
ES-2351: 5.2 release branch versions should be bumped to 5.2.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.java.installations.auto-download=false
 
 # Versioning
-cordaProductVersion = 5.2.0
+cordaProductVersion = 5.2.1
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.


### PR DESCRIPTION
Now that 5.2 has shipped, we can increment the patch version to 5.2.1 on various C5 repos.

