### PR TITLE
CORE-20543: Update ChangeUserParentGroupIdRequest to use loginName

### DIFF
--- a/data/avro-schema/src/main/resources/avro/net/corda/data/permissions/management/user/ChangeUserParentGroupIdRequest.avsc
+++ b/data/avro-schema/src/main/resources/avro/net/corda/data/permissions/management/user/ChangeUserParentGroupIdRequest.avsc
@@ -4,7 +4,7 @@
   "namespace": "net.corda.data.permissions.management.user",
   "fields": [
     {
-      "name": "userId",
+      "name": "loginName",
       "type": "string"
     },
     {

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ cordaProductVersion = 5.3.0
 # NOTE: update this each time this module contains a breaking change
 ## NOTE: currently this is a top level revision, so all API versions will line up, but this could be moved to
 ##   a per module property in which case module versions can change independently.
-cordaApiRevision = 15
+cordaApiRevision = 16
 
 # Main
 kotlin.stdlib.default.dependency = false


### PR DESCRIPTION
- Updated the ChangeUserParentGroupIdRequest to be loginName instead of userId, as all user operations take loginName as input.