### PR TITLE
CORE-20790: Add version to ChangeGroupParentIdRequest

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/permissions/management/group/ChangeGroupParentIdRequest.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/permissions/management/group/ChangeGroupParentIdRequest.avsc
@@ -8,6 +8,10 @@
       "type": "string"
     },
     {
+      "name": "version",
+      "type": "int"
+    },
+    {
       "name": "newParentGroupId",
       "type": [ "null", "string" ]
     }


### PR DESCRIPTION
Used to prevent concurrency issues when updating the parent id of a group. 