### PR TITLE
CORE-19908: Fix crypto schema to include default values for retrying

### DIFF
--- a/data/config-schema/src/main/resources/net/corda/schema/configuration/crypto/1.0/corda.crypto.json
+++ b/data/config-schema/src/main/resources/net/corda/schema/configuration/crypto/1.0/corda.crypto.json
@@ -18,7 +18,7 @@
           "properties": {
             "default": {
               "type": "integer",
-              "default": 10000
+              "default": 60
             }
           }
         },
@@ -29,7 +29,7 @@
           "properties": {
             "default": {
               "type": "integer",
-              "default": 60
+              "default": 10000
             }
           }
         }
@@ -44,6 +44,7 @@
         "maxAttempts": {
           "description": "The maximum attempts to process a message.",
           "type": "object",
+          "default": {},
           "properties": {
             "default": {
               "type": "integer",
@@ -56,6 +57,7 @@
         "waitBetweenMills": {
           "description": "The time between attempts in milliseconds. If the number of values specified is less than the number of attempts, the last item is repeated.",
           "type": "object",
+          "default": {},
           "properties": {
             "default": {
               "type": "array",


### PR DESCRIPTION
The schema for the retrying section of the crypto config was malformed and didn't set defaults correctly. This PR fixes the schema and allows it to set defaults better. Additionally, the defaults in the caching section seemed like they had been swapped around, as the default caching timeout was 10,000 minutes and the number of cached items was only 60. This PR also swaps those values around.