### PR TITLE
R3SOL-400  Explicitly add the JSON column type to v5.1 utxo creation

### DIFF
--- a/.github/workflows/check-pr-title.yml
+++ b/.github/workflows/check-pr-title.yml
@@ -9,6 +9,6 @@ jobs:
     steps:
       - uses: morrisoncole/pr-lint-action@v1.7.1
         with:
-          title-regex: '^((CORDA|EG|ENT|INFRA|CORE|DOC|ES|DA5)-\d+)(.*)'
+          title-regex: '^((CORDA|R3SOL|EG|ENT|INFRA|CORE|DOC|ES|DA5)-\d+)(.*)'
           on-failed-regex-comment: "PR title failed to match regex -> `%regex%`"
           repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v5.1.xml
+++ b/data/db-schema/src/main/resources/net/corda/db/schema/vnode-vault/migration/ledger-utxo-creation-v5.1.xml
@@ -3,6 +3,11 @@
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.3.xsd">
 
+    <property name="json.column.type" value="JSONB" dbms="postgresql"/>
+
+    <!-- Please note that HSQLDB schema is supported for integration test purposes only. -->
+    <property name="json.column.type" value="CLOB" dbms="hsqldb"/>
+
     <changeSet author="R3.Corda" id="ledger-utxo-creation-v5.1">
         <createIndex indexName="utxo_visible_transaction_state_idx_consumed"
                      tableName="utxo_visible_transaction_state">


### PR DESCRIPTION
### Overiew

Right now when running the `ledger-utxo-creation-v5.1` changeset the property `json.column.type` comes from another changeset XML when they are imported together.

However, this makes it impossible to execute `ledger-utxo-creation-v5.1` as a standalone changeset because this property will become undefined. Adding this property to the changeset.